### PR TITLE
Go: Parsing fixes

### DIFF
--- a/be1-go/hub/client.go
+++ b/be1-go/hub/client.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	maxMessageSize = 512
+	// maxMessageSize denotes a meximum possible message size in bytes
+	maxMessageSize = 256 * 1024
 
 	writeWait = 10 * time.Second
 

--- a/be1-go/hub/client.go
+++ b/be1-go/hub/client.go
@@ -150,6 +150,6 @@ func (c *Client) SendResult(id int, res message.Result) {
 		log.Printf("failed to marshal answer: %v", err)
 	}
 
-	log.Printf("answerBuf: %s", answerBuf)
+	log.Printf("answerBuf: %s, received id: %d", answerBuf, id)
 	c.send <- answerBuf
 }

--- a/be1-go/hub/client.go
+++ b/be1-go/hub/client.go
@@ -150,5 +150,6 @@ func (c *Client) SendResult(id int, res message.Result) {
 		log.Printf("failed to marshal answer: %v", err)
 	}
 
+	log.Printf("answerBuf: %s", answerBuf)
 	c.send <- answerBuf
 }

--- a/be1-go/hub/organizer.go
+++ b/be1-go/hub/organizer.go
@@ -512,7 +512,7 @@ func (c *laoChannel) processMessageObject(public message.PublicKey, data message
 		c.inboxMu.Lock()
 		msg, ok := c.inbox[msgEncoded]
 		if !ok {
-			// We received a witness signature before the message itself.
+			// TODO: We received a witness signature before the message itself.
 			// We ignore it for now but it might be worth keeping it until we
 			// actually receive the message
 			log.Printf("failed to find message_id %s for witness message", msgEncoded)

--- a/be1-go/hub/organizer.go
+++ b/be1-go/hub/organizer.go
@@ -97,7 +97,7 @@ func (o *organizerHub) handleIncomingMessage(incomingMessage *IncomingMessage) {
 
 		status := 0
 		result := message.Result{General: &status}
-		log.Printf("sending result: %v", result)
+		log.Printf("sending result: %+v", result)
 		client.SendResult(id, result)
 		return
 	}

--- a/be1-go/hub/organizer.go
+++ b/be1-go/hub/organizer.go
@@ -84,6 +84,7 @@ func (o *organizerHub) handleIncomingMessage(incomingMessage *IncomingMessage) {
 			if err != nil {
 				log.Printf("failed to create lao: %v", err)
 				client.SendError(query.Publish.ID, err)
+				return
 			}
 		} else {
 			log.Printf("invalid method: %s", query.GetMethod())
@@ -91,8 +92,13 @@ func (o *organizerHub) handleIncomingMessage(incomingMessage *IncomingMessage) {
 				Code:        -1,
 				Description: "you may only invoke lao/create on /root",
 			})
+			return
 		}
 
+		status := 0
+		result := message.Result{General: &status}
+		log.Printf("sending result: %v", result)
+		client.SendResult(id, result)
 		return
 	}
 

--- a/be1-go/message/answer.go
+++ b/be1-go/message/answer.go
@@ -77,10 +77,12 @@ func (a Answer) MarshalJSON() ([]byte, error) {
 		JSONRpc string  `json:"jsonrpc"`
 		Result  *Result `json:"result,omitempty"`
 		Error   *Error  `json:"error,omitempty"`
+		ID      *int    `json:"id"`
 	}
 
 	tmp := internal{
 		JSONRpc: "2.0",
+		ID:      a.ID,
 		Result:  a.Result,
 		Error:   a.Error,
 	}

--- a/be1-go/message/data.go
+++ b/be1-go/message/data.go
@@ -36,15 +36,12 @@ type Data interface {
 
 	GetObject() DataObject
 
-	GetRaw() []byte
-
 	//GetTimestamp() Timestamp
 }
 
 type GenericData struct {
 	Action DataAction `json:"action"`
 	Object DataObject `json:"object"`
-	Raw    []byte
 }
 
 func (g *GenericData) GetAction() DataAction {
@@ -53,10 +50,6 @@ func (g *GenericData) GetAction() DataAction {
 
 func (g *GenericData) GetObject() DataObject {
 	return g.Object
-}
-
-func (g *GenericData) GetRaw() []byte {
-	return g.Raw
 }
 
 type LaoDataAction DataAction

--- a/be1-go/message/message.go
+++ b/be1-go/message/message.go
@@ -3,7 +3,9 @@ package message
 import (
 	"crypto/sha256"
 	"encoding/json"
+	"student20_pop"
 
+	"go.dedis.ch/kyber/v3/sign/schnorr"
 	"golang.org/x/xerrors"
 )
 
@@ -21,6 +23,7 @@ type Message struct {
 	Sender            PublicKey                `json:"sender"`
 	Signature         Signature                `json:"signature"`
 	WitnessSignatures []PublicKeySignaturePair `json:"witness_signatures"`
+	RawData           []byte
 }
 
 func NewMessage(sender PublicKey, signature Signature, witnessSignatures []PublicKeySignaturePair, data Data) (*Message, error) {
@@ -71,37 +74,47 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 		return xerrors.Errorf("error parsing message: %v", err)
 	}
 
-	gd := &GenericData{}
-	err = json.Unmarshal(tmp.Data, gd)
-	if err != nil {
-		return xerrors.Errorf("error parsing data wrapper: %v", err)
-	}
-
 	m.MessageID = tmp.MessageID
 	m.Sender = tmp.Sender
 	m.Signature = tmp.Signature
 	m.WitnessSignatures = tmp.WitnessSignatures
+	m.RawData = tmp.Data
+
+	return nil
+}
+
+func (m *Message) VerifyAndUnmarshalData() error {
+	err := schnorr.VerifyWithChecks(student20_pop.Suite, m.Sender, m.RawData, m.Signature)
+	if err != nil {
+		return xerrors.Errorf("error verifying signature: %v", err)
+	}
+
+	gd := &GenericData{}
+	err = json.Unmarshal(m.RawData, gd)
+	if err != nil {
+		return xerrors.Errorf("error parsing data wrapper: %v", err)
+	}
 
 	action := gd.GetAction()
 
 	switch gd.GetObject() {
 	case DataObject(LaoObject):
-		err := m.parseLAOData(LaoDataAction(action), tmp.Data)
+		err := m.parseLAOData(LaoDataAction(action), m.RawData)
 		if err != nil {
 			return xerrors.Errorf("error parsing lao data: %v", err)
 		}
 	case DataObject(MeetingObject):
-		err := m.parseMeetingData(MeetingDataAction(action), tmp.Data)
+		err := m.parseMeetingData(MeetingDataAction(action), m.RawData)
 		if err != nil {
 			return xerrors.Errorf("error parsing meeting data: %v", err)
 		}
 	case DataObject(MessageObject):
-		err := m.parseMessageData(MessageDataAction(action), tmp.Data)
+		err := m.parseMessageData(MessageDataAction(action), m.RawData)
 		if err != nil {
 			return xerrors.Errorf("error parsing message data: %v", err)
 		}
 	case DataObject(RollCallObject):
-		err := m.parseRollCallData(RollCallAction(action), tmp.Data)
+		err := m.parseRollCallData(RollCallAction(action), m.RawData)
 		if err != nil {
 			return xerrors.Errorf("error parsing roll call data: %v", err)
 		}
@@ -116,7 +129,6 @@ func (m *Message) parseRollCallData(action RollCallAction, data []byte) error {
 	switch action {
 	case CreateRollCallAction:
 		create := &CreateRollCallData{GenericData: &GenericData{}}
-		create.Raw = data
 
 		err := json.Unmarshal(data, create)
 		if err != nil {
@@ -127,7 +139,6 @@ func (m *Message) parseRollCallData(action RollCallAction, data []byte) error {
 		return nil
 	case RollCallAction(OpenRollCallAction), RollCallAction(ReopenRollCallAction):
 		open := &OpenRollCallData{GenericData: &GenericData{}}
-		open.Raw = data
 
 		err := json.Unmarshal(data, open)
 		if err != nil {
@@ -138,7 +149,6 @@ func (m *Message) parseRollCallData(action RollCallAction, data []byte) error {
 		return nil
 	case CloseRollCallAction:
 		closeInst := &CloseRollCallData{GenericData: &GenericData{}}
-		closeInst.Raw = data
 
 		err := json.Unmarshal(data, closeInst)
 		if err != nil {
@@ -158,7 +168,6 @@ func (m *Message) parseMessageData(action MessageDataAction, data []byte) error 
 	}
 
 	witness := &WitnessMessageData{GenericData: &GenericData{}}
-	witness.Raw = data
 
 	err := json.Unmarshal(data, witness)
 	if err != nil {
@@ -173,7 +182,6 @@ func (m *Message) parseMeetingData(action MeetingDataAction, data []byte) error 
 	switch action {
 	case CreateMeetingAction:
 		create := &CreateMeetingData{GenericData: &GenericData{}}
-		create.Raw = data
 
 		err := json.Unmarshal(data, create)
 		if err != nil {
@@ -184,7 +192,6 @@ func (m *Message) parseMeetingData(action MeetingDataAction, data []byte) error 
 		return nil
 	case StateMeetingAction:
 		state := &StateMeetingData{GenericData: &GenericData{}}
-		state.Raw = data
 
 		err := json.Unmarshal(data, state)
 		if err != nil {
@@ -203,7 +210,6 @@ func (m *Message) parseLAOData(action LaoDataAction, data []byte) error {
 	switch action {
 	case CreateLaoAction:
 		create := &CreateLAOData{GenericData: &GenericData{}}
-		create.Raw = data
 
 		err := json.Unmarshal(data, create)
 		if err != nil {
@@ -214,7 +220,6 @@ func (m *Message) parseLAOData(action LaoDataAction, data []byte) error {
 		return nil
 	case UpdateLaoAction:
 		update := &UpdateLAOData{GenericData: &GenericData{}}
-		update.Raw = data
 
 		err := json.Unmarshal(data, update)
 		if err != nil {
@@ -225,7 +230,6 @@ func (m *Message) parseLAOData(action LaoDataAction, data []byte) error {
 		return nil
 	case StateLaoAction:
 		state := &StateLAOData{GenericData: &GenericData{}}
-		state.Raw = data
 
 		err := json.Unmarshal(data, state)
 		if err != nil {

--- a/be1-go/message/message.go
+++ b/be1-go/message/message.go
@@ -195,7 +195,7 @@ func (m *Message) parseMeetingData(action MeetingDataAction, data []byte) error 
 func (m *Message) parseLAOData(action LaoDataAction, data []byte) error {
 	switch action {
 	case CreateLaoAction:
-		create := &CreateLAOData{}
+		create := &CreateLAOData{GenericData: &GenericData{}}
 		create.Raw = data
 
 		err := json.Unmarshal(data, create)

--- a/be1-go/message/message.go
+++ b/be1-go/message/message.go
@@ -128,7 +128,7 @@ func (m *Message) VerifyAndUnmarshalData() error {
 func (m *Message) parseRollCallData(action RollCallAction, data []byte) error {
 	switch action {
 	case CreateRollCallAction:
-		create := &CreateRollCallData{GenericData: &GenericData{}}
+		create := &CreateRollCallData{}
 
 		err := json.Unmarshal(data, create)
 		if err != nil {
@@ -138,7 +138,7 @@ func (m *Message) parseRollCallData(action RollCallAction, data []byte) error {
 		m.Data = create
 		return nil
 	case RollCallAction(OpenRollCallAction), RollCallAction(ReopenRollCallAction):
-		open := &OpenRollCallData{GenericData: &GenericData{}}
+		open := &OpenRollCallData{}
 
 		err := json.Unmarshal(data, open)
 		if err != nil {
@@ -148,7 +148,7 @@ func (m *Message) parseRollCallData(action RollCallAction, data []byte) error {
 		m.Data = open
 		return nil
 	case CloseRollCallAction:
-		closeInst := &CloseRollCallData{GenericData: &GenericData{}}
+		closeInst := &CloseRollCallData{}
 
 		err := json.Unmarshal(data, closeInst)
 		if err != nil {
@@ -167,7 +167,7 @@ func (m *Message) parseMessageData(action MessageDataAction, data []byte) error 
 		return xerrors.Errorf("invalid action type: %s", action)
 	}
 
-	witness := &WitnessMessageData{GenericData: &GenericData{}}
+	witness := &WitnessMessageData{}
 
 	err := json.Unmarshal(data, witness)
 	if err != nil {
@@ -181,7 +181,7 @@ func (m *Message) parseMessageData(action MessageDataAction, data []byte) error 
 func (m *Message) parseMeetingData(action MeetingDataAction, data []byte) error {
 	switch action {
 	case CreateMeetingAction:
-		create := &CreateMeetingData{GenericData: &GenericData{}}
+		create := &CreateMeetingData{}
 
 		err := json.Unmarshal(data, create)
 		if err != nil {
@@ -191,7 +191,7 @@ func (m *Message) parseMeetingData(action MeetingDataAction, data []byte) error 
 		m.Data = create
 		return nil
 	case StateMeetingAction:
-		state := &StateMeetingData{GenericData: &GenericData{}}
+		state := &StateMeetingData{}
 
 		err := json.Unmarshal(data, state)
 		if err != nil {
@@ -209,7 +209,7 @@ func (m *Message) parseMeetingData(action MeetingDataAction, data []byte) error 
 func (m *Message) parseLAOData(action LaoDataAction, data []byte) error {
 	switch action {
 	case CreateLaoAction:
-		create := &CreateLAOData{GenericData: &GenericData{}}
+		create := &CreateLAOData{}
 
 		err := json.Unmarshal(data, create)
 		if err != nil {
@@ -219,7 +219,7 @@ func (m *Message) parseLAOData(action LaoDataAction, data []byte) error {
 		m.Data = create
 		return nil
 	case UpdateLaoAction:
-		update := &UpdateLAOData{GenericData: &GenericData{}}
+		update := &UpdateLAOData{}
 
 		err := json.Unmarshal(data, update)
 		if err != nil {
@@ -229,7 +229,7 @@ func (m *Message) parseLAOData(action LaoDataAction, data []byte) error {
 		m.Data = update
 		return nil
 	case StateLaoAction:
-		state := &StateLAOData{GenericData: &GenericData{}}
+		state := &StateLAOData{}
 
 		err := json.Unmarshal(data, state)
 		if err != nil {

--- a/be1-go/message/message.go
+++ b/be1-go/message/message.go
@@ -115,7 +115,8 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 func (m *Message) parseRollCallData(action RollCallAction, data []byte) error {
 	switch action {
 	case CreateRollCallAction:
-		create := &CreateRollCallData{}
+		create := &CreateRollCallData{GenericData: &GenericData{}}
+		create.Raw = data
 
 		err := json.Unmarshal(data, create)
 		if err != nil {
@@ -125,7 +126,8 @@ func (m *Message) parseRollCallData(action RollCallAction, data []byte) error {
 		m.Data = create
 		return nil
 	case RollCallAction(OpenRollCallAction), RollCallAction(ReopenRollCallAction):
-		open := &OpenRollCallData{}
+		open := &OpenRollCallData{GenericData: &GenericData{}}
+		open.Raw = data
 
 		err := json.Unmarshal(data, open)
 		if err != nil {
@@ -135,7 +137,8 @@ func (m *Message) parseRollCallData(action RollCallAction, data []byte) error {
 		m.Data = open
 		return nil
 	case CloseRollCallAction:
-		closeInst := &CloseRollCallData{}
+		closeInst := &CloseRollCallData{GenericData: &GenericData{}}
+		closeInst.Raw = data
 
 		err := json.Unmarshal(data, closeInst)
 		if err != nil {
@@ -154,7 +157,9 @@ func (m *Message) parseMessageData(action MessageDataAction, data []byte) error 
 		return xerrors.Errorf("invalid action type: %s", action)
 	}
 
-	witness := &WitnessMessageData{}
+	witness := &WitnessMessageData{GenericData: &GenericData{}}
+	witness.Raw = data
+
 	err := json.Unmarshal(data, witness)
 	if err != nil {
 		return xerrors.Errorf("failed to parse witness action: %v", err)
@@ -167,7 +172,8 @@ func (m *Message) parseMessageData(action MessageDataAction, data []byte) error 
 func (m *Message) parseMeetingData(action MeetingDataAction, data []byte) error {
 	switch action {
 	case CreateMeetingAction:
-		create := &CreateMeetingData{}
+		create := &CreateMeetingData{GenericData: &GenericData{}}
+		create.Raw = data
 
 		err := json.Unmarshal(data, create)
 		if err != nil {
@@ -177,7 +183,8 @@ func (m *Message) parseMeetingData(action MeetingDataAction, data []byte) error 
 		m.Data = create
 		return nil
 	case StateMeetingAction:
-		state := &StateMeetingData{}
+		state := &StateMeetingData{GenericData: &GenericData{}}
+		state.Raw = data
 
 		err := json.Unmarshal(data, state)
 		if err != nil {
@@ -206,7 +213,7 @@ func (m *Message) parseLAOData(action LaoDataAction, data []byte) error {
 		m.Data = create
 		return nil
 	case UpdateLaoAction:
-		update := &UpdateLAOData{}
+		update := &UpdateLAOData{GenericData: &GenericData{}}
 		update.Raw = data
 
 		err := json.Unmarshal(data, update)
@@ -217,7 +224,7 @@ func (m *Message) parseLAOData(action LaoDataAction, data []byte) error {
 		m.Data = update
 		return nil
 	case StateLaoAction:
-		state := &StateLAOData{}
+		state := &StateLAOData{GenericData: &GenericData{}}
 		state.Raw = data
 
 		err := json.Unmarshal(data, state)


### PR DESCRIPTION
This PR introduces the following changes:

- Increases the max message size to 256K
- Sends an ack on `lao/create`
- Moved GenericData.Raw to Message.RawData
- Removed Query::Verify and added Message::VerifyAndUnmarshal()
- Marshals `id` field in `message.Answer`