### PR TITLE
android: signature generation/verification

### DIFF
--- a/app/src/main/java/com/github/dedis/student20_pop/PoPApplication.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/PoPApplication.java
@@ -57,9 +57,9 @@ public class PoPApplication extends Application {
   public void onCreate() {
     super.onCreate();
 
-    startPurgeRoutine(new Handler(Looper.getMainLooper()));
+//    startPurgeRoutine(new Handler(Looper.getMainLooper()));
 
-    appContext = getApplicationContext();
+//    appContext = getApplicationContext();
 
     // activateTestingValues(); // comment this line when testing with a back-end
   }
@@ -278,24 +278,6 @@ public class PoPApplication extends Application {
         new Event(
             "Present Event 1", laoId, Instant.now().getEpochSecond(), "Somewhere", DISCUSSION),
         new Event("Past Event 1", laoId, 1481643086L, "Here", MEETING));
-  }
-
-  /**
-   * Start the routine the will purge periodically every open session to close timeout requests
-   *
-   * @param handler to run the routine on
-   */
-  private void startPurgeRoutine(Handler handler) {
-    handler.post(
-        new Runnable() {
-          @Override
-          public void run() {
-            synchronized (openSessions) {
-              openSessions.values().forEach(hlp -> hlp.lowLevel().purgeTimeoutRequests());
-              handler.postDelayed(this, LowLevelProxy.REQUEST_TIMEOUT);
-            }
-          }
-        });
   }
 
   /** Type of results when adding a witness */

--- a/app/src/main/java/com/github/dedis/student20_pop/PoPApplication.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/PoPApplication.java
@@ -1,12 +1,9 @@
 package com.github.dedis.student20_pop;
 
-import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.Handler;
 import android.os.Looper;
-import android.util.Log;
 
 import com.github.dedis.student20_pop.model.Keys;
 import com.github.dedis.student20_pop.model.Lao;
@@ -19,7 +16,6 @@ import com.github.dedis.student20_pop.utility.protocol.DataHandler;
 import com.github.dedis.student20_pop.utility.protocol.HighLevelProxy;
 import com.github.dedis.student20_pop.utility.protocol.LowLevelProxy;
 import com.github.dedis.student20_pop.utility.protocol.ProtocolProxyFactory;
-import com.github.dedis.student20_pop.utility.security.PrivateInfoStorage;
 
 import java.net.URI;
 import java.time.Instant;
@@ -65,43 +61,17 @@ public class PoPApplication extends Application {
 
     appContext = getApplicationContext();
 
-    SharedPreferences sp = this.getSharedPreferences(TAG, Context.MODE_PRIVATE);
-
-    // Verify if the information is not present
-    if (person == null) {
-      // Verify if the user already exists
-      if (sp.contains(SP_PERSON_ID_KEY)) {
-        // Recover user's information
-        String id = sp.getString(SP_PERSON_ID_KEY, "");
-        String authentication = PrivateInfoStorage.readData(this, id);
-        if (authentication == null) {
-          person = new Person(USERNAME);
-          Log.d(TAG, "Private key of user cannot be accessed, new key pair is created");
-          if (PrivateInfoStorage.storeData(this, person.getId(), person.getAuthentication()))
-            Log.d(TAG, "Stored private key of organizer");
-        } else {
-          person = new Person(USERNAME, id, authentication, new ArrayList<>());
-        }
-      } else {
-        // Create new user
-        person = new Person(USERNAME);
-        // Store private key of user
-        if (PrivateInfoStorage.storeData(this, person.getId(), person.getAuthentication()))
-          Log.d(TAG, "Stored private key of organizer");
-      }
-    }
-
-    activateTestingValues(); // comment this line when testing with a back-end
+    // activateTestingValues(); // comment this line when testing with a back-end
   }
 
-  @SuppressLint("ApplySharedPref")
-  @Override
-  public void onTerminate() {
-    super.onTerminate();
-    SharedPreferences sp = this.getSharedPreferences(TAG, Context.MODE_PRIVATE);
-    // Use commit instead of apply for information to be stored immediately
-    sp.edit().putString(SP_PERSON_ID_KEY, person.getId()).commit();
-  }
+//  @SuppressLint("ApplySharedPref")
+//  @Override
+//  public void onTerminate() {
+//    super.onTerminate();
+//    SharedPreferences sp = this.getSharedPreferences(TAG, Context.MODE_PRIVATE);
+//    // Use commit instead of apply for information to be stored immediately
+//    sp.edit().putString(SP_PERSON_ID_KEY, person.getId()).commit();
+//  }
 
   /** Returns PoP Application Context. */
   public static Context getAppContext() {

--- a/app/src/main/java/com/github/dedis/student20_pop/ViewModelFactory.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ViewModelFactory.java
@@ -1,12 +1,18 @@
 package com.github.dedis.student20_pop;
 
 import android.app.Application;
+import android.util.AndroidRuntimeException;
 
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.github.dedis.student20_pop.home.HomeViewModel;
+import com.google.crypto.tink.KeysetHandle;
+import com.google.crypto.tink.integration.android.AndroidKeysetManager;
 import com.google.gson.Gson;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 
 public class ViewModelFactory extends ViewModelProvider.NewInstanceFactory {
 
@@ -15,6 +21,8 @@ public class ViewModelFactory extends ViewModelProvider.NewInstanceFactory {
     private final Application application;
 
     private final Gson gson = Injection.provideGson();
+
+    private final AndroidKeysetManager keysetManager;
 
     public static ViewModelFactory getInstance(Application application) {
         if (INSTANCE == null) {
@@ -33,12 +41,22 @@ public class ViewModelFactory extends ViewModelProvider.NewInstanceFactory {
 
     private ViewModelFactory(Application application) {
         this.application = application;
+        try {
+            this.keysetManager = Injection.provideAndroidKeysetManager(application.getApplicationContext());
+        } catch (IOException | GeneralSecurityException e) {
+            throw new RuntimeException("Could not provide AndroidKeysetManager", e);
+        }
     }
 
     @Override
     public <T extends ViewModel> T create(Class<T> modelClass) {
         if (modelClass.isAssignableFrom(HomeViewModel.class)) {
-            return (T) new HomeViewModel(application, gson, Injection.provideLAORepository(application, gson));
+            return (T) new HomeViewModel(
+                    application,
+                    gson,
+                    Injection.provideLAORepository(application, gson),
+                    keysetManager
+            );
         }
 
         throw new IllegalArgumentException("Unknown ViewModel class: " + modelClass.getName());

--- a/app/src/main/java/com/github/dedis/student20_pop/ViewModelFactory.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ViewModelFactory.java
@@ -54,7 +54,10 @@ public class ViewModelFactory extends ViewModelProvider.NewInstanceFactory {
             return (T) new HomeViewModel(
                     application,
                     gson,
-                    Injection.provideLAORepository(application, gson),
+                    Injection.provideLAORepository(
+                            application,
+                            Injection.provideLAOService(Injection.provideScarlet(application, Injection.provideOkHttpClient(), gson))
+                            ),
                     keysetManager
             );
         }

--- a/app/src/main/java/com/github/dedis/student20_pop/home/HomeActivity.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/home/HomeActivity.java
@@ -3,6 +3,7 @@ package com.github.dedis.student20_pop.home;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.widget.Button;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -23,6 +24,8 @@ import com.google.android.gms.vision.barcode.BarcodeDetector;
 
 
 public class HomeActivity extends AppCompatActivity {
+
+    private final String TAG = HomeActivity.class.getSimpleName();
 
     private HomeViewModel mViewModel;
 

--- a/app/src/main/java/com/github/dedis/student20_pop/home/HomeViewModel.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/home/HomeViewModel.java
@@ -24,6 +24,7 @@ import com.github.dedis.student20_pop.model.network.method.message.data.lao.Stat
 import com.github.dedis.student20_pop.ui.qrcode.CameraPermissionViewModel;
 import com.github.dedis.student20_pop.ui.qrcode.QRCodeScanningViewModel;
 import com.google.android.gms.vision.barcode.Barcode;
+import com.google.crypto.tink.integration.android.AndroidKeysetManager;
 import com.google.gson.Gson;
 
 import java.net.URI;
@@ -57,16 +58,18 @@ public class HomeViewModel extends AndroidViewModel implements CameraPermissionV
     private final MutableLiveData<Map<String, Lao>> mLAOsById = new MutableLiveData<>();
     private final LiveData<List<Lao>> mLAOs = Transformations.map(mLAOsById, laosById ->
             new ArrayList<>(laosById.values()));
-    private final Gson gson;
+    private final Gson mGson;
     private final LAORepository mLAORepository;
-
     private Disposable disposable;
+    private final AndroidKeysetManager mKeysetManager;
 
-    public HomeViewModel(@NonNull Application application, Gson gson, LAORepository laoRepository) {
+    public HomeViewModel(@NonNull Application application, Gson gson, LAORepository laoRepository,
+                         AndroidKeysetManager keysetManager) {
         super(application);
 
         mLAORepository = laoRepository;
-        this.gson = gson;
+        mGson = gson;
+        mKeysetManager = keysetManager;
 
         subscribeToMessages();
     }
@@ -152,7 +155,7 @@ public class HomeViewModel extends AndroidViewModel implements CameraPermissionV
 
         // Log.d(TAG, "data: " + msg.getData() + " dataJSON: " + dataJson);
 
-        Data data = gson.fromJson(dataJson, Data.class);
+        Data data = mGson.fromJson(dataJson, Data.class);
 
         if (data instanceof StateLao) {
             StateLao stateLao = (StateLao) data;

--- a/app/src/main/java/com/github/dedis/student20_pop/model/Election.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/model/Election.java
@@ -29,7 +29,7 @@ public final class Election {
     }
     this.name = name;
     this.time = Instant.now().getEpochSecond();
-    this.id = Hash.hash(lao, time, name);
+    this.id = ""; // Hash.hash(lao, time, name);
     this.lao = lao;
     this.options = options;
   }

--- a/app/src/main/java/com/github/dedis/student20_pop/model/Lao.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/model/Lao.java
@@ -50,7 +50,7 @@ public final class Lao {
 
     this.name = name.trim();
     this.creation = Instant.now().getEpochSecond();
-    this.id = Hash.hash(organizer, creation, name);
+    this.id = ""; //Hash.hash(organizer, creation, name);
     this.organizer = organizer;
     this.host = host;
     this.witnesses = new ArrayList<>();

--- a/app/src/main/java/com/github/dedis/student20_pop/model/data/LAODataSource.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/model/data/LAODataSource.java
@@ -7,8 +7,10 @@ import com.github.dedis.student20_pop.model.entities.ModificationSignature;
 import com.github.dedis.student20_pop.model.entities.Person;
 import com.github.dedis.student20_pop.model.entities.RollCall;
 import com.github.dedis.student20_pop.model.network.GenericMessage;
+import com.github.dedis.student20_pop.model.network.method.Message;
 import com.github.dedis.student20_pop.model.network.method.Subscribe;
 import com.github.dedis.student20_pop.utility.json.JSONRPCRequest;
+import com.tinder.scarlet.WebSocket;
 
 import java.util.List;
 
@@ -20,6 +22,7 @@ public interface LAODataSource {
 
         Flowable<GenericMessage> observeMessage();
 
+        void sendMessage(Message msg);
     }
 
     interface Local {

--- a/app/src/main/java/com/github/dedis/student20_pop/model/data/LAORemoteDataSource.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/model/data/LAORemoteDataSource.java
@@ -1,6 +1,9 @@
 package com.github.dedis.student20_pop.model.data;
 
 import com.github.dedis.student20_pop.model.network.GenericMessage;
+import com.github.dedis.student20_pop.model.network.method.Message;
+import com.github.dedis.student20_pop.utility.json.JSONRPCRequest;
+import com.tinder.scarlet.WebSocket;
 
 import io.reactivex.Flowable;
 
@@ -24,4 +27,7 @@ public class LAORemoteDataSource implements LAODataSource.Remote {
         return laoService.observeMessage();
     }
 
+    public void sendMessage(Message msg) {
+        laoService.sendMessage(msg);
+    }
 }

--- a/app/src/main/java/com/github/dedis/student20_pop/model/data/LAORepository.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/model/data/LAORepository.java
@@ -8,6 +8,8 @@ import com.github.dedis.student20_pop.model.entities.LAOEntity;
 import com.github.dedis.student20_pop.model.network.GenericMessage;
 import com.github.dedis.student20_pop.model.network.answer.Result;
 import com.github.dedis.student20_pop.model.network.method.Broadcast;
+import com.github.dedis.student20_pop.model.network.method.Message;
+import com.tinder.scarlet.WebSocket;
 
 import io.reactivex.Flowable;
 
@@ -47,6 +49,10 @@ public class LAORepository {
         return mRemoteDataSource.observeMessage()
                 .filter(genericMessage -> genericMessage instanceof Broadcast)
                 .map(genericMessage -> (Broadcast) genericMessage);
+    }
+
+    public void sendMessage(Message msg) {
+        mRemoteDataSource.sendMessage(msg);
     }
 
     public LAOEntity getLAO(String channel) {

--- a/app/src/main/java/com/github/dedis/student20_pop/model/data/LAOService.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/model/data/LAOService.java
@@ -3,6 +3,7 @@ package com.github.dedis.student20_pop.model.data;
 import com.github.dedis.student20_pop.model.network.GenericMessage;
 import com.github.dedis.student20_pop.model.network.method.Message;
 import com.github.dedis.student20_pop.utility.json.JSONRPCRequest;
+import com.tinder.scarlet.WebSocket;
 import com.tinder.scarlet.ws.Receive;
 import com.tinder.scarlet.ws.Send;
 
@@ -11,7 +12,7 @@ import io.reactivex.Flowable;
 public interface LAOService {
 
     @Send
-    void sendJSONRPCRequest(JSONRPCRequest request);
+    void sendMessage(Message msg);
 
     @Receive
     Flowable<GenericMessage> observeMessage();

--- a/app/src/main/java/com/github/dedis/student20_pop/model/event/Event.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/model/event/Event.java
@@ -34,7 +34,7 @@ public class Event {
     this.name = name;
     this.time = Instant.now().getEpochSecond();
     this.startTime = startTime;
-    this.id = Hash.hash(type.getSuffix(), lao, time, name);
+    this.id = ""; //Hash.hash(type.getSuffix(), lao, time, name);
     this.lao = lao;
     this.attendees = new ObservableArrayList<>();
     this.location = location;

--- a/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/PublicKeySignaturePair.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/PublicKeySignaturePair.java
@@ -1,0 +1,13 @@
+package com.github.dedis.student20_pop.model.network.method.message;
+
+public class PublicKeySignaturePair {
+
+    private byte[] witness;
+
+    private byte[] signature;
+
+    public PublicKeySignaturePair(byte[] witness, byte[] signature) {
+        this.witness = witness;
+        this.signature = signature;
+    }
+}

--- a/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/data/lao/CreateLao.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/data/lao/CreateLao.java
@@ -4,8 +4,10 @@ import com.github.dedis.student20_pop.model.network.method.message.data.Action;
 import com.github.dedis.student20_pop.model.network.method.message.data.Data;
 import com.github.dedis.student20_pop.model.network.method.message.data.Objects;
 import com.github.dedis.student20_pop.utility.protocol.DataHandler;
+import com.github.dedis.student20_pop.utility.security.Hash;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,6 +36,14 @@ public class CreateLao extends Data {
     this.creation = creation;
     this.organizer = organizer;
     this.witnesses = witnesses;
+  }
+
+  public CreateLao(String name, String organizer) {
+    this.name = name;
+    this.organizer = organizer;
+    this.creation = Instant.now().toEpochMilli();
+    this.id = Hash.hash("L", organizer, Long.toString(creation), name);
+    this.witnesses = new ArrayList<>();
   }
 
   public String getId() {

--- a/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/data/message/WitnessMessage.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/data/message/WitnessMessage.java
@@ -4,6 +4,8 @@ import com.github.dedis.student20_pop.model.network.method.message.data.Action;
 import com.github.dedis.student20_pop.model.network.method.message.data.Data;
 import com.github.dedis.student20_pop.model.network.method.message.data.Objects;
 import com.github.dedis.student20_pop.utility.protocol.DataHandler;
+import com.google.crypto.tink.PublicKeyVerify;
+import com.google.crypto.tink.subtle.Ed25519Verify;
 import com.google.gson.annotations.SerializedName;
 
 import java.net.URI;

--- a/app/src/main/java/com/github/dedis/student20_pop/ui/LaunchFragment.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/ui/LaunchFragment.java
@@ -76,7 +76,7 @@ public final class LaunchFragment extends Fragment {
 
   private void launchLao() {
     mHomeViewModel.launchLao();
-    mHomeViewModel.openHome();
+    //mHomeViewModel.openHome();
   }
 
   private void cancelLaoLaunch() {

--- a/app/src/main/java/com/github/dedis/student20_pop/utility/json/JsonMessageGeneralSerializer.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/utility/json/JsonMessageGeneralSerializer.java
@@ -1,0 +1,60 @@
+package com.github.dedis.student20_pop.utility.json;
+
+import android.util.Base64;
+
+import com.github.dedis.student20_pop.model.network.method.Message;
+import com.github.dedis.student20_pop.model.network.method.message.MessageGeneral;
+import com.github.dedis.student20_pop.model.network.method.message.PublicKeySignaturePair;
+import com.github.dedis.student20_pop.model.network.method.message.data.Data;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+public class JsonMessageGeneralSerializer implements JsonSerializer<MessageGeneral>, JsonDeserializer<MessageGeneral> {
+    @Override
+    public MessageGeneral deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        JsonObject root = json.getAsJsonObject();
+
+        byte[] messageId = Base64.decode(root.get("message_id").getAsString(), Base64.NO_WRAP);
+        byte[] dataBuf = Base64.decode(root.get("data").getAsString(), Base64.NO_WRAP);
+        byte[] sender = Base64.decode(root.get("sender").getAsString(), Base64.NO_WRAP);
+        byte[] signature = Base64.decode(root.get("signature").getAsString(), Base64.NO_WRAP);
+
+        List<PublicKeySignaturePair> witnessSignatures = context.deserialize(root.get("witness_signatures"), PublicKeySignaturePair.class);
+
+        JsonElement dataElement = JsonParser.parseString(new String(dataBuf));
+        Data data = context.deserialize(dataElement, Data.class);
+
+        return new MessageGeneral(
+                sender,
+                dataBuf,
+                data,
+                signature,
+                messageId,
+                witnessSignatures
+        );
+    }
+
+    @Override
+    public JsonElement serialize(MessageGeneral src, Type typeOfSrc, JsonSerializationContext context) {
+        JsonObject result = new JsonObject();
+
+        result.addProperty("message_id", src.getMessageId());
+        result.addProperty("sender", src.getSender());
+        result.addProperty("signature", src.getSignature());
+
+
+        result.addProperty("data", src.getDataEncoded());
+        result.add("witness_signatures", context.serialize(src.getWitnessSignatures()));
+
+        return result;
+    }
+}

--- a/app/src/main/java/com/github/dedis/student20_pop/utility/network/WebSocketHighLevelProxy.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/utility/network/WebSocketHighLevelProxy.java
@@ -42,8 +42,10 @@ public final class WebSocketHighLevelProxy implements HighLevelProxy {
         publicKey,
         privateKey,
         ROOT,
-        new CreateLao(
-            Hash.hash(organizer, creation, name), name, creation, organizer, new ArrayList<>()));
+        null
+            );
+//        new CreateLao(
+//            Hash.hash(organizer, creation, name), name, creation, organizer, new ArrayList<>()));
   }
 
   @Override
@@ -72,8 +74,9 @@ public final class WebSocketHighLevelProxy implements HighLevelProxy {
         publicKey,
         privateKey,
         ROOT + "/" + laoId,
-        new CreateMeeting(
-            Hash.hash("M", laoId, creation, name), name, creation, location, start, end));
+        null);
+//        new CreateMeeting(
+//            Hash.hash("M", laoId, creation, name), name, creation, location, start, end));
   }
 
   @Override
@@ -100,14 +103,15 @@ public final class WebSocketHighLevelProxy implements HighLevelProxy {
         publicKey,
         privateKey,
         ROOT + "/" + laoId,
-        new CreateRollCall(
-            Hash.hash("R", laoId, creation, name),
-            name,
-            creation,
-            start,
-            startType,
-            location,
-            description));
+        null);
+//        new CreateRollCall(
+//            Hash.hash("R", laoId, creation, name),
+//            name,
+//            creation,
+//            start,
+//            startType,
+//            location,
+//            description));
   }
 
   @Override

--- a/app/src/main/java/com/github/dedis/student20_pop/utility/network/WebSocketLowLevelProxy.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/utility/network/WebSocketLowLevelProxy.java
@@ -152,9 +152,10 @@ public final class WebSocketLowLevelProxy implements LowLevelProxy, MessageListe
             .encodeToString(gson.toJson(message, Data.class).getBytes(StandardCharsets.UTF_8));
     String signature = Signature.sign(key, data);
     String msgId = Hash.hash(data, signature);
-    MessageGeneral container =
-        new MessageGeneral(sender, data, signature, msgId, new ArrayList<>());
-    return makeRequest(Integer.class, id -> new Publish(channel, id, container));
+//    MessageGeneral container =
+//        new MessageGeneral(sender, data, signature, msgId, new ArrayList<>());
+//    return makeRequest(Integer.class, id -> new Publish(channel, id, container));
+    return makeRequest(Integer.class, id -> new Publish(channel, id, null));
   }
 
   @Override
@@ -250,12 +251,12 @@ public final class WebSocketLowLevelProxy implements LowLevelProxy, MessageListe
     @Override
     public void handle(Broadcast broadcast) {
       MessageGeneral container = broadcast.getMessage();
-      Data data =
-          gson.fromJson(
-              new String(Base64.getDecoder().decode(container.getData()), StandardCharsets.UTF_8),
-              Data.class);
-
-      data.accept(dataHandler, sessionURI, broadcast.getChannel());
+//      Data data =
+//          gson.fromJson(
+//              new String(Base64.getDecoder().decode(container.getData()), StandardCharsets.UTF_8),
+////              Data.class);
+//
+//      data.accept(dataHandler, sessionURI, broadcast.getChannel());
     }
   }
 }

--- a/app/src/main/java/com/github/dedis/student20_pop/utility/security/Hash.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/utility/security/Hash.java
@@ -23,20 +23,20 @@ public class Hash {
    * @return the hashed data or null if failed to hash
    * @throws IllegalArgumentException if the data is null
    */
-  public static String hash(Object... data) {
-    if (data == null) {
-      throw new IllegalArgumentException("Can't hash a null data");
-    }
-
-    StringJoiner joiner = new StringJoiner(",", "[", "]");
-    for (Object elem : data) {
-      if (elem == null) {
-        throw new IllegalArgumentException("Can't hash null data");
+  public static String hash(String... strs) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      for (String str : strs) {
+        String length = Integer.toString(str.length());
+        digest.update(length.getBytes(StandardCharsets.UTF_8));
+        digest.update(str.getBytes(StandardCharsets.UTF_8));
       }
-      joiner.add(DELIMITER + esc(elem.toString()) + DELIMITER);
+      byte[] digestBuf = digest.digest();
+      return Base64.getEncoder().encodeToString(digestBuf);
+    } catch (NoSuchAlgorithmException e) {
+      Log.e(TAG, "failed to hash", e);
+      return "";
     }
-
-    return hash(joiner.toString());
   }
 
   private static String esc(String input) {

--- a/app/src/main/java/com/github/dedis/student20_pop/utility/security/Keys.java
+++ b/app/src/main/java/com/github/dedis/student20_pop/utility/security/Keys.java
@@ -1,0 +1,32 @@
+package com.github.dedis.student20_pop.utility.security;
+
+import android.util.Base64;
+
+import com.google.crypto.tink.CleartextKeysetHandle;
+import com.google.crypto.tink.JsonKeysetWriter;
+import com.google.crypto.tink.KeysetHandle;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class Keys {
+    public static String getEncodedKey(KeysetHandle handle) throws IOException {
+        ByteArrayOutputStream publicKeysetStream = new ByteArrayOutputStream();
+        CleartextKeysetHandle.write(handle, JsonKeysetWriter.withOutputStream(publicKeysetStream));
+
+        JsonElement publicKeyJson = JsonParser.parseString(publicKeysetStream.toString());
+        JsonObject root = publicKeyJson.getAsJsonObject();
+        JsonArray keyArray = root.get("key").getAsJsonArray();
+        JsonObject keyObject = keyArray.get(0).getAsJsonObject();
+        JsonObject keyData = keyObject.get("keyData").getAsJsonObject();
+
+        String encoded = keyData.get("value").getAsString();
+        byte[] buf = Base64.decode(encoded, Base64.NO_WRAP);
+
+        return Base64.encodeToString(buf, 2, 32, Base64.NO_WRAP);
+    }
+}

--- a/app/src/prod/java/com/github/dedis/student20_pop/Injection.java
+++ b/app/src/prod/java/com/github/dedis/student20_pop/Injection.java
@@ -25,6 +25,9 @@ import com.google.android.gms.vision.CameraSource;
 import com.google.android.gms.vision.Detector;
 import com.google.android.gms.vision.barcode.Barcode;
 import com.google.android.gms.vision.barcode.BarcodeDetector;
+import com.google.crypto.tink.integration.android.AndroidKeysetManager;
+import com.google.crypto.tink.signature.Ed25519PrivateKeyManager;
+import com.google.crypto.tink.signature.PublicKeySignWrapper;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.tinder.scarlet.Scarlet;
@@ -33,12 +36,34 @@ import com.tinder.scarlet.messageadapter.gson.GsonMessageAdapter;
 import com.tinder.scarlet.streamadapter.rxjava2.RxJava2StreamAdapterFactory;
 import com.tinder.scarlet.websocket.okhttp.OkHttpClientUtils;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
 
 public class Injection {
     private static String SERVER_URL = "ws://10.0.2.2:8080";
+
     private static final String TAG = "INJECTION";
+
+    private static final String KEYSET_NAME = "POP_KEYSET";
+
+    private static final String SHARED_PREF_FILE_NAME = "POP_KEYSET_SP";
+
+    private static final String MASTER_KEY_URI = "android-keystore://POP_MASTER_KEY";
+
+    public static AndroidKeysetManager provideAndroidKeysetManager(Context applicationContext)
+            throws IOException, GeneralSecurityException {
+
+        PublicKeySignWrapper.register();
+
+        return new AndroidKeysetManager.Builder()
+                .withSharedPref(applicationContext, KEYSET_NAME, SHARED_PREF_FILE_NAME)
+                .withKeyTemplate(Ed25519PrivateKeyManager.ed25519Template())
+                .withMasterKeyUri(MASTER_KEY_URI)
+                .build();
+    }
 
     public static Gson provideGson() {
         return new GsonBuilder()

--- a/app/src/prod/java/com/github/dedis/student20_pop/Injection.java
+++ b/app/src/prod/java/com/github/dedis/student20_pop/Injection.java
@@ -2,6 +2,7 @@ package com.github.dedis.student20_pop;
 
 import android.app.Application;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.hardware.Camera;
 
 import androidx.annotation.NonNull;
@@ -56,6 +57,10 @@ public class Injection {
     public static AndroidKeysetManager provideAndroidKeysetManager(Context applicationContext)
             throws IOException, GeneralSecurityException {
 
+        SharedPreferences.Editor editor = applicationContext.getSharedPreferences(SHARED_PREF_FILE_NAME, Context.MODE_PRIVATE).edit();
+        editor.apply();
+
+        Ed25519PrivateKeyManager.registerPair(true);
         PublicKeySignWrapper.register();
 
         return new AndroidKeysetManager.Builder()

--- a/app/src/prod/java/com/github/dedis/student20_pop/Injection.java
+++ b/app/src/prod/java/com/github/dedis/student20_pop/Injection.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.hardware.Camera;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 
@@ -15,28 +16,39 @@ import com.github.dedis.student20_pop.model.data.LAOService;
 import com.github.dedis.student20_pop.model.network.GenericMessage;
 import com.github.dedis.student20_pop.model.network.answer.Answer;
 import com.github.dedis.student20_pop.model.network.method.Message;
+import com.github.dedis.student20_pop.model.network.method.message.MessageGeneral;
 import com.github.dedis.student20_pop.model.network.method.message.data.Data;
 import com.github.dedis.student20_pop.model.network.method.message.data.rollcall.CreateRollCall;
 import com.github.dedis.student20_pop.utility.json.JsonAnswerSerializer;
 import com.github.dedis.student20_pop.utility.json.JsonCreateRollCallSerializer;
 import com.github.dedis.student20_pop.utility.json.JsonDataSerializer;
 import com.github.dedis.student20_pop.utility.json.JsonGenericMessageDeserializer;
+import com.github.dedis.student20_pop.utility.json.JsonMessageGeneralSerializer;
 import com.github.dedis.student20_pop.utility.json.JsonMessageSerializer;
+import com.github.dedis.student20_pop.utility.security.Keys;
 import com.google.android.gms.vision.CameraSource;
 import com.google.android.gms.vision.Detector;
 import com.google.android.gms.vision.barcode.Barcode;
 import com.google.android.gms.vision.barcode.BarcodeDetector;
+import com.google.crypto.tink.CleartextKeysetHandle;
+import com.google.crypto.tink.JsonKeysetWriter;
+import com.google.crypto.tink.KeysetHandle;
 import com.google.crypto.tink.integration.android.AndroidKeysetManager;
 import com.google.crypto.tink.signature.Ed25519PrivateKeyManager;
 import com.google.crypto.tink.signature.PublicKeySignWrapper;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.tinder.scarlet.Scarlet;
 import com.tinder.scarlet.lifecycle.android.AndroidLifecycle;
 import com.tinder.scarlet.messageadapter.gson.GsonMessageAdapter;
 import com.tinder.scarlet.streamadapter.rxjava2.RxJava2StreamAdapterFactory;
 import com.tinder.scarlet.websocket.okhttp.OkHttpClientUtils;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
@@ -54,6 +66,12 @@ public class Injection {
 
     private static final String MASTER_KEY_URI = "android-keystore://POP_MASTER_KEY";
 
+    private static OkHttpClient OK_HTTP_CLIENT_INSTANCE;
+
+    private static Scarlet SCARLET_INSTANCE;
+
+    private static LAOService LAO_SERVICE_INSTANCE;
+
     public static AndroidKeysetManager provideAndroidKeysetManager(Context applicationContext)
             throws IOException, GeneralSecurityException {
 
@@ -63,11 +81,23 @@ public class Injection {
         Ed25519PrivateKeyManager.registerPair(true);
         PublicKeySignWrapper.register();
 
-        return new AndroidKeysetManager.Builder()
+        // TODO: move to background thread
+        AndroidKeysetManager keysetManager = new AndroidKeysetManager.Builder()
                 .withSharedPref(applicationContext, KEYSET_NAME, SHARED_PREF_FILE_NAME)
-                .withKeyTemplate(Ed25519PrivateKeyManager.ed25519Template())
+                .withKeyTemplate(Ed25519PrivateKeyManager.rawEd25519Template())
                 .withMasterKeyUri(MASTER_KEY_URI)
                 .build();
+
+        KeysetHandle publicKeysetHandle = keysetManager.getKeysetHandle().getPublicKeysetHandle();
+
+        try {
+            String publicKey = Keys.getEncodedKey(publicKeysetHandle);
+            Log.d(TAG, "public key = " + publicKey);
+        } catch (IOException e) {
+            Log.e(TAG,"failed to retrieve public key", e);
+        }
+
+        return keysetManager;
     }
 
     public static Gson provideGson() {
@@ -77,6 +107,7 @@ public class Injection {
                 .registerTypeAdapter(Data.class, new JsonDataSerializer())
                 .registerTypeAdapter(Answer.class, new JsonAnswerSerializer())
                 .registerTypeAdapter(CreateRollCall.class, new JsonCreateRollCallSerializer())
+                .registerTypeAdapter(MessageGeneral.class, new JsonMessageGeneralSerializer())
                 .create();
     }
 
@@ -95,20 +126,38 @@ public class Injection {
         .build();
     }
 
-    public static LAORepository provideLAORepository(@NonNull Application application, Gson gson) {
-        OkHttpClient okHttpClient = new OkHttpClient.Builder()
-                .addInterceptor(new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BASIC))
-                .build();
+    public static OkHttpClient provideOkHttpClient() {
+        if (OK_HTTP_CLIENT_INSTANCE == null) {
+            Log.d(TAG, "creating new OkHttpClient");
+            OK_HTTP_CLIENT_INSTANCE = new OkHttpClient.Builder()
+                    .addInterceptor(new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BASIC))
+                    .build();
+        }
+        return OK_HTTP_CLIENT_INSTANCE;
+    }
 
-        Scarlet scarlet = new Scarlet.Builder()
+    public static Scarlet provideScarlet(Application application, OkHttpClient okHttpClient, Gson gson) {
+        if (SCARLET_INSTANCE == null) {
+            Log.d(TAG, "creating new Scarlet");
+            SCARLET_INSTANCE = new Scarlet.Builder()
                 .webSocketFactory(OkHttpClientUtils.newWebSocketFactory(okHttpClient, SERVER_URL))
                 .addMessageAdapterFactory(new GsonMessageAdapter.Factory(gson))
                 .addStreamAdapterFactory(new RxJava2StreamAdapterFactory())
                 .lifecycle(AndroidLifecycle.ofApplicationForeground(application))
                 //.backoffStrategy(new ExponentialBackoffStrategy())
                 .build();
+        }
+        return SCARLET_INSTANCE;
+    }
 
-        LAOService service = scarlet.create(LAOService.class);
+    public static LAOService provideLAOService(Scarlet scarlet) {
+        if (LAO_SERVICE_INSTANCE == null) {
+            LAO_SERVICE_INSTANCE = scarlet.create(LAOService.class);
+        }
+        return LAO_SERVICE_INSTANCE;
+    }
+
+    public static LAORepository provideLAORepository(Application application, LAOService service) {
         LAODatabase db = LAODatabase.getDatabase(application);
 
         return LAORepository.getInstance(LAORemoteDataSource.getInstance(service), LAOLocalDataSource.getInstance(db));


### PR DESCRIPTION
Note: To be merged after #216 

Made the following modifications to `MessageGeneral`:
- Use a `PublicKeySignaturePair` for WitnessSignatures
- Data members use a `byte[]` instead of String to make them compatible with sign and verify operations
- Implemented a serializer and deserializer with a signature verification check

Added a utility class `Keys` which allows retrieving a Base64 representation of a Tink `KeysetHandle`.

Added a `LaoService::sendMessage(Message msg)` to send a `Message` over the WS connection.
