### PR TITLE
Fixed Expo Web import paths

### DIFF
--- a/fe1-web/babel.config.js
+++ b/fe1-web/babel.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = (api) => {
   api.cache(true);
   return {
@@ -8,6 +10,10 @@ module.exports = (api) => {
         {
           root: ['./'],
           extensions: ['.ios.js', '.android.js', '.js', '.ts', '.tsx', '.json'],
+          alias: {
+            test_data: path.resolve(__dirname, '../tests/data'),
+            protocol: path.resolve(__dirname, '../protocol'),
+          }
         },
       ],
     ],

--- a/fe1-web/components/RollCallScanning.tsx
+++ b/fe1-web/components/RollCallScanning.tsx
@@ -10,7 +10,10 @@ import STRINGS from 'res/strings';
 import { Buttons, Colors, Typography } from '../styles';
 import CameraButton from './CameraButton';
 import PROPS_TYPE from '../res/Props';
-import { requestCloseRollCall } from '../network/MessageApi';
+
+// FIXME: this code path is not yet active
+//import { requestCloseRollCall } from '../network/MessageApi';
+const requestCloseRollCall = () => {};
 
 /**
  * Scanning roll-call component: a description string, the number of participants scanned,

--- a/fe1-web/package-lock.json
+++ b/fe1-web/package-lock.json
@@ -45,6 +45,7 @@
       },
       "devDependencies": {
         "@babel/core": "~7.9.0",
+        "@expo/webpack-config": "^0.12.44",
         "@types/base-64": "^0.1.3",
         "@types/chai": "^4.2.14",
         "@types/jest": "^26.0.20",

--- a/fe1-web/package.json
+++ b/fe1-web/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",
+    "@expo/webpack-config": "^0.12.44",
     "@types/base-64": "^0.1.3",
     "@types/chai": "^4.2.14",
     "@types/jest": "^26.0.20",

--- a/fe1-web/webpack.config.js
+++ b/fe1-web/webpack.config.js
@@ -1,0 +1,18 @@
+const createExpoWebpackConfigAsync = require('@expo/webpack-config');
+const path = require('path');
+
+const aliases = {
+  test_data: path.resolve(__dirname, '../tests/data'),
+  protocol: path.resolve(__dirname, '../protocol'),
+};
+
+module.exports = async function (env, argv) {
+  const config = await createExpoWebpackConfigAsync(env, argv);
+
+  config.resolve.alias = {
+    ...config.resolve.alias,
+    ...aliases,
+  };
+
+  return config;
+};


### PR DESCRIPTION
The expo launcher would not start anymore, because import paths outside of root were not correctly managed by Webpack.

Webpack was silently configured by Expo, this PR adds explicit Webpack configuration. 