### PR TITLE
Start of be2 cleanup

### DIFF
--- a/be2-scala/.github/workflows/be2-scala.yml
+++ b/be2-scala/.github/workflows/be2-scala.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ work-be2-* ]
   pull_request:
-    branches: [ be2-scala ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/be2-scala/.github/workflows/be2-scala.yml
+++ b/be2-scala/.github/workflows/be2-scala.yml
@@ -1,0 +1,29 @@
+name: PoP CI be2-scala
+
+on:
+  push:
+    branches: [ work-be2-* ]
+  pull_request:
+    branches: [ be2-scala ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Run unit tests
+        run: sbt coverage test
+
+      - name: Coverage report generation
+        run: sbt coverageReport
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true

--- a/be2-scala/.gitignore
+++ b/be2-scala/.gitignore
@@ -1,0 +1,16 @@
+# scala
+target
+*.class
+
+# sbt
+
+
+# IntelliJ
+*.iml
+*.ipr
+*.iws
+.idea
+out
+
+# Test
+database_test

--- a/be2-scala/README.md
+++ b/be2-scala/README.md
@@ -1,0 +1,32 @@
+# student20_pop: be2-scala branch
+Proof-of-personhood, fall 2020: Scala language back-end
+
+[TOC]
+
+## Running the project
+
+There are two main possible ways of running the project :
+* import the project using IntelliJ
+* using **sbt**, execute `sbt compile` and `sbt run`
+
+---
+
+
+
+## External libraries
+
+The project relies on several sbt dependencies (external libraries) :
+
+- websockets : [**akka-http**](https://doc.akka.io/docs/akka-http/current/introduction.html) for websocket server. It uses [akka-streams](https://doc.akka.io/docs/akka/current/stream/index.html) as dependency.
+- database : [**leveldb**](https://github.com/codeborui/leveldb-scala) which relies on both [snappy](https://search.maven.org/artifact/org.xerial.snappy/snappy-java/1.1.7.3/jar) (for compression/decompression) and [akka-persistence](https://doc.akka.io/docs/akka/current/persistence.html)
+- Json parser : [**spray-json**](https://github.com/spray/spray-json) for Json encoding/decoding
+- encryption : [**tink**](https://github.com/google/tink/blob/master/docs/JAVA-HOWTO.md) to verify signatures
+- testing : [**scalatest**](https://www.scalatest.org/) for unit tests
+
+---
+
+
+
+## Coding convention
+
+Our coding guidelines can be found [here](https://docs.scala-lang.org/style/).

--- a/be2-scala/README.md
+++ b/be2-scala/README.md
@@ -1,5 +1,5 @@
-# student20_pop: be2-scala branch
-Proof-of-personhood, fall 2020: Scala language back-end
+# student21_pop: be2-scala branch
+Proof-of-personhood, spring 2021: Scala language back-end
 
 [TOC]
 

--- a/be2-scala/build.sbt
+++ b/be2-scala/build.sbt
@@ -1,0 +1,38 @@
+name := "pop"
+
+version := "0.1"
+
+scalaVersion := "2.13.3"
+
+coverageEnabled := true
+
+
+
+//For websockets
+val AkkaVersion = "2.6.8"
+val AkkaHttpVersion = "10.2.0"
+libraryDependencies ++= Seq(
+  "com.typesafe.akka" %% "akka-stream-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion)
+//logging for akka
+libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.1.3" % Runtime
+
+// For LevelDB database
+// https://mvnrepository.com/artifact/org.iq80.leveldb/leveldb
+libraryDependencies += "org.iq80.leveldb" % "leveldb" % "0.12"
+libraryDependencies += "org.xerial.snappy" % "snappy-java" % "1.1.7.3"
+// missing binary dependency, leveldbjni
+//libraryDependencies += "com.typesafe.akka" %% "akka-persistence" % AkkaVersion
+
+
+// Json Parser (https://github.com/spray/spray-json)
+libraryDependencies += "io.spray" %%  "spray-json" % "1.3.5"
+
+//Encryption
+libraryDependencies += "com.google.crypto.tink" % "tink" % "1.5.0"
+
+// Scala unit tests
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % Test
+
+
+conflictManager := ConflictManager.latestCompatible

--- a/be2-scala/project/build.properties
+++ b/be2-scala/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 1.3.13

--- a/be2-scala/project/plugins.sbt
+++ b/be2-scala/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")

--- a/be2-scala/src/main/scala/ch/epfl/pop/DBActor.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/DBActor.scala
@@ -1,0 +1,116 @@
+package ch.epfl.pop
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import akka.NotUsed
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorRef, ActorSystem, Behavior}
+import akka.stream.scaladsl.{Sink, Source}
+import ch.epfl.pop.json.JsonMessages._
+import ch.epfl.pop.json._
+import ch.epfl.pop.json.JsonMessageParser.serializeMessage
+import org.iq80.leveldb.impl.Iq80DBFactory.factory
+import org.iq80.leveldb.{DB, Options}
+
+import java.util
+
+
+/**
+ * The role of a DBActor is to serve write and read requests to the database.
+ */
+object DBActor {
+
+  sealed trait DBMessage
+
+  /**
+   * Request to write a message in the database
+   * @param channel the channel where the message must be published
+   * @param message the message to write in the database
+   * @param replyTo the actor to respond to
+   */
+  final case class Write(channel: ChannelName, message : MessageContent, replyTo: ActorRef[Boolean]) extends DBMessage
+
+  /**
+   * Request to read all messages on a channel
+   * @param channel the channel we want to read
+   * @param rid the id of the request
+   * @param replyTo the actor to reply to
+   */
+  final case class Catchup(channel: ChannelName, rid: Int, replyTo: ActorRef[JsonMessageAnswerServer]) extends DBMessage
+
+  /**
+   * Request to read a specific messages on a channel
+   * @param channel the channel where the message was published
+   * @param id the id of the message we want to read
+   * @param replyTo the actor to reply to
+   */
+  final case class Read(channel: ChannelName, id: Hash, replyTo: ActorRef[Option[MessageContent]]) extends DBMessage
+
+
+  /**
+   * Create an actor handling the database
+   * @param path where to store the database
+   * @return an actor handling requests to the database
+   */
+  def apply(path: String): Behavior[DBMessage] = database(path, Map.empty)
+
+  private def database(path : String, channelsDB: Map[String, DB]): Behavior[DBMessage] = Behaviors.receive { (ctx, message) =>
+     message match {
+
+      case Write(channel, message, replyTo) =>
+        val (newChannelsDB, db) = channelsDB.get(channel) match {
+          case Some(db) => (channelsDB, db)
+          case None =>
+            val options = new Options()
+            options.createIfMissing(true)
+            val db = factory.open(new File(path + "/" + channel), options)
+            (channelsDB + (channel -> db), db)
+        }
+
+        val id = message.message_id
+        ctx.log.debug("Writing message with id: " + util.Arrays.toString(id) + " on channel " + channel)
+        db.put(id, serializeMessage(message).getBytes)
+
+        replyTo ! true
+
+        database(path, newChannelsDB)
+
+      case Catchup(channel, rid, replyTo) =>
+        if(channelsDB.contains(channel)) {
+          val db = channelsDB(channel)
+          val it = db.iterator()
+          var messages : List[ChannelMessage] = Nil
+          while(it.hasNext) {
+            val message: Array[Byte] = it.next().getValue
+            ctx.log.debug(new String(message, StandardCharsets.UTF_8))
+            val messageParsed: ChannelMessage = JsonMessageParser.parseChannelMessage(message)
+            messages =  messageParsed :: messages
+          }
+          replyTo ! AnswerResultArrayMessageServer(result = messages.reverse, id = rid)
+
+        }
+        else {
+          ctx.log.debug("Error invalid channel " + channel + "on catchup.")
+          val error = MessageErrorContent(-2, "Invalid resource: channel " + channel + " does not exist.")
+          replyTo ! AnswerErrorMessageServer(error = error, id = Some(rid))
+        }
+        Behaviors.same
+
+      case Read(channel, id, replyTo) =>
+        ctx.log.debug("Writing message with id: " + util.Arrays.toString(id) + " on channel " + channel)
+         if(channelsDB.contains(channel)) {
+           val db = channelsDB(channel)
+           val res = db.get(id) match {
+             case null => None
+             case value => Some(JsonMessageParser.parseChannelMessage(value))
+           }
+           replyTo ! res
+         }
+         else {
+           replyTo ! None
+         }
+         Behaviors.same
+     }
+  }
+
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/Server.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/Server.scala
@@ -1,0 +1,61 @@
+package ch.epfl.pop
+
+import java.util.concurrent.TimeUnit
+
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.server.Directives._
+import akka.stream.scaladsl.{BroadcastHub, Keep, MergeHub}
+import akka.util.Timeout
+import ch.epfl.pop.json.JsonMessages.PropagateMessageServer
+import ch.epfl.pop.pubsub.{ChannelActor, PublishSubscribe}
+import org.iq80.leveldb.Options
+
+import scala.concurrent.ExecutionContextExecutor
+import scala.io.StdIn
+import scala.util.{Failure, Success}
+
+object Server {
+
+  /**
+   * Create a webserver that handles http requests and websockets requests.
+   */
+  def main(args: Array[String]): Unit = {
+    val PORT = 8000
+    val PATH = ""
+
+    val root = Behaviors.setup[Nothing] { context =>
+      implicit val system: ActorSystem[Nothing] = context.system
+
+      //Stream that send all published messages to all clients
+      val (publishEntry, subscribeExit) = MergeHub.source[PropagateMessageServer].toMat(BroadcastHub.sink)(Keep.both).run()
+      implicit val timeout: Timeout = Timeout(1, TimeUnit.SECONDS)
+      val actor = context.spawn(ChannelActor(subscribeExit), "actor")
+      //Create database
+      val options: Options = new Options()
+      options.createIfMissing(true)
+      val DatabasePath: String = "database"
+      val dbActor = context.spawn(DBActor(DatabasePath), "actorDB")
+
+      def publishSubscribeRoute = path(PATH) {
+        handleWebSocketMessages(PublishSubscribe.messageFlow(actor, dbActor)(timeout, system, publishEntry))
+      }
+
+      implicit val executionContext: ExecutionContextExecutor = system.executionContext
+      val bindingFuture = Http().newServerAt("localhost", PORT).bind(publishSubscribeRoute)
+      bindingFuture.onComplete {
+        case Success(value) => println("ch.epfl.pop.Server online at ws://localhost:" + PORT + "/" + PATH)
+        case Failure(exception) => println("ch.epfl.pop.Server failed to start")
+          system.terminate()
+      }
+
+      Behaviors.empty
+    }
+
+    val system = ActorSystem[Nothing](root, "pop")
+
+    StdIn.readLine() // let it run until user presses return
+
+  }
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/Validate.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/Validate.scala
@@ -1,0 +1,218 @@
+package ch.epfl.pop
+
+import java.util.Arrays
+import ch.epfl.pop.crypto.{Hash, Signature}
+import ch.epfl.pop.json.{Actions, Hash, Key, MessageContent, MessageContentData, MessageErrorContent}
+import ch.epfl.pop.crypto.Signature.verify
+import ch.epfl.pop.json.JsonMessages.{BroadcastLaoMessageClient, BroadcastMeetingMessageClient, CloseRollCallMessageClient, CreateLaoMessageClient, CreateMeetingMessageClient, CreateRollCallMessageClient, OpenRollCallMessageClient, UpdateLaoMessageClient, WitnessMessageMessageClient}
+import ch.epfl.pop.json.JsonUtils.ErrorCodes.InvalidData
+
+import java.util
+
+/**
+ * Methods used to verify that messages follow the protocol
+ */
+object Validate {
+
+  /**
+   * Verify that the signature and the id of the message are correct
+   * @param content the message
+   * @return None if correct, an error otherwise
+   */
+  def validate(content: MessageContent): Option[MessageErrorContent] = {
+    if(!verify(content.encodedData, content.signature, content.sender)) {
+      Some(MessageErrorContent(InvalidData.id, "Invalid signature"))
+    }
+    else {
+      val id = Hash.computeMessageId(content.encodedData, content.signature)
+      if(util.Arrays.equals(id, content.message_id)) {
+        None
+      }
+      else {
+        Some(MessageErrorContent(InvalidData.id, "Invalid message id"))
+      }
+    }
+  }
+
+  /**
+   * Verify that the message parameters are valid, according to the protocol
+   * @param msg the message to validate
+   * @return None if correct, an error otherwise
+   */
+  def validate(msg: CreateLaoMessageClient): Option[MessageErrorContent] = {
+    val midLevelMsg = msg.params.message.get
+    val lao = midLevelMsg.data
+    val id = Hash.computeLAOId(lao.organizer, lao.creation, lao.name)
+
+    if (!util.Arrays.equals(id, lao.id)) getError("Invalid LAO id.")
+    else if (! (lao.creation > 0)) getError("Creation timestamp should be positive.")
+    else if (! util.Arrays.equals(midLevelMsg.sender, lao.organizer))
+      getError("The sender of the message should be the same as the organizer of the LAO.")
+    else None
+  }
+
+  /**
+   * Verify that the message parameters are valid, according to the protocol
+   * @param msg the message to validate
+   * @return None if correct, an error otherwise
+   */
+  def validate(msg: UpdateLaoMessageClient): Option[MessageErrorContent] = {
+    val midLevelMsg = msg.params.message.get
+    val laoUpdate = midLevelMsg.data
+
+    if (!(laoUpdate.last_modified > 0))
+      getError("Last modified should be positive")
+    else None
+  }
+
+  /**
+   * Verify that the message parameters are valid, according to the protocol
+   * @param msg the message to validate
+   * @param laoMod the creation/update message this message refers to
+   * @return None if correct, an error otherwise
+   */
+  def validate(msg: BroadcastLaoMessageClient, laoMod : MessageContentData): Option[MessageErrorContent] = {
+    val midLevelMsg = msg.params.message.get
+    val laoState = midLevelMsg.data
+
+    val same = " should be the same in the state and the creation/modification message."
+    if (!util.Arrays.equals(laoMod.id, laoState.id))
+      getError("LAO id" + same)
+    else if (laoMod.action == Actions.Create && !(laoState.creation == laoMod.creation))
+      getError("The creation timestamp" + same )
+    else if(laoMod.action == Actions.Create && !(laoState.last_modified == laoState.creation))
+      getError("The creation and last_modified fields should be the same when creating an LAO")
+    else if (!(laoState.name == laoMod.name))
+      getError("The name" + same)
+    else if (laoMod.action == Actions.UpdateProperties && !(laoState.last_modified == laoMod.last_modified))
+      getError("The last modified timestamp" + same)
+    else if (!util.Arrays.equals(laoState.organizer, laoMod.organizer))
+      getError("The organizer" + same)
+    else if (!(laoState.witnesses.length == laoMod.witnesses.length))
+      getError("The number of witnesses" + same)
+    else if (!compareWitnesses(laoState.witnesses, laoMod.witnesses))
+      getError("Witnesses" + same)
+    else if (!util.Arrays.equals(midLevelMsg.sender, laoState.organizer))
+      getError("The sender of the message should be the same as the organizer of the LAO.")
+    else None
+  }
+
+  /**
+   * Verify that the message parameters are valid, according to the protocol
+   * @param msg the message to validate
+   * @return None if correct, an error otherwise
+   */
+  def validate(msg: WitnessMessageMessageClient): Option[MessageErrorContent] = {
+    val midLevelMsg = msg.params.message.get
+    val witnessMsg = midLevelMsg.data
+    if(! Signature.verify(witnessMsg.message_id, witnessMsg.signature, midLevelMsg.sender))
+      getError("Invalid witness signature.")
+    else
+      None
+  }
+
+  /**
+   * Verify that the message parameters are valid, according to the protocol
+   * @param msg the message to validate
+   * @param laoId the id of the LAO
+   * @return None if correct, an error otherwise
+   */
+  def validate(msg: CreateMeetingMessageClient, laoId: Hash): Option[MessageErrorContent] = {
+    val midLevelMsg = msg.params.message.get
+    val createMsg = midLevelMsg.data
+    val id = Hash.computeMeetingId(laoId, createMsg.creation, createMsg.name)
+    if (!(util.Arrays.equals(id, createMsg.id)))
+      getError("Invalid meeting id.")
+    else if (!(createMsg.creation > 0))
+      getError("Creation timestamp should be positive.")
+    else if (!(createMsg.creation == createMsg.last_modified))
+      getError("Creation timestamp should be equals to last_modified.")
+    else if (!(createMsg.start > createMsg.creation))
+      getError("Meeting start time should be bigger than the creation time.")
+    else if (!(createMsg.end > createMsg.start))
+      getError("Meeting end should be bigger than meeting start")
+    else None
+  }
+
+  /**
+   * Verify that the message parameters are valid, according to the protocol
+   * @param msg the message to validate
+   * @param meetingMod the creation/update message this message refers to
+   * @return None if correct, an error otherwise
+   */
+  def validate(msg: BroadcastMeetingMessageClient, meetingMod : MessageContentData): Option[MessageErrorContent] = {
+    val midLevelMsg = msg.params.message.get
+    val stateMsg = midLevelMsg.data
+    val same = " should be the same in the state and the creation/modification message."
+
+    if (!(util.Arrays.equals(stateMsg.id, meetingMod.id)))
+      getError("The meeting id" + same)
+    else if (!(stateMsg.name == meetingMod.name))
+      getError("The meeting name" + same)
+    else if (!(stateMsg.creation == meetingMod.creation))
+      getError("The creation timestamp" + same)
+    else if(!(stateMsg.start == meetingMod.start))
+      getError("The start timestamp" + same)
+    else if (!(stateMsg.end == meetingMod.end))
+      getError("The end timestamp")
+    else None
+  }
+
+  /**
+   * Verify that the message parameters are valid, according to the protocol
+   * @param msg the message to validate
+   * @param laoId the id of the LAO
+   * @return None if correct, an error otherwise
+   */
+  def validate(msg: CreateRollCallMessageClient, laoId: Hash): Option[MessageErrorContent] = {
+    val midLevelMsg = msg.params.message.get
+    val createMsg = midLevelMsg.data
+
+    if(!util.Arrays.equals(Hash.computeRollCallId(laoId, createMsg.creation, createMsg.name), createMsg.id))
+      getError("Invalid roll-call id.")
+    else if (!(createMsg.creation > 0))
+      getError("Creation timestamp should be positive.")
+    else if(!(createMsg.start >= createMsg.creation || createMsg.scheduled > createMsg.creation))
+      getError("The start/scheduled time should be greater than the creation time")
+    else
+      None
+  }
+
+  /**
+   * Verify that the message parameters are valid, according to the protocol
+   * @param msg the message to validate
+   * @return None if correct, an error otherwise
+   */
+  def validate(msg: OpenRollCallMessageClient): Option[MessageErrorContent] = {
+    val midLevelMsg = msg.params.message.get
+    val openMessage = midLevelMsg.data
+
+    if (!(openMessage.start > 0))
+      getError("Start timestamp should be positive.")
+    else None
+  }
+
+  /**
+   * Verify that the message parameters are valid, according to the protocol
+   * @param msg the message to validate
+   * @return None if correct, an error otherwise
+   */
+  def validate(msg: CloseRollCallMessageClient): Option[MessageErrorContent] = {
+    val midLevelMsg = msg.params.message.get
+    val closeMessage = midLevelMsg.data
+
+    if (!(closeMessage.start > 0))
+      getError("Start timestamp should be positive.")
+    else if (!(closeMessage.end > closeMessage.start))
+      getError("End time should be greater than start time.")
+    else None
+  }
+
+  private def compareWitnesses(w1: List[Key], w2: List[Key]): Boolean = {
+    assert(w1.length == w2.length)
+    w1.zip(w2).forall(p => util.Arrays.equals(p._1, p._2))
+  }
+  private def getError(error: String): Some[MessageErrorContent] = {
+    Some(MessageErrorContent(InvalidData.id, error))
+  }
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/crypto/Hash.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/crypto/Hash.scala
@@ -1,0 +1,70 @@
+package ch.epfl.pop.crypto
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import ch.epfl.pop.json.{Base64String, Hash, Key, Signature}
+
+import java.util.Base64
+
+object Hash {
+
+  /**
+   * Compute the id of the message, which is the Hash(msg||signature)
+   * @param msg the message in base64
+   * @param signature the signature of the message
+   * @return the id of the message
+   */
+  def computeMessageId(msg: Base64String, signature: Signature): Hash = {
+    val data = arrayRepr(msg, Base64.getEncoder.encodeToString(signature))
+    val id = getMessageDigest().digest(data.getBytes(StandardCharsets.UTF_8))
+    id
+  }
+
+  /**
+   * Compute the LAO id, which is Hash(organizer||creation||name)
+   * @param organizer the organizer of the LAO
+   * @param creation the creation timestamp of the LAO
+   * @param name the name of the LAO
+   * @return the id of the LAO
+   */
+  def computeLAOId(organizer: Key, creation: Long, name: String): Hash = {
+    val data = arrayRepr(Base64.getEncoder.encodeToString(organizer), creation.toString, name)
+    val id = getMessageDigest().digest(data.getBytes(StandardCharsets.UTF_8))
+    id
+  }
+
+
+  /**
+   * Compute the meeting id, which is Hash('M'||laoId||creation||name)
+   * @param laoID the id of the LAO
+   * @param creation the creation timestamp of the meeting
+   * @param name the name of the meeting
+   * @return the id of the meeting
+   */
+  def computeMeetingId(laoID: Hash, creation: Long, name: String): Hash = computeGenericId("M", laoID, creation, name)
+
+  /**
+   * Compute the roll-call id, which is Hash('R'||laoId||creation||name)
+   * @param laoID the id of the LAO
+   * @param creation the creation timestamp of the roll-call
+   * @param name the name of the roll-call
+   * @return the id of the roll-call
+   */
+  def computeRollCallId(laoID: Hash, creation: Long, name: String): Hash = computeGenericId("R", laoID, creation, name)
+
+
+  private def computeGenericId(typ: String, a: Array[Byte], l: Long, s: String): Hash = {
+    val data = arrayRepr(typ, Base64.getEncoder.encodeToString(a), l.toString, s)
+    val id = getMessageDigest().digest(data.getBytes(StandardCharsets.UTF_8))
+    id
+  }
+
+  private def arrayRepr(strings: String*): String =
+    "[" + strings.tail.foldLeft(escapeAndQuote(strings.head))((acc, s) => acc + "," + escapeAndQuote(s)) + "]"
+
+  private def escapeAndQuote(s: String): String = '"' + s.replace("\\", "\\\\").replace("\"", "\\\"") + '"'
+
+  private def getMessageDigest() = MessageDigest.getInstance("SHA-256")
+
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/crypto/Signature.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/crypto/Signature.scala
@@ -1,0 +1,32 @@
+package ch.epfl.pop.crypto
+
+import ch.epfl.pop.json.{Base64String, Key, Signature}
+import com.google.crypto.tink.subtle.Ed25519Verify
+
+import java.security.GeneralSecurityException
+import java.util.Base64
+import java.nio.charset.StandardCharsets.UTF_8
+
+object Signature {
+
+  /**
+   * Verify if a signature is correct.
+   *
+   * @param msg       the message to verify, encoded in base64
+   * @param signature the signature corresponding to the message
+   * @param key       the public key used for verification
+   * @return whether the signature is correct
+   */
+  def verify(msg: Base64String, signature: Signature, key: Key): Boolean = {
+    val ed = new Ed25519Verify(key)
+    val msgDecoded = Base64.getDecoder.decode(msg.getBytes(UTF_8))
+
+    try {
+      ed.verify(signature, msgDecoded)
+      true
+    }
+    catch {
+      case _ : GeneralSecurityException => false
+    }
+  }
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/json/JsonCommunicationProtocol.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/json/JsonCommunicationProtocol.scala
@@ -1,0 +1,461 @@
+package ch.epfl.pop.json
+
+import ch.epfl.pop.json.Actions.Actions
+import ch.epfl.pop.json.JsonMessages._
+import ch.epfl.pop.json.JsonUtils._
+import ch.epfl.pop.json.Methods.Methods
+import ch.epfl.pop.json.Objects.Objects
+import spray.json._
+
+import java.nio.charset.StandardCharsets
+import scala.collection.immutable
+import scala.util.{Failure, Success, Try}
+
+
+/**
+ * Custom Json communication protocol
+ */
+object JsonCommunicationProtocol extends DefaultJsonProtocol {
+
+  /* implicit used to parse/serialize a Methods enumeration value */
+  implicit object JsonEnumMethodsFormat extends RootJsonFormat[Methods] {
+    @throws(classOf[DeserializationException])
+    override def read(json: JsValue): Methods = Methods.unapply(json.convertTo[String]) match {
+      case Some(v) => v
+      case _ => throw DeserializationException("invalid \"method\" field : unrecognized")
+    }
+    override def write(obj: Methods): JsValue = JsString(obj.toString)
+  }
+
+  /* implicit used to parse/serialize a Objects enumeration value */
+  implicit object JsonEnumObjectsFormat extends RootJsonFormat[Objects] {
+    @throws(classOf[DeserializationException])
+    override def read(json: JsValue): Objects = Objects.unapply(json.convertTo[String]) match {
+      case Some(v) => v
+      case _ => throw DeserializationException("invalid \"object\" field : unrecognized")
+    }
+    override def write(obj: Objects): JsValue = JsString(obj.toString)
+  }
+
+  /* implicit used to parse/serialize a Actions enumeration value */
+  implicit object JsonEnumActionsFormat extends RootJsonFormat[Actions] {
+    @throws(classOf[DeserializationException])
+    override def read(json: JsValue): Actions = Actions.unapply(json.convertTo[String]) match {
+      case Some(v) => v
+      case _ => throw DeserializationException("invalid \"action\" field : unrecognized")
+    }
+    override def write(obj: Actions): JsValue = JsString(obj.toString)
+  }
+
+  /* implicit used to parse/serialize a String encoded in Base64 */
+  implicit object ByteArrayFormat extends RootJsonFormat[ByteArray] {
+    @throws(classOf[IllegalArgumentException])
+    override def read(json: JsValue): ByteArray =
+      JsonUtils.DECODER.decode(json.convertTo[String].getBytes(StandardCharsets.UTF_8))
+    override def write(obj: ByteArray): JsValue = JsString(JsonUtils.ENCODER.encode(obj).map(_.toChar).mkString)
+  }
+
+  implicit val keySignPairFormat: RootJsonFormat[KeySignPair] = jsonFormat2(KeySignPair)
+
+
+  /* ------------------- ADMIN MESSAGES CLIENT ------------------- */
+
+  implicit object MessageContentDataFormat extends RootJsonFormat[MessageContentData] {
+    override def read(json: JsValue): MessageContentData = {
+      val jsonObject: JsObject = json.asJsObject
+      jsonObject.getFields("object").head.convertTo[String] match {
+
+        /* create LAO, update LAO's properties and broadcast LAO's state */
+        case Objects.Lao() =>
+          jsonObject.getFields("action", "id", "name", "creation", "organizer", "witnesses") match {
+
+            // create LAO and broadcast LAO's state
+            case Seq(a@JsString(_), id@JsString(_), JsString(n), c@JsNumber(_), orgKey@JsString(_), JsArray(w)) =>
+              val action: Actions = a.convertTo[Actions]
+              val mcb = new MessageContentDataBuilder()
+                .setHeader(Objects.Lao, action)
+                .setId(id.convertTo[ByteArray])
+                .setName(n)
+                .setCreation(c.convertTo[TimeStamp])
+                .setOrganizer(orgKey.convertTo[Key])
+                .setWitnesses(w.map(_.convertTo[Key]).toList)
+
+
+              action match {
+                case Actions.UpdateProperties =>
+                  jsonObject.getFields("last_modified") match {
+                    case Seq(lm@JsNumber(_)) => mcb.setLastModified(lm.convertTo[TimeStamp])
+                    case _ => throw JsonMessageParserException(
+                      s"""invalid "$action" query : field "last_modified" missing or wrongly formatted"""
+                    )
+                  }
+                case Actions.State =>
+                  jsonObject.getFields("last_modified", "modification_id", "modification_signatures") match {
+                    case Seq(lm@JsNumber(_), mid@JsString(_), JsArray(ms)) =>
+                      mcb.setLastModified(lm.convertTo[TimeStamp])
+                        .setModificationId(mid.convertTo[ByteArray])
+                        .setModificationSignatures(ms.map(_.convertTo[KeySignPair]).toList)
+
+                    case _ => throw JsonMessageParserException(
+                      "invalid \"stateBroadcastLao\" query : fields (\"modification_id\" and/or " +
+                      "\"modification_signatures\" and/or \"last_modified\") missing or wrongly formatted"
+                    )
+                  }
+
+                case _ =>
+              }
+
+              mcb.build()
+
+
+            // update LAO's properties
+            case Seq(action@JsString(_), id@JsString(_), JsString(name), JsArray(witnesses)) =>
+              val mcb = new MessageContentDataBuilder()
+                .setHeader(Objects.Lao, action.convertTo[Actions])
+                .setId(id.convertTo[ByteArray])
+                .setName(name)
+                .setWitnesses(witnesses.map(_.convertTo[Key]).toList)
+
+              jsonObject.getFields("last_modified") match {
+                case Seq(lm@JsNumber(_)) => mcb.setLastModified(lm.convertTo[TimeStamp])
+                case _ => throw JsonMessageParserException(
+                  """invalid "updateLaoProperties" query : field "last_modified" missing or wrongly formatted"""
+                )
+              }
+
+              mcb.build()
+
+
+            // parsing error : invalid message content data fields
+            case _ => throw JsonMessageParserException("invalid \"MessageContentData\" : fields missing or wrongly formatted")
+        }
+
+        /* witness a message */
+        case Objects.Message() =>
+          jsonObject.getFields("action", "message_id", "signature") match {
+            case Seq(action@JsString(_), mid@JsString(_), signature@JsString(_)) =>
+              new MessageContentDataBuilder()
+                .setHeader(Objects.Message, action.convertTo[Actions])
+                .setMessageId(mid.convertTo[Base64String])
+                .setSignature(signature.convertTo[Signature])
+                .build()
+
+            // parsing error : invalid message content data fields
+            case _ => throw JsonMessageParserException("invalid \"MessageContentData\" : fields missing or wrongly formatted")
+          }
+
+        /* create meeting and broadcast meeting's state */
+        case Objects.Meeting() =>
+          jsonObject.getFields("action", "id", "name", "creation", "start") match {
+            case Seq(a@JsString(_), id@JsString(_), JsString(n), c@JsNumber(_), st@JsNumber(_)) =>
+              val action: Actions = a.convertTo[Actions]
+
+              val location: Seq[JsValue] = jsonObject.getFields("location")
+              val end: Seq[JsValue] = jsonObject.getFields("end")
+              val extra: Seq[JsValue] = jsonObject.getFields("extra")
+
+              val mcd = new MessageContentDataBuilder()
+                .setHeader(Objects.Meeting, action)
+                .setId(id.convertTo[ByteArray])
+                .setName(n)
+                .setCreation(c.convertTo[TimeStamp])
+                .setStart(st.convertTo[TimeStamp])
+
+              action match {
+                case Actions.State =>
+                  jsonObject.getFields("last_modified", "modification_id", "modification_signatures") match {
+                    case Seq(lm@JsNumber(_), mid@JsString(_), JsArray(ms)) =>
+                      mcd.setLastModified(lm.convertTo[TimeStamp])
+                        .setModificationId(mid.convertTo[ByteArray])
+                        .setModificationSignatures(ms.map(_.convertTo[KeySignPair]).toList)
+                    case _ => throw JsonMessageParserException(
+                      "invalid \"stateBroadcastMeeting\" query : fields (\"modification_id\" and/or " +
+                        "\"modification_signatures\" and/or \"last_modified\") missing or wrongly formatted"
+                    )
+                  }
+                case _ =>
+              }
+
+              location match {
+                case Seq(JsString(l)) => mcd.setLocation(l)
+                case _ =>
+              }
+              end match {
+                case Seq(end@JsNumber(_)) => mcd.setEnd(end.convertTo[TimeStamp])
+                case _ =>
+              }
+              extra match { case _ => mcd.setExtra("extra: [unknown extra type?]") }
+
+              mcd.build()
+
+            // parsing error : invalid message content data fields
+            case _ => throw JsonMessageParserException("invalid \"MessageContentData\" : fields missing or wrongly formatted")
+          }
+
+        /* create/open/reopen/close roll call */
+        case Objects.RollCall() =>
+          jsonObject.getFields("action", "id") match {
+            case Seq(a@JsString(_), id@JsString(_)) =>
+              val action: Actions = a.convertTo[Actions]
+
+              val mcd = new MessageContentDataBuilder()
+                .setHeader(Objects.RollCall, action)
+                .setId(id.convertTo[ByteArray])
+
+              action match {
+                case Actions.Create =>
+                  jsonObject.getFields("name", "creation", "location") match {
+                    case Seq(JsString(name), creation@JsNumber(_), JsString(location)) =>
+                      mcd.setName(name)
+                        .setCreation(creation.convertTo[TimeStamp])
+                        .setLocation(location)
+
+                      jsonObject.getFields("start") match {
+                        case Seq(s@JsNumber(_)) => mcd.setStart(s.convertTo[TimeStamp])
+                        case _ =>
+                      }
+                      jsonObject.getFields("scheduled") match {
+                        case Seq(s@JsNumber(_)) => mcd.setScheduled(s.convertTo[TimeStamp])
+                        case _ =>
+                      }
+                      jsonObject.getFields("roll_call_description") match {
+                        case Seq(JsString(description)) => mcd.setRollCallDescription(description)
+                        case _ =>
+                      }
+
+                    case _ => throw JsonMessageParserException(
+                      "invalid \"CreateRollCall\" query : fields (\"name\" and/or " +
+                        "\"creation\" and/or \"location\") missing or wrongly formatted"
+                    )
+                  }
+
+                case Actions.Open | Actions.Reopen =>
+                  jsonObject.getFields("start") match {
+                    case Seq(start@JsNumber(_)) =>
+                      mcd.setStart(start.convertTo[TimeStamp])
+
+                    case _ => throw JsonMessageParserException(
+                      "invalid \"OpenRollCall/ReopenRollCall\" query : field (\"start\") missing or wrongly formatted"
+                    )
+                  }
+
+                case Actions.Close =>
+                  jsonObject.getFields("start", "end", "attendees") match {
+                    case Seq(start@JsNumber(_), end@JsNumber(_), JsArray(attendees)) =>
+                      mcd.setStart(start.convertTo[TimeStamp])
+                        .setEnd(end.convertTo[TimeStamp])
+                        .setAttendees(attendees.map(_.convertTo[Key]).toList)
+
+                    case _ => throw JsonMessageParserException(
+                      "invalid \"CloseRollCall\" query : fields (\"start\" and/or " +
+                        "\"end\" and/or \"attendees\") missing or wrongly formatted"
+                    )
+                  }
+                case _ => throw JsonMessageParserException(
+                  s"""invalid roll call query : action "${action.toString}" is unrecognizable"""
+                )
+              }
+
+              mcd.build()
+
+
+            // parsing error : invalid message content data fields
+            case _ => throw JsonMessageParserException("invalid \"MessageContentData\" : fields missing or wrongly formatted")
+          }
+
+        /* parsing error : object field not recognized */
+        case _ => throw JsonMessageParserException("invalid \"MessageContentData\" : invalid \"object\" field (unrecognized)")
+      }
+    }
+
+    override def write(obj: MessageContentData): JsValue = {
+
+      var jsObjectContent: immutable.ListMap[String, JsValue] = immutable.ListMap[String, JsValue]()
+
+      jsObjectContent += ("object" -> JsString(obj._object.toString))
+      jsObjectContent += ("action" -> JsString(obj.action.toString))
+
+      if (!obj.id.isEmpty) jsObjectContent += ("id" -> obj.id.toJson)
+      if (obj.name != "") jsObjectContent += ("name" -> obj.name.toJson)
+      if (obj.creation != -1L) jsObjectContent += ("creation" -> obj.creation.toJson)
+      if (obj.last_modified != -1L) jsObjectContent += ("last_modified" -> obj.last_modified.toJson)
+      if (!obj.organizer.isEmpty) jsObjectContent += ("organizer" -> obj.organizer.toJson)
+      if (obj._object == Objects.Lao) jsObjectContent += ("witnesses" -> JsArray(obj.witnesses.map(w => w.toJson).toVector))
+      if (!obj.modification_id.isEmpty) jsObjectContent += ("modification_id" -> obj.modification_id.toJson)
+      if (obj._object == Objects.Lao && obj.action == Actions.State)
+        jsObjectContent += ("modification_signatures" -> JsArray(obj.modification_signatures.map(s => s.toJson).toVector))
+      if (!obj.message_id.isEmpty) jsObjectContent += ("message_id" -> obj.message_id.toJson)
+      if (!obj.signature.isEmpty) jsObjectContent += ("signature" -> obj.signature.toJson)
+      if (obj.location != "") jsObjectContent += ("location" -> obj.location.toJson)
+      if (obj.start != -1L) jsObjectContent += ("start" -> obj.start.toJson)
+      if (obj.end != -1L) jsObjectContent += ("end" -> obj.end.toJson)
+      if (obj.extra != "") jsObjectContent += ("extra" -> obj.extra.toJson)
+      if (obj.scheduled != -1L) jsObjectContent += ("scheduled" -> obj.scheduled.toJson)
+      if (obj.roll_call_description != "") jsObjectContent += ("roll_call_description" -> obj.end.toJson)
+      if (obj._object == Objects.RollCall && obj.action == Actions.Close)
+        jsObjectContent += ("attendees" -> JsArray(obj.attendees.map(a => a.toJson).toVector))
+
+      JsObject(jsObjectContent)
+    }
+  }
+
+  implicit object MessageContentFormat extends RootJsonFormat[MessageContent] {
+    override def read(json: JsValue): MessageContent =
+      json.asJsObject.getFields("data", "sender", "signature", "message_id", "witness_signatures") match {
+        case Seq(data, sender, signature, message_id, JsArray(witnesses)) =>
+          val string64Data: Base64String = data.convertTo[Base64String]
+          val decodedData: String = JsonUtils.DECODER.decode(string64Data).map(_.toChar).mkString
+
+          MessageContent(
+            string64Data,
+            decodedData.parseJson.convertTo[MessageContentData],
+            sender.convertTo[Key],
+            signature.convertTo[Signature],
+            message_id.convertTo[Hash],
+            witnesses.map(_.convertTo[KeySignPair]).toList
+          )
+
+        // parsing error : invalid message content fields
+        case _ => throw JsonMessageParserException("invalid \"MessageContent\" : fields missing or wrongly formatted")
+      }
+
+    override def write(obj: MessageContent): JsValue =
+      JsObject(
+        "data" -> obj.encodedData.toJson,
+        "sender" -> obj.sender.toJson,
+        "signature" -> obj.signature.toJson,
+        "message_id" -> obj.message_id.toJson,
+        "witness_signatures" -> JsArray(obj.witness_signatures.map(_.toJson).toVector)
+      )
+  }
+
+  implicit val messageParametersFormat: RootJsonFormat[MessageParameters] = jsonFormat2(MessageParameters)
+
+  implicit object JsonMessagePublishClientFormat extends RootJsonFormat[JsonMessagePublishClient] {
+    override def read(json: JsValue): JsonMessagePublishClient = {
+      json.asJsObject.getFields("jsonrpc", "method", "params", "id") match {
+        case Seq(JsString(version), method@JsString(_), params@JsObject(_), JsNumber(id)) =>
+
+          val parsed: Try[JsonMessagePublishClient] = Try {
+            val parsedParams: MessageParameters = params.convertTo[MessageParameters]
+
+            parsedParams.message match {
+              case Some(messageContent) => (messageContent.data._object, messageContent.data.action) match {
+
+                /* CreateLaoMessageClient, UpdateLaoMessageClient and BroadcastLaoMessageClient */
+                case (Objects.Lao, action) => action match {
+                  // CreateLaoMessageClient
+                  case Actions.Create => CreateLaoMessageClient(parsedParams, id.toInt, method.convertTo[Methods], version)
+                  // UpdateLaoMessageClient
+                  case Actions.UpdateProperties => UpdateLaoMessageClient(parsedParams, id.toInt, method.convertTo[Methods], version)
+                  // BroadcastLaoMessageClient
+                  case Actions.State => BroadcastLaoMessageClient(parsedParams, id.toInt, method.convertTo[Methods], version)
+                }
+
+                /* WitnessMessageMessageClient */
+                case (Objects.Message, Actions.Witness) => WitnessMessageMessageClient(parsedParams, id.toInt, method.convertTo[Methods], version)
+
+                /* CreateMeetingMessageClient and BroadcastMeetingMessageClient */
+                case (Objects.Meeting, action) => action match {
+                  // CreateMeetingMessageClient
+                  case Actions.Create => CreateMeetingMessageClient(parsedParams, id.toInt, method.convertTo[Methods], version)
+                  // BroadcastMeetingMessageClient
+                  case Actions.State => BroadcastMeetingMessageClient(parsedParams, id.toInt, method.convertTo[Methods], version)
+                }
+
+                /* CreateRollCallMessageClient, OpenRollCallMessageClient and CloseRollCallMessageClient */
+                case (Objects.RollCall, action) => action match {
+                  // CreateRollCallMessageClient
+                  case Actions.Create => CreateRollCallMessageClient(parsedParams, id.toInt, method.convertTo[Methods], version)
+                  // OpenRollCallMessageClient
+                  case Actions.Open | Actions.Reopen => OpenRollCallMessageClient(parsedParams, id.toInt, method.convertTo[Methods], version)
+                  // CloseRollCallMessageClient
+                  case Actions.Close => CloseRollCallMessageClient(parsedParams, id.toInt, method.convertTo[Methods], version)
+                }
+
+                /* parsing error : invalid object/action pair */
+                case _ => throw JsonMessageParserException(
+                  s"invalid message : invalid (object = ${messageContent.data._object}, action = ${messageContent.data.action}) pair",
+                  Some(id.toInt)
+                )
+              }
+
+              // Should never happen missing MessageContent in MessageParameters
+              case _ => throw JsonMessageParserException(
+                "missing MessageContent in MessageParameter for JsonMessagePublishClient", Some(id.toInt)
+              )
+            }
+          }
+
+          parsed match {
+            case Success(mpc) => mpc
+            case Failure(s) => s match {
+              case DeserializationException(msg, _, _) => throw JsonMessageParserException(msg, Some(id.toInt))
+              case _ => throw s
+            }
+          }
+
+        // parsing error : invalid message parameters fields
+        case _ =>
+          val msg: String = "invalid MessageParameters : fields missing or wrongly formatted"
+          json.asJsObject.getFields("id") match {
+            case Seq(JsNumber(id)) => throw JsonMessageParserException(msg, Some(id.toInt))
+            case _ => throw JsonMessageParserException(msg)
+          }
+      }
+    }
+
+
+    override def write(obj: JsonMessagePublishClient): JsValue =
+      JsObject(
+        "jsonrpc" -> obj.jsonrpc.toJson,
+        "method" -> obj.method.toJson,
+        "params" -> obj.params.toJson,
+        "id" -> obj.id.toJson
+      )
+  }
+
+
+  /* ------------------- ANSWER MESSAGES SERVER ------------------- */
+
+  implicit val messageErrorContentFormat: RootJsonFormat[MessageErrorContent] = jsonFormat2(MessageErrorContent)
+
+  implicit val propagateMessageServerFormat: RootJsonFormat[PropagateMessageServer] = jsonFormat3(PropagateMessageServer)
+
+  implicit val answerResultIntMessageServerFormat: RootJsonFormat[AnswerResultIntMessageServer] = jsonFormat3(AnswerResultIntMessageServer)
+  implicit val answerResultArrayMessageServerFormat: RootJsonFormat[AnswerResultArrayMessageServer] = jsonFormat3(AnswerResultArrayMessageServer)
+
+  implicit object AnswerErrorMessageServerFormat extends RootJsonFormat[AnswerErrorMessageServer] {
+    override def read(json: JsValue): AnswerErrorMessageServer = {
+      json.asJsObject.getFields("jsonrpc", "error") match {
+        case Seq(JsString(version), err@JsObject(_)) =>
+          json.asJsObject.getFields("id") match {
+            case Seq(JsNumber(id)) => AnswerErrorMessageServer(Some(id.toInt), err.convertTo[MessageErrorContent], version)
+            case Seq(JsNull) => AnswerErrorMessageServer(None, err.convertTo[MessageErrorContent], version)
+            case _ => throw JsonMessageParserException("invalid \"AnswerErrorMessageServer\" : id field wrongly formatted")
+          }
+        case _ => throw JsonMessageParserException("invalid \"AnswerErrorMessageServer\" : fields missing or wrongly formatted")
+      }
+    }
+
+    override def write(obj: AnswerErrorMessageServer): JsValue = {
+      val optId: JsValue = obj.id match {
+        case Some(idx) => idx.toJson
+        case _ => JsNull
+      }
+
+      JsObject(
+        "jsonrpc" -> obj.jsonrpc.toJson,
+        "error" -> obj.error.toJson,
+        "id" -> optId
+      )
+    }
+  }
+
+
+  /* ------------------- PUBSUB MESSAGES CLIENT ------------------- */
+
+  implicit val subscribeMessageClientFormat: RootJsonFormat[SubscribeMessageClient] = jsonFormat4(SubscribeMessageClient)
+  implicit val unsubscribeMessageClientFormat: RootJsonFormat[UnsubscribeMessageClient] = jsonFormat4(UnsubscribeMessageClient)
+  implicit val catchupMessageClientFormat: RootJsonFormat[CatchupMessageClient] = jsonFormat4(CatchupMessageClient)
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/json/JsonMessageParser.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/json/JsonMessageParser.scala
@@ -1,0 +1,164 @@
+package ch.epfl.pop.json
+
+import ch.epfl.pop.json.JsonCommunicationProtocol._
+import ch.epfl.pop.json.JsonMessages._
+import ch.epfl.pop.json.JsonUtils.ErrorCodes.ErrorCodes
+import ch.epfl.pop.json.JsonUtils.{ErrorCodes, JsonMessageParserError, JsonMessageParserException}
+import spray.json._
+
+import scala.util.{Failure, Success, Try}
+
+
+/**
+ * Custom Json Parser for our Json-RPC protocol
+ */
+object JsonMessageParser {
+
+  /**
+   * Parse a Json string into a JsonMessage
+   *
+   * @param source the input string
+   * @return the parsed version of source
+   */
+  def parseMessage(source: String): Either[JsonMessage, JsonMessageParserError] = {
+
+    def buildJsonMessageParserException(
+                                         obj: JsObject,
+                                         id: Option[Int] = None,
+                                         errorCode: ErrorCodes = ErrorCodes.InvalidData,
+                                         description: String = ""): JsonMessageParserError = {
+
+      val msg: String = if (description == "") errorCode.toString else description
+
+      obj.getFields("id") match {
+        case Seq(JsNumber(id)) => JsonMessageParserError(msg, Some(id.toInt), errorCode)
+        case _ => JsonMessageParserError(msg, None, errorCode)
+      }
+    }
+
+
+    Try(source.parseJson.asJsObject) match {
+      case Success(obj) =>
+
+        try {
+          obj.getFields("jsonrpc") match {
+            case Seq(JsString(v)) =>
+              if (v != JsonUtils.JSON_RPC_VERSION)
+                throw JsonMessageParserException("invalid \"jsonrpc\" field : invalid jsonrpc version")
+            case _ => throw JsonMessageParserException("invalid message : jsonrpc field missing or wrongly formatted")
+          }
+
+          val fields: Set[String] = obj.fields.keySet
+
+          if (fields.contains("method")) {
+            /* parse a client query message */
+            obj.getFields("method") match {
+              case Seq(JsString(m)) => m match {
+                /* Subscribe to a channel */
+                case Methods.Subscribe() => Left(obj.convertTo[SubscribeMessageClient])
+
+                /* Unsubscribe from a channel */
+                case Methods.Unsubscribe() => Left(obj.convertTo[UnsubscribeMessageClient])
+
+                /* Propagate message on a channel */
+                case Methods.Broadcast() => Left(obj.convertTo[PropagateMessageServer])
+
+                /* Catchup on past message on a channel */
+                case Methods.Catchup() => Left(obj.convertTo[CatchupMessageClient])
+
+                /* Publish on a channel + All Higher-level communication */
+                case Methods.Publish() => Left(obj.convertTo[JsonMessagePublishClient])
+
+                /* parsing error : invalid method value */
+                case _ => throw JsonMessageParserException("invalid message : method value unrecognized")
+              }
+              case _ => throw JsonMessageParserException(
+                "invalid message : message contains a \"method\" field, but its type is unknown"
+              )
+            }
+
+          } else if (fields.contains("result")) {
+            // check that an answer message it either positive (x)or negative
+            if (fields.contains("error"))
+              throw JsonMessageParserException("invalid message : an answer cannot have both \"result\" and \"error\" fields")
+
+            /* parse a positive answer message */
+            obj.getFields("result") match {
+              case Seq(JsNumber(_)) => Left(obj.convertTo[AnswerResultIntMessageServer])
+              case Seq(JsArray(_)) => Left(obj.convertTo[AnswerResultArrayMessageServer])
+              case _ => throw JsonMessageParserException(
+                "invalid message : message contains a \"result\" field, but its type is unknown"
+              )
+            }
+
+          } else if (fields.contains("error")) {
+
+            /* parse a negative answer message */
+            obj.getFields("error") match {
+              case Seq(JsObject(_)) => Left(obj.convertTo[AnswerErrorMessageServer])
+              case _ => throw JsonMessageParserException(
+                "invalid message : message contains a \"error\" field, but its type is unknown"
+              )
+            }
+
+          } else {
+            /* parsing error : the message doesn't fall in any of the above categories */
+            throw JsonMessageParserException("invalid message : fields missing or wrongly formatted")
+
+          }
+
+        } catch {
+          case JsonMessageParserException(msg, id, code) => Right(buildJsonMessageParserException(obj, id, code, msg))
+          case DeserializationException(msg, _, _) => Right(buildJsonMessageParserException(obj, description = msg))
+          case _: Throwable => Right(buildJsonMessageParserException(obj))
+        }
+
+      /* parsing error : String is not a valid JsObject */
+      case Failure(_) => Right(JsonMessageParserError("Invalid Json formatting (not a valid JsonObject)"))
+    }
+  }
+
+  def parseChannelMessage(source: Array[Byte]): ChannelMessage = source.map(_.toChar).mkString.parseJson.convertTo[ChannelMessage]
+
+
+  /**
+   * Serialize a JsonMessage into a string
+   *
+   * @param message the JsonMessage to serialize
+   * @return the serialized version of JsonMessage
+   */
+  @throws(classOf[SerializationException])
+  def serializeMessage(message: JsonMessage): String = message match {
+    case _: JsonMessageAnswerServer => message match {
+      case m: AnswerResultIntMessageServer => m.toJson.toString
+      case m: AnswerResultArrayMessageServer => m.toJson.toString
+      case m: AnswerErrorMessageServer => m.toJson.toString
+      case m: PropagateMessageServer => m.toJson.toString
+      case _ => throw new SerializationException("Json serializer failed : unknown message type")
+    }
+
+    case _: JsonMessagePublishClient => message match {
+      case m: CreateLaoMessageClient => m.toJson(JsonMessagePublishClientFormat.write).toString
+      case m: UpdateLaoMessageClient => m.toJson(JsonMessagePublishClientFormat.write).toString
+      case m: BroadcastLaoMessageClient => m.toJson(JsonMessagePublishClientFormat.write).toString
+      case m: WitnessMessageMessageClient => m.toJson(JsonMessagePublishClientFormat.write).toString
+      case m: CreateMeetingMessageClient => m.toJson(JsonMessagePublishClientFormat.write).toString
+      case m: BroadcastMeetingMessageClient => m.toJson(JsonMessagePublishClientFormat.write).toString
+      case m: CreateRollCallMessageClient => m.toJson(JsonMessagePublishClientFormat.write).toString
+      case m: OpenRollCallMessageClient => m.toJson(JsonMessagePublishClientFormat.write).toString
+      case m: CloseRollCallMessageClient => m.toJson(JsonMessagePublishClientFormat.write).toString
+      case _ => throw new SerializationException("Json serializer failed : unknown message type")
+    }
+
+    case _: JsonMessagePubSubClient => message match {
+      case m: SubscribeMessageClient => m.toJson.toString
+      case m: UnsubscribeMessageClient => m.toJson.toString
+      case m: CatchupMessageClient => m.toJson.toString
+      case _ => throw new SerializationException("Json serializer failed : unknown message type")
+    }
+
+    case _ => throw new SerializationException("Json serializer failed : invalid input message")
+  }
+
+  def serializeMessage(mc: MessageContent): String = mc.toJson.toString
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/json/JsonMessages.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/json/JsonMessages.scala
@@ -1,0 +1,173 @@
+package ch.epfl.pop.json
+
+import ch.epfl.pop.json.Methods.Methods
+import ch.epfl.pop.json.JsonUtils.JSON_RPC_VERSION
+
+
+/**
+ * Collection of parsed Json messages
+ */
+object JsonMessages {
+
+  /** Parsed Json message as output of the JsonParser */
+  sealed trait JsonMessage
+
+
+  /* --------------------------------------------------------- */
+  /* ---------------- ANSWER MESSAGES SERVER ----------------- */
+  /* --------------------------------------------------------- */
+
+  /** Parsed answer Json message from the server */
+  sealed trait JsonMessageAnswerServer extends JsonMessage
+
+
+  /** Parsed result answer (Int result) Json message from the server */
+  final case class AnswerResultIntMessageServer(
+                                                 id: Int,
+                                                 result: Int = 0,
+                                                 jsonrpc: String = JSON_RPC_VERSION
+                                               ) extends JsonMessageAnswerServer
+
+  /** Parsed result answer (Array result) Json message from the server */
+  final case class AnswerResultArrayMessageServer(
+                                                   id: Int,
+                                                   result: List[ChannelMessage],
+                                                   jsonrpc: String = JSON_RPC_VERSION
+                                                 ) extends JsonMessageAnswerServer
+
+  /** Parsed error answer Json message from the server */
+  final case class AnswerErrorMessageServer(
+                                             id: Option[Int],
+                                             error: MessageErrorContent,
+                                             jsonrpc: String = JSON_RPC_VERSION
+                                           ) extends JsonMessageAnswerServer
+
+  /** Parsed client propagate a message on a channel query */
+  final case class PropagateMessageServer(
+                                           params: MessageParameters,
+                                           method: Methods = Methods.Broadcast,
+                                           jsonrpc: String = JSON_RPC_VERSION
+                                         ) extends JsonMessageAnswerServer
+
+  /* --------------------------------------------------------- */
+  /* ------------ ADMINISTRATION MESSAGES CLIENT ------------- */
+  /* --------------------------------------------------------- */
+
+  /** Parsed Administration Json message from the client */
+  sealed class JsonMessagePublishClient(
+                                         val params: MessageParameters,
+                                         val id: Int,
+                                         val method: Methods,
+                                         val jsonrpc: String = JSON_RPC_VERSION
+                                       ) extends JsonMessagePubSubClient
+
+
+  /* --------------- ADMIN CLIENT MESSAGES --------------- */
+
+  /** Parsed client LAO creation query */
+  final case class CreateLaoMessageClient(
+                                           override val params: MessageParameters,
+                                           override val id: Int,
+                                           override val method: Methods,
+                                           override val jsonrpc: String = JSON_RPC_VERSION
+                                         ) extends JsonMessagePublishClient(params, id, method, jsonrpc)
+
+  /** Parsed client LAO update query */
+  final case class UpdateLaoMessageClient(
+                                           override val params: MessageParameters,
+                                           override val id: Int,
+                                           override val method: Methods,
+                                           override val jsonrpc: String = JSON_RPC_VERSION
+                                         ) extends JsonMessagePublishClient(params, id, method, jsonrpc)
+
+  /** Parsed client LAO state broadcast query */
+  final case class BroadcastLaoMessageClient(
+                                              override val params: MessageParameters,
+                                              override val id: Int,
+                                              override val method: Methods,
+                                              override val jsonrpc: String = JSON_RPC_VERSION
+                                            ) extends JsonMessagePublishClient(params, id, method, jsonrpc)
+
+  /** Parsed client message witness query */
+  final case class WitnessMessageMessageClient(
+                                                override val params: MessageParameters,
+                                                override val id: Int,
+                                                override val method: Methods,
+                                                override val jsonrpc: String = JSON_RPC_VERSION
+                                              ) extends JsonMessagePublishClient(params, id, method, jsonrpc)
+
+  /** Parsed client meeting creation query */
+  final case class CreateMeetingMessageClient(
+                                               override val params: MessageParameters,
+                                               override val id: Int,
+                                               override val method: Methods,
+                                               override val jsonrpc: String = JSON_RPC_VERSION
+                                             ) extends JsonMessagePublishClient(params, id, method, jsonrpc)
+
+  /** Parsed client meeting state broadcast query */
+  final case class BroadcastMeetingMessageClient(
+                                                  override val params: MessageParameters,
+                                                  override val id: Int,
+                                                  override val method: Methods,
+                                                  override val jsonrpc: String = JSON_RPC_VERSION
+                                                ) extends JsonMessagePublishClient(params, id, method, jsonrpc)
+
+  /** Parsed client roll call creation query */
+  final case class CreateRollCallMessageClient(
+                                                override val params: MessageParameters,
+                                                override val id: Int,
+                                                override val method: Methods,
+                                                override val jsonrpc: String = JSON_RPC_VERSION
+                                              ) extends JsonMessagePublishClient(params, id, method, jsonrpc)
+
+  /** Parsed client roll call re/opening query */
+  final case class OpenRollCallMessageClient(
+                                              override val params: MessageParameters,
+                                              override val id: Int,
+                                              override val method: Methods,
+                                              override val jsonrpc: String = JSON_RPC_VERSION
+                                            ) extends JsonMessagePublishClient(params, id, method, jsonrpc)
+
+  /** Parsed client roll call closing query */
+  final case class CloseRollCallMessageClient(
+                                               override val params: MessageParameters,
+                                               override val id: Int,
+                                               override val method: Methods,
+                                               override val jsonrpc: String = JSON_RPC_VERSION
+                                             ) extends JsonMessagePublishClient(params, id, method, jsonrpc)
+
+
+  /* --------------------------------------------------------- */
+  /* ---------------- PUBSUB MESSAGES CLIENT ----------------- */
+  /* --------------------------------------------------------- */
+
+  /** Parsed PubSub Json message from the client */
+  sealed trait JsonMessagePubSubClient extends JsonMessage
+
+
+  /* --------------- PUBSUB CLIENT MESSAGES --------------- */
+
+  /** Parsed client subscribe to a channel query */
+  final case class SubscribeMessageClient(
+                                           params: MessageParameters,
+                                           id: Int,
+                                           method: Methods = Methods.Subscribe,
+                                           jsonrpc: String = JSON_RPC_VERSION
+                                         ) extends JsonMessagePubSubClient
+
+  /** Parsed client unsubscribe from a channel query */
+  final case class UnsubscribeMessageClient(
+                                             params: MessageParameters,
+                                             id: Int,
+                                             method: Methods = Methods.Unsubscribe,
+                                             jsonrpc: String = JSON_RPC_VERSION
+                                           ) extends JsonMessagePubSubClient
+
+  /** Parsed client catchup on past messages on a channel query */
+  final case class CatchupMessageClient(
+                                         params: MessageParameters,
+                                         id: Int,
+                                         method: Methods = Methods.Catchup,
+                                         jsonrpc: String = JSON_RPC_VERSION
+                                       ) extends JsonMessagePubSubClient
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/json/JsonUtils.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/json/JsonUtils.scala
@@ -1,0 +1,119 @@
+package ch.epfl.pop.json
+
+import java.util.Base64
+
+import ch.epfl.pop.json.Actions.Actions
+import ch.epfl.pop.json.JsonUtils.ErrorCodes.ErrorCodes
+import ch.epfl.pop.json.Objects.Objects
+
+
+object JsonUtils {
+
+  /** JSON-RPC protocol version */
+  val JSON_RPC_VERSION: String = "2.0"
+
+  /** Static references to Base64 encoder/decoder */
+  val ENCODER: Base64.Encoder = Base64.getEncoder
+  val DECODER: Base64.Decoder = Base64.getDecoder
+
+  /** Parsing exception, always caught by the parser */
+  final case class JsonMessageParserException(
+                                               description: String,
+                                               id: Option[Int] = None,
+                                               errorCode: ErrorCodes = ErrorCodes.InvalidData
+                                             ) extends Exception(description) {}
+
+  /** Object sent back to PubSub if a parsing error occurred */
+  final case class JsonMessageParserError(
+                                           description: String,
+                                           id: Option[Int] = None,
+                                           errorCode: ErrorCodes = ErrorCodes.InvalidData
+                                         )
+
+  object ErrorCodes extends Enumeration {
+    type ErrorCodes = Value
+
+    // operation was successful (should never be used)
+    val Success: JsonUtils.ErrorCodes.Value = Value(0, "operation was successful")
+    // invalid action
+    val InvalidAction: JsonUtils.ErrorCodes.Value = Value(-1, "invalid action")
+    // invalid resource (e.g. channel does not exist, channel was not subscribed to, etc.)
+    val InvalidResource: JsonUtils.ErrorCodes.Value = Value(-2, "invalid resource")
+    // resource already exists (e.g. lao already exists, channel already exists, etc.)
+    val AlreadyExists: JsonUtils.ErrorCodes.Value = Value(-3, "resource already exists")
+    // request data is invalid (e.g. message is invalid)
+    val InvalidData: JsonUtils.ErrorCodes.Value = Value(-4, "request data is invalid")
+    // access denied (e.g. subscribing to a “restricted” channel)
+    val AccessDenied: JsonUtils.ErrorCodes.Value = Value(-5, "access denied")
+  }
+
+
+
+  /** Builder for MessageContentData */
+  final class MessageContentDataBuilder() {
+    /* basic common fields */
+    var _object: Objects = _
+    var action: Actions = _
+
+    /* LAO related fields */
+    var id: ByteArray = Array[Byte]()
+    var name: String = ""
+    var creation: TimeStamp = -1L
+    var last_modified: TimeStamp = -1L
+    var organizer: Key = Array[Byte]()
+    var witnesses: List[Key] = List()
+
+    /* state LAO broadcast fields */
+    var modification_id: ByteArray = Array[Byte]()
+    var modification_signatures: List[KeySignPair] = List()
+
+    /* witness a message related fields */
+    var message_id: Base64String = ""
+    var signature: Signature = Array[Byte]()
+
+    /* meeting related fields */
+    var location: String = ""
+    var start: TimeStamp = -1L
+    var end: TimeStamp = -1L
+    var extra: UNKNOWN = ""
+
+    /* roll call related fields */
+    var scheduled: TimeStamp = -1L
+    var roll_call_description: String = ""
+    var attendees: List[Key] = List()
+
+
+    def build(): MessageContentData = {
+      MessageContentData(
+        _object, action,
+        id, name, creation, last_modified, organizer, witnesses,
+        modification_id, modification_signatures,
+        message_id, signature,
+        location, start, end, extra,
+        scheduled, roll_call_description, attendees
+      )
+    }
+
+    def setHeader(obj: Objects, act: Actions): MessageContentDataBuilder = {setObject(obj); setAction(act); this }
+
+    def setObject(obj: Objects): MessageContentDataBuilder = { this._object = obj; this }
+    def setAction(action: Actions): MessageContentDataBuilder = { this.action = action; this }
+    def setId(id: ByteArray): MessageContentDataBuilder = { this.id = id; this }
+    def setName(name: String): MessageContentDataBuilder = { this.name = name; this }
+    def setCreation(creation: TimeStamp): MessageContentDataBuilder = { this.creation = creation; this }
+    def setLastModified(lastModified: TimeStamp): MessageContentDataBuilder = { this.last_modified = lastModified; this }
+    def setOrganizer(organizer: Key): MessageContentDataBuilder = { this.organizer = organizer; this }
+    def setWitnesses(witnesses: List[Key]): MessageContentDataBuilder = { this.witnesses = witnesses; this }
+    def setModificationId(modification_id: ByteArray): MessageContentDataBuilder = { this.modification_id = modification_id; this }
+    def setMessageId(id: Base64String): MessageContentDataBuilder = { this.message_id = id; this }
+    def setModificationSignatures(modification_sig: List[KeySignPair]): MessageContentDataBuilder = { this.modification_signatures = modification_sig; this}
+    def setSignature(signature: Signature): MessageContentDataBuilder = { this.signature = signature; this }
+    def setLocation(location: String): MessageContentDataBuilder = { this.location = location; this }
+    def setStart(start: TimeStamp): MessageContentDataBuilder = { this.start = start; this }
+    def setEnd(end: TimeStamp): MessageContentDataBuilder = { this.end = end; this }
+    def setExtra(extra: UNKNOWN): MessageContentDataBuilder = { this.extra = extra; this }
+    def setScheduled(scheduled: TimeStamp): MessageContentDataBuilder = { this.scheduled = scheduled; this }
+    def setRollCallDescription(description: String): MessageContentDataBuilder = { this.roll_call_description = description; this }
+    def setAttendees(attendees: List[Key]): MessageContentDataBuilder = { this.attendees = attendees; this }
+  }
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/json/json.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/json/json.scala
@@ -1,0 +1,131 @@
+package ch.epfl.pop
+
+import ch.epfl.pop.json.Actions.Actions
+import ch.epfl.pop.json.Objects.Objects
+
+
+/** Collection of types used in Json parsing */
+package object json {
+  // TODO [unknown extra type?]. Should be removed at some point when we know how to describe an "extra"
+  type UNKNOWN = String
+
+  /** Base64 strings (untouched and decoded) */
+  type Base64String = String
+  type ByteArray = Array[Byte]
+
+  type TimeStamp = Long
+  type Signature = ByteArray
+  type Key = ByteArray
+  type Hash = ByteArray
+
+  type ChannelName = String
+  type ChannelMessage = MessageContent
+
+
+
+
+  sealed trait Matching {
+    // See https://stackoverflow.com/questions/3407032/comparing-string-and-enumeration
+    def unapply(s: String): Boolean = s == toString
+  }
+
+  object Methods extends Enumeration {
+    type Methods = Value
+
+    val Subscribe: json.Methods.Value with Matching = MatchingValue("subscribe")
+    val Unsubscribe: json.Methods.Value with Matching = MatchingValue("unsubscribe")
+    val Broadcast: json.Methods.Value with Matching = MatchingValue("broadcast")
+    val Catchup: json.Methods.Value with Matching = MatchingValue("catchup")
+    val Publish: json.Methods.Value with Matching = MatchingValue("publish")
+
+    def MatchingValue(v: String): Value with Matching = new Val(nextId, v) with Matching
+    def unapply(s: String): Option[Value] = values.find(s == _.toString)
+  }
+
+
+  final case class MessageParameters(channel: ChannelName, message: Option[MessageContent])
+  final case class MessageContent(
+                                   encodedData: Base64String,
+                                   data: MessageContentData,
+                                   sender: Key,
+                                   signature: Signature,
+                                   message_id: Hash,
+                                   witness_signatures: List[KeySignPair]
+                                 ) {
+
+    def updateWitnesses(s: KeySignPair): MessageContent =
+      MessageContent(encodedData, data, sender, signature, message_id, s :: witness_signatures)
+  }
+
+  final case class MessageErrorContent(code: Int, description: String)
+
+  final case class KeySignPair(witness: Key, signature: Signature)
+
+  /* --------------------------------------------------------- */
+  /* ---------------------- ADMIN TYPES ---------------------- */
+  /* --------------------------------------------------------- */
+
+  object Objects extends Enumeration {
+    type Objects = Value
+
+    val Lao: json.Objects.Value with Matching = MatchingValue("lao")
+    val Message: json.Objects.Value with Matching = MatchingValue("message")
+    val Meeting: json.Objects.Value with Matching = MatchingValue("meeting")
+    val RollCall: json.Objects.Value with Matching = MatchingValue("roll_call")
+
+    def MatchingValue(v: String): Value with Matching = new Val(nextId, v) with Matching
+    def unapply(s: String): Option[Value] = values.find(s == _.toString)
+  }
+
+
+  object Actions extends Enumeration {
+    type Actions = Value
+
+    val Create: json.Actions.Value = MatchingValue("create")
+    val UpdateProperties: json.Actions.Value = MatchingValue("update_properties")
+    val State: json.Actions.Value = MatchingValue("state")
+    val Witness: json.Actions.Value = MatchingValue("witness")
+    /* roll call related actions */
+    val Open: json.Actions.Value = MatchingValue("open")
+    val Reopen: json.Actions.Value = MatchingValue("reopen")
+    val Close: json.Actions.Value = MatchingValue("close")
+
+    def MatchingValue(v: String): Value with Matching =  new Val(nextId, v) with Matching
+    def unapply(s: String): Option[Value] = values.find(s == _.toString)
+  }
+
+
+  /** Data field of a JSON message */
+  final case class MessageContentData(
+    /* basic common fields */
+    _object: Objects,
+    action: Actions,
+
+    /* LAO related fields */
+    id: Array[Byte],
+    name: String,
+    creation: TimeStamp,
+    last_modified: TimeStamp,
+    organizer: Key,
+    witnesses: List[Key],
+
+    /* state LAO broadcast fields */
+    modification_id: Array[Byte],
+    modification_signatures: List[KeySignPair],
+
+    /* witness a message related fields */
+    message_id: Base64String,
+    signature: Signature,
+
+    /* meeting related fields */
+    location: String,
+    start: TimeStamp,
+    end: TimeStamp,
+    extra: UNKNOWN,
+
+    /* roll call related fields */
+    scheduled: TimeStamp,
+    roll_call_description: String,
+    attendees: List[Key],
+  )
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/ErrorObject.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/ErrorObject.scala
@@ -1,0 +1,3 @@
+package ch.epfl.pop.model.network
+
+case class ErrorObject(code: Int, description: String)

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/JsonRpcMessage.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/JsonRpcMessage.scala
@@ -1,0 +1,6 @@
+package ch.epfl.pop.model.network
+
+trait JsonRpcMessage {
+  val jsonrpc: String
+  // Note: Parsable enforced in companion objects
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/JsonRpcRequest.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/JsonRpcRequest.scala
@@ -1,0 +1,24 @@
+package ch.epfl.pop.model.network
+import ch.epfl.pop.model.network.method.ParamsSimple
+import ch.epfl.pop.model.network.method.message.data.MessageData
+
+case class JsonRpcRequest(
+                           jsonrpc: String,
+                           method: Method.Method,
+                           params: ParamsSimple,
+                           id: Option[Int]
+                         ) extends JsonRpcMessage
+
+object JsonRpcRequest extends Parsable {
+  def apply(
+             jsonrpc: String,
+             method: Method.Method,
+             params: ParamsSimple,
+             id: Option[Int]
+           ): JsonRpcRequest = {
+    // FIXME add checks
+    new JsonRpcRequest(jsonrpc, method, params, id)
+  }
+
+  override def buildFromJson(messageData: MessageData, payload: String): JsonRpcRequest = ???
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/JsonRpcRequest.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/JsonRpcRequest.scala
@@ -1,11 +1,11 @@
 package ch.epfl.pop.model.network
-import ch.epfl.pop.model.network.method.ParamsSimple
+import ch.epfl.pop.model.network.method.Params
 import ch.epfl.pop.model.network.method.message.data.MessageData
 
 case class JsonRpcRequest(
                            jsonrpc: String,
                            method: Method.Method,
-                           params: ParamsSimple,
+                           params: Params,
                            id: Option[Int]
                          ) extends JsonRpcMessage
 
@@ -13,7 +13,7 @@ object JsonRpcRequest extends Parsable {
   def apply(
              jsonrpc: String,
              method: Method.Method,
-             params: ParamsSimple,
+             params: Params,
              id: Option[Int]
            ): JsonRpcRequest = {
     // FIXME add checks

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/JsonRpcResponse.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/JsonRpcResponse.scala
@@ -1,0 +1,24 @@
+package ch.epfl.pop.model.network
+
+import ch.epfl.pop.model.network.method.message.data.MessageData
+
+case class JsonRpcResponse(
+                           jsonrpc: String,
+                           result: Option[Any], // FIXME
+                           error: Option[ErrorObject],
+                           id: Int
+                         ) extends JsonRpcMessage
+
+object JsonRpcResponse extends Parsable {
+  def apply(
+             jsonrpc: String,
+             result: Option[Any], // FIXME
+             error: Option[ErrorObject],
+             id: Int
+           ): JsonRpcResponse = {
+    // FIXME add checks
+    new JsonRpcResponse(jsonrpc, result, error, id)
+  }
+
+  override def buildFromJson(messageData: MessageData, payload: String): JsonRpcResponse = ???
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/Matching.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/Matching.scala
@@ -1,4 +1,4 @@
-package ch.epfl.pop.model.network.method.message.data
+package ch.epfl.pop.model.network
 
 sealed trait Matching {
   // See https://stackoverflow.com/questions/3407032/comparing-string-and-enumeration

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/Method.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/Method.scala
@@ -1,0 +1,18 @@
+package ch.epfl.pop.model.network
+
+object Method extends Enumeration {
+  type Method = Value
+
+  // uninitialized placeholder
+  val INVALID: Value = MatchingValue("__INVALID_METHOD__")
+
+  val BROADCAST: Value = MatchingValue("message")
+  val PUBLISH: Value = MatchingValue("publish")
+  val SUBSCRIBE: Value = MatchingValue("subscribe")
+  val UNSUBSCRIBE: Value = MatchingValue("unsubscribe")
+  val CATCHUP: Value = MatchingValue("catchup")
+
+  def MatchingValue(v: String): Value with Matching =  new Val(nextId, v) with Matching
+  def unapply(s: String): Option[Value] = values.find(s == _.toString)
+}
+

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/Parsable.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/Parsable.scala
@@ -1,0 +1,7 @@
+package ch.epfl.pop.model.network
+
+import ch.epfl.pop.model.network.method.message.data.MessageData
+
+trait Parsable {
+  def buildFromJson(messageData: MessageData, payload: String): Any
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Broadcast.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Broadcast.scala
@@ -1,8 +1,16 @@
 package ch.epfl.pop.model.network.method
 
+import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.network.method.message.Message
 import ch.epfl.pop.model.network.method.message.data.MessageData
 
-case class Broadcast(channel: Channel, message: Message) extends ParamsWithMessage {
+case class Broadcast(channel: Channel, message: Message) extends ParamsWithMessage
+
+object Broadcast extends Parsable {
+  def apply(channel: Channel, message: Message): Broadcast = {
+    // FIXME add checks
+    new Broadcast(channel, message)
+  }
+
   override def buildFromJson(messageData: MessageData, payload: String): Broadcast = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Broadcast.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Broadcast.scala
@@ -1,0 +1,8 @@
+package ch.epfl.pop.model.network.method
+
+import ch.epfl.pop.model.network.method.message.Message
+import ch.epfl.pop.model.network.method.message.data.MessageData
+
+case class Broadcast(channel: Channel, message: Message) extends ParamsWithMessage {
+  override def buildFromJson(messageData: MessageData, payload: String): Broadcast = ???
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Catchup.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Catchup.scala
@@ -1,7 +1,15 @@
 package ch.epfl.pop.model.network.method
 
+import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.network.method.message.data.MessageData
 
-case class Catchup(channel: Channel) extends Params {
+case class Catchup(channel: Channel) extends Params
+
+object Catchup extends Parsable {
+  def apply(channel: Channel): Catchup = {
+    // FIXME add checks
+    new Catchup(channel)
+  }
+
   override def buildFromJson(messageData: MessageData, payload: String): Catchup = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Catchup.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Catchup.scala
@@ -1,0 +1,7 @@
+package ch.epfl.pop.model.network.method
+
+import ch.epfl.pop.model.network.method.message.data.MessageData
+
+case class Catchup(channel: Channel) extends ParamsSimple {
+  override def buildFromJson(messageData: MessageData, payload: String): Catchup = ???
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Catchup.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Catchup.scala
@@ -2,6 +2,6 @@ package ch.epfl.pop.model.network.method
 
 import ch.epfl.pop.model.network.method.message.data.MessageData
 
-case class Catchup(channel: Channel) extends ParamsSimple {
+case class Catchup(channel: Channel) extends Params {
   override def buildFromJson(messageData: MessageData, payload: String): Catchup = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Params.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Params.scala
@@ -2,6 +2,6 @@ package ch.epfl.pop.model.network.method
 
 import ch.epfl.pop.model.network.Parsable
 
-trait ParamsSimple extends Parsable {
+trait Params extends Parsable {
   val channel: Channel
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Params.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Params.scala
@@ -1,7 +1,6 @@
 package ch.epfl.pop.model.network.method
 
-import ch.epfl.pop.model.network.Parsable
-
-trait Params extends Parsable {
+trait Params {
   val channel: Channel
+  // Note: Parsable enforced in companion objects
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/ParamsSimple.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/ParamsSimple.scala
@@ -1,0 +1,7 @@
+package ch.epfl.pop.model.network.method
+
+import ch.epfl.pop.model.network.Parsable
+
+trait ParamsSimple extends Parsable {
+  val channel: Channel
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/ParamsWithMessage.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/ParamsWithMessage.scala
@@ -2,6 +2,6 @@ package ch.epfl.pop.model.network.method
 
 import ch.epfl.pop.model.network.method.message.Message
 
-trait ParamsWithMessage extends ParamsSimple {
+trait ParamsWithMessage extends Params {
   val message: Message
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/ParamsWithMessage.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/ParamsWithMessage.scala
@@ -1,0 +1,7 @@
+package ch.epfl.pop.model.network.method
+
+import ch.epfl.pop.model.network.method.message.Message
+
+trait ParamsWithMessage extends ParamsSimple {
+  val message: Message
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Publish.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Publish.scala
@@ -1,8 +1,16 @@
 package ch.epfl.pop.model.network.method
 
+import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.network.method.message.Message
 import ch.epfl.pop.model.network.method.message.data.MessageData
 
-case class Publish(channel: Channel, message: Message) extends ParamsWithMessage {
+case class Publish(channel: Channel, message: Message) extends ParamsWithMessage
+
+object Publish extends Parsable {
+  def apply(channel: Channel, message: Message): Publish = {
+    // FIXME add checks
+    new Publish(channel, message)
+  }
+
   override def buildFromJson(messageData: MessageData, payload: String): Publish = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Publish.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Publish.scala
@@ -1,0 +1,8 @@
+package ch.epfl.pop.model.network.method
+
+import ch.epfl.pop.model.network.method.message.Message
+import ch.epfl.pop.model.network.method.message.data.MessageData
+
+case class Publish(channel: Channel, message: Message) extends ParamsWithMessage {
+  override def buildFromJson(messageData: MessageData, payload: String): Publish = ???
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Subscribe.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Subscribe.scala
@@ -2,6 +2,6 @@ package ch.epfl.pop.model.network.method
 
 import ch.epfl.pop.model.network.method.message.data.MessageData
 
-case class Subscribe(channel: Channel) extends ParamsSimple {
+case class Subscribe(channel: Channel) extends Params {
   override def buildFromJson(messageData: MessageData, payload: String): Subscribe = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Subscribe.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Subscribe.scala
@@ -1,0 +1,7 @@
+package ch.epfl.pop.model.network.method
+
+import ch.epfl.pop.model.network.method.message.data.MessageData
+
+case class Subscribe(channel: Channel) extends ParamsSimple {
+  override def buildFromJson(messageData: MessageData, payload: String): Subscribe = ???
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Subscribe.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Subscribe.scala
@@ -1,7 +1,15 @@
 package ch.epfl.pop.model.network.method
 
+import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.network.method.message.data.MessageData
 
-case class Subscribe(channel: Channel) extends Params {
+case class Subscribe(channel: Channel) extends Params
+
+object Subscribe extends Parsable {
+  def apply(channel: Channel): Subscribe = {
+    // FIXME add checks
+    new Subscribe(channel)
+  }
+
   override def buildFromJson(messageData: MessageData, payload: String): Subscribe = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Unsubscribe.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Unsubscribe.scala
@@ -2,6 +2,6 @@ package ch.epfl.pop.model.network.method
 
 import ch.epfl.pop.model.network.method.message.data.MessageData
 
-case class Unsubscribe(channel: Channel) extends ParamsSimple {
+case class Unsubscribe(channel: Channel) extends Params {
   override def buildFromJson(messageData: MessageData, payload: String): Unsubscribe = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Unsubscribe.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Unsubscribe.scala
@@ -1,0 +1,7 @@
+package ch.epfl.pop.model.network.method
+
+import ch.epfl.pop.model.network.method.message.data.MessageData
+
+case class Unsubscribe(channel: Channel) extends ParamsSimple {
+  override def buildFromJson(messageData: MessageData, payload: String): Unsubscribe = ???
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Unsubscribe.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Unsubscribe.scala
@@ -1,7 +1,15 @@
 package ch.epfl.pop.model.network.method
 
+import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.network.method.message.data.MessageData
 
-case class Unsubscribe(channel: Channel) extends Params {
+case class Unsubscribe(channel: Channel) extends Params
+
+object Unsubscribe extends Parsable {
+  def apply(channel: Channel): Unsubscribe = {
+    // FIXME add checks
+    new Unsubscribe(channel)
+  }
+
   override def buildFromJson(messageData: MessageData, payload: String): Unsubscribe = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/Message.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/Message.scala
@@ -1,6 +1,7 @@
 package ch.epfl.pop.model.network.method.message
 
-import ch.epfl.pop.model.network.method.message.data.{MessageData, Parsable}
+import ch.epfl.pop.model.network.Parsable
+import ch.epfl.pop.model.network.method.message.data.MessageData
 import ch.epfl.pop.model.objects.{Base64Data, Hash, PublicKey, Signature, WitnessSignaturePair}
 
 case class Message(
@@ -24,5 +25,5 @@ object Message extends Parsable {
     new Message(data, sender, signature, message_id, witness_signatures, ???)
   }
 
-  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+  override def buildFromJson(messageData: MessageData, payload: String): Message = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/Message.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/Message.scala
@@ -1,0 +1,28 @@
+package ch.epfl.pop.model.network.method.message
+
+import ch.epfl.pop.model.network.method.message.data.{MessageData, Parsable}
+import ch.epfl.pop.model.objects.{Base64Data, Hash, PublicKey, Signature, WitnessSignaturePair}
+
+case class Message(
+                    data: Base64Data,
+                    sender: PublicKey,
+                    signature: Signature,
+                    message_id: Hash,
+                    witness_signatures: List[WitnessSignaturePair],
+                    decodedData: MessageData
+                  )
+
+object Message extends Parsable {
+  def apply(
+             data: Base64Data,
+             sender: PublicKey,
+             signature: Signature,
+             message_id: Hash,
+             witness_signatures: List[WitnessSignaturePair]
+           ): Message = {
+    // FIXME add checks
+    new Message(data, sender, signature, message_id, witness_signatures, ???)
+  }
+
+  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/ActionType.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/ActionType.scala
@@ -1,5 +1,7 @@
 package ch.epfl.pop.model.network.method.message.data
 
+import ch.epfl.pop.model.network.Matching
+
 object ActionType extends Enumeration {
   type ActionType = Value
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/ActionType.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/ActionType.scala
@@ -1,0 +1,19 @@
+package ch.epfl.pop.model.network.method.message.data
+
+object ActionType extends Enumeration {
+  type ActionType = Value
+
+  // uninitialized placeholder
+  val INVALID: Value = MatchingValue("__INVALID_ACTION__")
+
+  val CREATE: Value = MatchingValue("create")
+  val UPDATE_PROPERTIES: Value = MatchingValue("update_properties")
+  val STATE: Value = MatchingValue("state")
+  val WITNESS: Value = MatchingValue("witness")
+  val OPEN: Value = MatchingValue("open")
+  val REOPEN: Value = MatchingValue("reopen")
+  val CLOSE: Value = MatchingValue("close")
+
+  def MatchingValue(v: String): Value with Matching =  new Val(nextId, v) with Matching
+  def unapply(s: String): Option[Value] = values.find(s == _.toString)
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/DataBuilder.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/DataBuilder.scala
@@ -1,0 +1,42 @@
+package ch.epfl.pop.model.network.method.message.data
+
+import ch.epfl.pop.model.network.method.message.data.lao.{CreateLao, StateLao, UpdateLao}
+import ch.epfl.pop.model.network.method.message.data.meeting.{CreateMeeting, StateMeeting}
+import ch.epfl.pop.model.network.method.message.data.rollCall.{CloseRollCall, CreateRollCall, OpenRollCall, ReopenRollCall}
+import ch.epfl.pop.model.network.method.message.data.witness.WitnessMessage
+
+object DataBuilder {
+  def buildData(messageData: MessageData, payload: String): Any = messageData._object match {
+    case ObjectType.LAO => buildLaoData(messageData, payload)
+    case ObjectType.MEETING => buildMeetingData(messageData, payload)
+    case ObjectType.ROLL_CALL => buildRollCallData(messageData, payload)
+    case ObjectType.MESSAGE => buildWitnessData(messageData, payload)
+    case _ => throw new ProtocolException(s"Unknown object '${messageData._object}' encountered while creating a Data")
+  }
+
+  def buildLaoData(messageData: MessageData, payload: String): Any = messageData.action match {
+    case ActionType.CREATE => CreateLao.buildFromJson(messageData, payload)
+    case ActionType.STATE => StateLao.buildFromJson(messageData, payload)
+    case ActionType.UPDATE_PROPERTIES => UpdateLao.buildFromJson(messageData, payload)
+    case _ => throw new ProtocolException(s"Unknown action '${messageData.action}' encountered while creating a Lao Data")
+  }
+
+  def buildMeetingData(messageData: MessageData, payload: String): Any = messageData.action match {
+    case ActionType.CREATE => CreateMeeting.buildFromJson(messageData, payload)
+    case ActionType.STATE => StateMeeting.buildFromJson(messageData, payload)
+    case _ => throw new ProtocolException(s"Unknown action '${messageData.action}' encountered while creating a Meeting Data")
+  }
+
+  def buildRollCallData(messageData: MessageData, payload: String): Any = messageData.action match {
+    case ActionType.CREATE => CreateRollCall.buildFromJson(messageData, payload)
+    case ActionType.OPEN => OpenRollCall.buildFromJson(messageData, payload)
+    case ActionType.REOPEN => ReopenRollCall.buildFromJson(messageData, payload)
+    case ActionType.CLOSE => CloseRollCall.buildFromJson(messageData, payload)
+    case _ => throw new ProtocolException(s"Unknown action '${messageData.action}' encountered while creating a RollCall Data")
+  }
+
+  def buildWitnessData(messageData: MessageData, payload: String): Any = messageData.action match {
+    case ActionType.WITNESS => WitnessMessage.buildFromJson(messageData, payload)
+    case _ => throw new ProtocolException(s"Unknown action '${messageData.action}' encountered while creating a Witness Data")
+  }
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/Matching.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/Matching.scala
@@ -1,0 +1,6 @@
+package ch.epfl.pop.model.network.method.message.data
+
+sealed trait Matching {
+  // See https://stackoverflow.com/questions/3407032/comparing-string-and-enumeration
+  def unapply(s: String): Boolean = s == toString
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/MessageData.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/MessageData.scala
@@ -1,0 +1,6 @@
+package ch.epfl.pop.model.network.method.message.data
+
+trait MessageData {
+  val _object: ObjectType.ObjectType
+  val action: ActionType.ActionType
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/ObjectType.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/ObjectType.scala
@@ -1,5 +1,7 @@
 package ch.epfl.pop.model.network.method.message.data
 
+import ch.epfl.pop.model.network.Matching
+
 object ObjectType extends Enumeration {
   type ObjectType = Value
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/ObjectType.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/ObjectType.scala
@@ -1,0 +1,17 @@
+package ch.epfl.pop.model.network.method.message.data
+
+object ObjectType extends Enumeration {
+  type ObjectType = Value
+
+  // uninitialized placeholder
+  val INVALID: Value = MatchingValue("__INVALID_OBJECT__")
+
+  val LAO: Value with Matching = MatchingValue("lao")
+  val MESSAGE: Value with Matching = MatchingValue("message")
+  val MEETING: Value with Matching = MatchingValue("meeting")
+  val ROLL_CALL: Value with Matching = MatchingValue("roll_call")
+
+  def MatchingValue(v: String): Value with Matching = new Val(nextId, v) with Matching
+  def unapply(s: String): Option[Value] = values.find(s == _.toString)
+}
+

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/Parsable.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/Parsable.scala
@@ -1,0 +1,5 @@
+package ch.epfl.pop.model.network.method.message.data
+
+trait Parsable {
+  def buildFromJson(messageData: MessageData, payload: String): Any
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/Parsable.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/Parsable.scala
@@ -1,5 +1,0 @@
-package ch.epfl.pop.model.network.method.message.data
-
-trait Parsable {
-  def buildFromJson(messageData: MessageData, payload: String): Any
-}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/ProtocolException.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/ProtocolException.scala
@@ -1,0 +1,17 @@
+package ch.epfl.pop.model.network.method.message.data
+
+class ProtocolException(message: String) extends Exception(message) {
+
+  def this(message: String, cause: Throwable) {
+    this(message)
+    initCause(cause)
+  }
+
+  def this(cause: Throwable) {
+    this(Option(cause).map(_.toString).orNull, cause)
+  }
+
+  def this() {
+    this(null: String)
+  }
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/CreateLao.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/CreateLao.scala
@@ -5,7 +5,13 @@ import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
 import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
 import ch.epfl.pop.model.objects.{Hash, PublicKey, Timestamp}
 
-case class CreateLao(id: Hash, name: String, creation: Timestamp, organizer: PublicKey, witnesses: List[PublicKey]) extends MessageData {
+case class CreateLao(
+                      id: Hash,
+                      name: String,
+                      creation: Timestamp,
+                      organizer: PublicKey,
+                      witnesses: List[PublicKey]
+                    ) extends MessageData {
   override val _object: ObjectType = ObjectType.LAO
   override val action: ActionType = ActionType.CREATE
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/CreateLao.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/CreateLao.scala
@@ -1,8 +1,9 @@
 package ch.epfl.pop.model.network.method.message.data.lao
 
+import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
 import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
-import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType}
 import ch.epfl.pop.model.objects.{Hash, PublicKey, Timestamp}
 
 case class CreateLao(

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/CreateLao.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/CreateLao.scala
@@ -1,11 +1,13 @@
 package ch.epfl.pop.model.network.method.message.data.lao
 
+import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
+import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
 import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
 import ch.epfl.pop.model.objects.{Hash, PublicKey, Timestamp}
 
-case class CreateLao(id: Hash, name: String, creation: Timestamp, organizer: PublicKey, witnesses: List[PublicKey]) {
-  private final val _object = ObjectType.LAO
-  private final val action = ActionType.CREATE
+case class CreateLao(id: Hash, name: String, creation: Timestamp, organizer: PublicKey, witnesses: List[PublicKey]) extends MessageData {
+  override val _object: ObjectType = ObjectType.LAO
+  override val action: ActionType = ActionType.CREATE
 }
 
 object CreateLao extends Parsable {
@@ -14,5 +16,5 @@ object CreateLao extends Parsable {
     new CreateLao(id, name, creation, organizer, witnesses)
   }
 
-  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+  override def buildFromJson(messageData: MessageData, payload: String): CreateLao = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/CreateLao.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/CreateLao.scala
@@ -1,0 +1,18 @@
+package ch.epfl.pop.model.network.method.message.data.lao
+
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.objects.{Hash, PublicKey, Timestamp}
+
+case class CreateLao(id: Hash, name: String, creation: Timestamp, organizer: PublicKey, witnesses: List[PublicKey]) {
+  private final val _object = ObjectType.LAO
+  private final val action = ActionType.CREATE
+}
+
+object CreateLao extends Parsable {
+  def apply(id: Hash, name: String, creation: Timestamp, organizer: PublicKey, witnesses: List[PublicKey]): CreateLao = {
+    // FIXME add checks
+    new CreateLao(id, name, creation, organizer, witnesses)
+  }
+
+  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/StateLao.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/StateLao.scala
@@ -1,8 +1,9 @@
 package ch.epfl.pop.model.network.method.message.data.lao
 
+import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
 import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
-import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType}
 import ch.epfl.pop.model.objects.{Hash, PublicKey, Timestamp, WitnessSignaturePair}
 
 case class StateLao(

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/StateLao.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/StateLao.scala
@@ -1,5 +1,7 @@
 package ch.epfl.pop.model.network.method.message.data.lao
 
+import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
+import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
 import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
 import ch.epfl.pop.model.objects.{Hash, PublicKey, Timestamp, WitnessSignaturePair}
 
@@ -12,9 +14,9 @@ case class StateLao(
                      witnesses: List[PublicKey],
                      modification_id: Hash,
                      modification_signatures: List[WitnessSignaturePair]
-                   ) {
-  private final val _object = ObjectType.LAO
-  private final val action = ActionType.STATE
+                   ) extends MessageData {
+  override val _object: ObjectType = ObjectType.LAO
+  override val action: ActionType = ActionType.STATE
 }
 
 object StateLao extends Parsable {
@@ -32,5 +34,5 @@ object StateLao extends Parsable {
     new StateLao(id, name, creation, last_modified, organizer, witnesses, modification_id, modification_signatures)
   }
 
-  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+  override def buildFromJson(messageData: MessageData, payload: String): StateLao = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/StateLao.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/StateLao.scala
@@ -1,0 +1,36 @@
+package ch.epfl.pop.model.network.method.message.data.lao
+
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.objects.{Hash, PublicKey, Timestamp, WitnessSignaturePair}
+
+case class StateLao(
+                     id: Hash,
+                     name: String,
+                     creation: Timestamp,
+                     last_modified: Timestamp,
+                     organizer: PublicKey,
+                     witnesses: List[PublicKey],
+                     modification_id: Hash,
+                     modification_signatures: List[WitnessSignaturePair]
+                   ) {
+  private final val _object = ObjectType.LAO
+  private final val action = ActionType.STATE
+}
+
+object StateLao extends Parsable {
+  def apply(
+             id: Hash,
+             name: String,
+             creation: Timestamp,
+             last_modified: Timestamp,
+             organizer: PublicKey,
+             witnesses: List[PublicKey],
+             modification_id: Hash,
+             modification_signatures: List[WitnessSignaturePair]
+           ): StateLao = {
+    // FIXME add checks
+    new StateLao(id, name, creation, last_modified, organizer, witnesses, modification_id, modification_signatures)
+  }
+
+  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/UpdateLao.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/UpdateLao.scala
@@ -1,11 +1,13 @@
 package ch.epfl.pop.model.network.method.message.data.lao
 
+import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
+import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
 import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
 import ch.epfl.pop.model.objects.{Hash, PublicKey, Timestamp}
 
-case class UpdateLao(id: Hash, name: String, last_modified: Timestamp, witnesses: List[PublicKey]) {
-  private final val _object = ObjectType.LAO
-  private final val action = ActionType.UPDATE_PROPERTIES
+case class UpdateLao(id: Hash, name: String, last_modified: Timestamp, witnesses: List[PublicKey]) extends MessageData {
+  override val _object: ObjectType = ObjectType.LAO
+  override val action: ActionType = ActionType.UPDATE_PROPERTIES
 }
 
 object UpdateLao extends Parsable {
@@ -14,5 +16,5 @@ object UpdateLao extends Parsable {
     new UpdateLao(id, name, last_modified, witnesses)
   }
 
-  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+  override def buildFromJson(messageData: MessageData, payload: String): UpdateLao = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/UpdateLao.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/UpdateLao.scala
@@ -1,8 +1,9 @@
 package ch.epfl.pop.model.network.method.message.data.lao
 
+import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
 import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
-import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType}
 import ch.epfl.pop.model.objects.{Hash, PublicKey, Timestamp}
 
 case class UpdateLao(id: Hash, name: String, last_modified: Timestamp, witnesses: List[PublicKey]) extends MessageData {

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/UpdateLao.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/lao/UpdateLao.scala
@@ -1,0 +1,18 @@
+package ch.epfl.pop.model.network.method.message.data.lao
+
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.objects.{Hash, PublicKey, Timestamp}
+
+case class UpdateLao(id: Hash, name: String, last_modified: Timestamp, witnesses: List[PublicKey]) {
+  private final val _object = ObjectType.LAO
+  private final val action = ActionType.UPDATE_PROPERTIES
+}
+
+object UpdateLao extends Parsable {
+  def apply(id: Hash, name: String, last_modified: Timestamp, witnesses: List[PublicKey]): UpdateLao = {
+    // FIXME add checks
+    new UpdateLao(id, name, last_modified, witnesses)
+  }
+
+  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/meeting/CreateMeeting.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/meeting/CreateMeeting.scala
@@ -1,5 +1,7 @@
 package ch.epfl.pop.model.network.method.message.data.meeting
 
+import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
+import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
 import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
 import ch.epfl.pop.model.objects.{Hash, Timestamp}
 
@@ -11,9 +13,9 @@ case class CreateMeeting(
                           start: Timestamp,
                           end: Option[Timestamp],
                           extra: Option[Any]
-                        ) {
-  private final val _object = ObjectType.MEETING
-  private final val action = ActionType.CREATE
+                        ) extends MessageData {
+  override val _object: ObjectType = ObjectType.MEETING
+  override val action: ActionType = ActionType.CREATE
 }
 
 object CreateMeeting extends Parsable {
@@ -30,5 +32,5 @@ object CreateMeeting extends Parsable {
     new CreateMeeting(id, name, creation, location, start, end, extra)
   }
 
-  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+  override def buildFromJson(messageData: MessageData, payload: String): CreateMeeting = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/meeting/CreateMeeting.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/meeting/CreateMeeting.scala
@@ -1,0 +1,34 @@
+package ch.epfl.pop.model.network.method.message.data.meeting
+
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.objects.{Hash, Timestamp}
+
+case class CreateMeeting(
+                          id: Hash,
+                          name: String,
+                          creation: Timestamp,
+                          location: Option[String],
+                          start: Timestamp,
+                          end: Option[Timestamp],
+                          extra: Option[Any]
+                        ) {
+  private final val _object = ObjectType.MEETING
+  private final val action = ActionType.CREATE
+}
+
+object CreateMeeting extends Parsable {
+  def apply(
+             id: Hash,
+             name: String,
+             creation: Timestamp,
+             location: Option[String],
+             start: Timestamp,
+             end: Option[Timestamp],
+             extra: Option[Any]
+           ): CreateMeeting = {
+    // FIXME add checks
+    new CreateMeeting(id, name, creation, location, start, end, extra)
+  }
+
+  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/meeting/CreateMeeting.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/meeting/CreateMeeting.scala
@@ -1,8 +1,9 @@
 package ch.epfl.pop.model.network.method.message.data.meeting
 
+import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
 import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
-import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType}
 import ch.epfl.pop.model.objects.{Hash, Timestamp}
 
 case class CreateMeeting(

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/meeting/StateMeeting.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/meeting/StateMeeting.scala
@@ -1,8 +1,9 @@
 package ch.epfl.pop.model.network.method.message.data.meeting
 
+import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
 import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
-import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType}
 import ch.epfl.pop.model.objects.{Hash, Timestamp, WitnessSignaturePair}
 
 case class StateMeeting(

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/meeting/StateMeeting.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/meeting/StateMeeting.scala
@@ -1,0 +1,40 @@
+package ch.epfl.pop.model.network.method.message.data.meeting
+
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.objects.{Hash, Timestamp, WitnessSignaturePair}
+
+case class StateMeeting(
+                         id: Hash,
+                         name: String,
+                         creation: Timestamp,
+                         last_modified: Timestamp,
+                         location: Option[String],
+                         start: Timestamp,
+                         end: Option[Timestamp],
+                         extra: Option[Any],
+                         modification_id: Hash,
+                         modification_signatures: List[WitnessSignaturePair]
+                       ) {
+  private final val _object = ObjectType.MEETING
+  private final val action = ActionType.STATE
+}
+
+object StateMeeting extends Parsable {
+  def apply(
+             id: Hash,
+             name: String,
+             creation: Timestamp,
+             last_modified: Timestamp,
+             location: Option[String],
+             start: Timestamp,
+             end: Option[Timestamp],
+             extra: Option[Any],
+             modification_id: Hash,
+             modification_signatures: List[WitnessSignaturePair]
+           ): StateMeeting = {
+    // FIXME add checks
+    new StateMeeting(id, name, creation, last_modified, location, start, end, extra, modification_id, modification_signatures)
+  }
+
+  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/meeting/StateMeeting.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/meeting/StateMeeting.scala
@@ -1,5 +1,7 @@
 package ch.epfl.pop.model.network.method.message.data.meeting
 
+import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
+import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
 import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
 import ch.epfl.pop.model.objects.{Hash, Timestamp, WitnessSignaturePair}
 
@@ -14,9 +16,9 @@ case class StateMeeting(
                          extra: Option[Any],
                          modification_id: Hash,
                          modification_signatures: List[WitnessSignaturePair]
-                       ) {
-  private final val _object = ObjectType.MEETING
-  private final val action = ActionType.STATE
+                       ) extends MessageData {
+  override val _object: ObjectType = ObjectType.MEETING
+  override val action: ActionType = ActionType.STATE
 }
 
 object StateMeeting extends Parsable {
@@ -36,5 +38,5 @@ object StateMeeting extends Parsable {
     new StateMeeting(id, name, creation, last_modified, location, start, end, extra, modification_id, modification_signatures)
   }
 
-  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+  override def buildFromJson(messageData: MessageData, payload: String): StateMeeting = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/CloseRollCall.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/CloseRollCall.scala
@@ -1,0 +1,31 @@
+package ch.epfl.pop.model.network.method.message.data.rollCall
+
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.objects.{Hash, PublicKey, Timestamp}
+
+case class CloseRollCall(
+                           update_id: Hash,
+                           closes: Hash,
+                           end: Timestamp,
+                           attendees: List[PublicKey]
+                         ) {
+  private final val _object = ObjectType.ROLL_CALL
+  private final val action = ActionType.CLOSE
+}
+
+object CloseRollCall extends Parsable {
+  def apply(
+             update_id: Hash,
+             closes: Hash,
+             end: Timestamp,
+             attendees: List[PublicKey]
+           ): CloseRollCall = {
+    // FIXME add checks
+    new CloseRollCall(update_id, closes, end, attendees)
+  }
+
+  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+}
+
+
+

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/CloseRollCall.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/CloseRollCall.scala
@@ -1,8 +1,9 @@
 package ch.epfl.pop.model.network.method.message.data.rollCall
 
+import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
 import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
-import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType}
 import ch.epfl.pop.model.objects.{Hash, PublicKey, Timestamp}
 
 case class CloseRollCall(

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/CloseRollCall.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/CloseRollCall.scala
@@ -1,5 +1,7 @@
 package ch.epfl.pop.model.network.method.message.data.rollCall
 
+import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
+import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
 import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
 import ch.epfl.pop.model.objects.{Hash, PublicKey, Timestamp}
 
@@ -8,9 +10,9 @@ case class CloseRollCall(
                            closes: Hash,
                            end: Timestamp,
                            attendees: List[PublicKey]
-                         ) {
-  private final val _object = ObjectType.ROLL_CALL
-  private final val action = ActionType.CLOSE
+                         ) extends MessageData {
+  override val _object: ObjectType = ObjectType.ROLL_CALL
+  override val action: ActionType = ActionType.CLOSE
 }
 
 object CloseRollCall extends Parsable {
@@ -24,7 +26,7 @@ object CloseRollCall extends Parsable {
     new CloseRollCall(update_id, closes, end, attendees)
   }
 
-  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+  override def buildFromJson(messageData: MessageData, payload: String): CloseRollCall = ???
 }
 
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/CreateRollCall.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/CreateRollCall.scala
@@ -1,8 +1,9 @@
 package ch.epfl.pop.model.network.method.message.data.rollCall
 
+import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
 import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
-import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType}
 import ch.epfl.pop.model.objects.{Hash, Timestamp}
 
 case class CreateRollCall(

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/CreateRollCall.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/CreateRollCall.scala
@@ -1,5 +1,7 @@
 package ch.epfl.pop.model.network.method.message.data.rollCall
 
+import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
+import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
 import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
 import ch.epfl.pop.model.objects.{Hash, Timestamp}
 
@@ -11,9 +13,9 @@ case class CreateRollCall(
                           scheduled: Option[Timestamp],
                           location: String,
                           roll_call_description: Option[String]
-                        ) {
-  private final val _object = ObjectType.ROLL_CALL
-  private final val action = ActionType.CREATE
+                        ) extends MessageData {
+  override val _object: ObjectType = ObjectType.ROLL_CALL
+  override val action: ActionType = ActionType.CREATE
 }
 
 object CreateRollCall extends Parsable {
@@ -30,5 +32,5 @@ object CreateRollCall extends Parsable {
     new CreateRollCall(id, name, creation, start, scheduled, location, roll_call_description)
   }
 
-  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+  override def buildFromJson(messageData: MessageData, payload: String): CreateRollCall = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/CreateRollCall.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/CreateRollCall.scala
@@ -1,0 +1,34 @@
+package ch.epfl.pop.model.network.method.message.data.rollCall
+
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.objects.{Hash, Timestamp}
+
+case class CreateRollCall(
+                          id: Hash,
+                          name: String,
+                          creation: Timestamp,
+                          start: Option[Timestamp],
+                          scheduled: Option[Timestamp],
+                          location: String,
+                          roll_call_description: Option[String]
+                        ) {
+  private final val _object = ObjectType.ROLL_CALL
+  private final val action = ActionType.CREATE
+}
+
+object CreateRollCall extends Parsable {
+  def apply(
+             id: Hash,
+             name: String,
+             creation: Timestamp,
+             start: Option[Timestamp],
+             scheduled: Option[Timestamp],
+             location: String,
+             roll_call_description: Option[String]
+           ): CreateRollCall = {
+    // FIXME add checks
+    new CreateRollCall(id, name, creation, start, scheduled, location, roll_call_description)
+  }
+
+  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/OpenRollCall.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/OpenRollCall.scala
@@ -1,8 +1,9 @@
 package ch.epfl.pop.model.network.method.message.data.rollCall
 
+import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
 import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
-import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType}
 import ch.epfl.pop.model.objects.{Hash, Timestamp}
 
 case class OpenRollCall(

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/OpenRollCall.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/OpenRollCall.scala
@@ -1,0 +1,26 @@
+package ch.epfl.pop.model.network.method.message.data.rollCall
+
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.objects.{Hash, Timestamp}
+
+case class OpenRollCall(
+                         update_id: Hash,
+                         opens: Hash,
+                         start: Timestamp
+                       ) {
+  private final val _object = ObjectType.ROLL_CALL
+  private final val action = ActionType.OPEN
+}
+
+object OpenRollCall extends Parsable {
+  def apply(
+             update_id: Hash,
+             opens: Hash,
+             start: Timestamp
+           ): OpenRollCall = {
+    // FIXME add checks
+    new OpenRollCall(update_id, opens, start)
+  }
+
+  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/OpenRollCall.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/OpenRollCall.scala
@@ -1,5 +1,7 @@
 package ch.epfl.pop.model.network.method.message.data.rollCall
 
+import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
+import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
 import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
 import ch.epfl.pop.model.objects.{Hash, Timestamp}
 
@@ -7,9 +9,9 @@ case class OpenRollCall(
                          update_id: Hash,
                          opens: Hash,
                          start: Timestamp
-                       ) {
-  private final val _object = ObjectType.ROLL_CALL
-  private final val action = ActionType.OPEN
+                       ) extends MessageData {
+  override val _object: ObjectType = ObjectType.ROLL_CALL
+  override val action: ActionType = ActionType.OPEN
 }
 
 object OpenRollCall extends Parsable {
@@ -22,5 +24,5 @@ object OpenRollCall extends Parsable {
     new OpenRollCall(update_id, opens, start)
   }
 
-  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+  override def buildFromJson(messageData: MessageData, payload: String): OpenRollCall = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/ReopenRollCall.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/ReopenRollCall.scala
@@ -1,0 +1,27 @@
+package ch.epfl.pop.model.network.method.message.data.rollCall
+
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.objects.{Hash, Timestamp}
+
+case class ReopenRollCall(
+                           update_id: Hash,
+                           opens: Hash,
+                           start: Timestamp
+                         ) {
+  private final val _object = ObjectType.ROLL_CALL
+  private final val action = ActionType.REOPEN
+}
+
+object ReopenRollCall extends Parsable {
+  def apply(
+             update_id: Hash,
+             opens: Hash,
+             start: Timestamp
+           ): ReopenRollCall = {
+    // FIXME add checks
+    new ReopenRollCall(update_id, opens, start)
+  }
+
+  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+}
+

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/ReopenRollCall.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/ReopenRollCall.scala
@@ -1,5 +1,7 @@
 package ch.epfl.pop.model.network.method.message.data.rollCall
 
+import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
+import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
 import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
 import ch.epfl.pop.model.objects.{Hash, Timestamp}
 
@@ -7,9 +9,9 @@ case class ReopenRollCall(
                            update_id: Hash,
                            opens: Hash,
                            start: Timestamp
-                         ) {
-  private final val _object = ObjectType.ROLL_CALL
-  private final val action = ActionType.REOPEN
+                         ) extends MessageData {
+  override val _object: ObjectType = ObjectType.ROLL_CALL
+  override val action: ActionType = ActionType.REOPEN
 }
 
 object ReopenRollCall extends Parsable {
@@ -22,6 +24,6 @@ object ReopenRollCall extends Parsable {
     new ReopenRollCall(update_id, opens, start)
   }
 
-  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+  override def buildFromJson(messageData: MessageData, payload: String): ReopenRollCall = ???
 }
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/ReopenRollCall.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/rollCall/ReopenRollCall.scala
@@ -1,8 +1,9 @@
 package ch.epfl.pop.model.network.method.message.data.rollCall
 
+import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
 import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
-import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType}
 import ch.epfl.pop.model.objects.{Hash, Timestamp}
 
 case class ReopenRollCall(

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/witness/WitnessMessage.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/witness/WitnessMessage.scala
@@ -1,8 +1,9 @@
 package ch.epfl.pop.model.network.method.message.data.witness
 
+import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
 import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
-import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType}
 import ch.epfl.pop.model.objects.{Hash, Signature}
 
 case class WitnessMessage(

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/witness/WitnessMessage.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/witness/WitnessMessage.scala
@@ -1,0 +1,24 @@
+package ch.epfl.pop.model.network.method.message.data.witness
+
+import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
+import ch.epfl.pop.model.objects.{Hash, Signature}
+
+case class WitnessMessage(
+                           message_id: Hash,
+                           signature: Signature,
+                         ) {
+  private final val _object = ObjectType.MESSAGE
+  private final val action = ActionType.WITNESS
+}
+
+object WitnessMessage extends Parsable {
+  def apply(
+             message_id: Hash,
+             signature: Signature,
+           ): WitnessMessage = {
+    // FIXME add checks
+    new WitnessMessage(message_id, signature)
+  }
+
+  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/witness/WitnessMessage.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/message/data/witness/WitnessMessage.scala
@@ -1,14 +1,16 @@
 package ch.epfl.pop.model.network.method.message.data.witness
 
+import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
+import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
 import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType, Parsable}
 import ch.epfl.pop.model.objects.{Hash, Signature}
 
 case class WitnessMessage(
                            message_id: Hash,
                            signature: Signature,
-                         ) {
-  private final val _object = ObjectType.MESSAGE
-  private final val action = ActionType.WITNESS
+                         ) extends MessageData {
+  override val _object: ObjectType = ObjectType.MESSAGE
+  override val action: ActionType = ActionType.WITNESS
 }
 
 object WitnessMessage extends Parsable {
@@ -20,5 +22,5 @@ object WitnessMessage extends Parsable {
     new WitnessMessage(message_id, signature)
   }
 
-  override def buildFromJson(messageData: MessageData, payload: String): Any = ???
+  override def buildFromJson(messageData: MessageData, payload: String): WitnessMessage = ???
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/package.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/package.scala
@@ -1,0 +1,5 @@
+package ch.epfl.pop.model.network
+
+package object method {
+  type Channel = String
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Base64Data.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Base64Data.scala
@@ -1,0 +1,3 @@
+package ch.epfl.pop.model.objects
+
+case class Base64Data(data: String)

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Hash.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Hash.scala
@@ -1,0 +1,3 @@
+package ch.epfl.pop.model.objects
+
+case class Hash(base64Data: Base64Data)

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/objects/PublicKey.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/objects/PublicKey.scala
@@ -1,0 +1,3 @@
+package ch.epfl.pop.model.objects
+
+case class PublicKey(base64Data: Base64Data)

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Signature.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Signature.scala
@@ -1,0 +1,5 @@
+package ch.epfl.pop.model.objects
+
+case class Signature(signature: Base64Data) {
+  def verify(key: PublicKey, message: Base64Data): Boolean = true // FIXME implement verify
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Timestamp.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Timestamp.scala
@@ -1,0 +1,3 @@
+package ch.epfl.pop.model.objects
+
+case class Timestamp(time: Long)

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/objects/WitnessSignaturePair.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/objects/WitnessSignaturePair.scala
@@ -1,0 +1,5 @@
+package ch.epfl.pop.model.objects
+
+case class WitnessSignaturePair(witness: PublicKey, signature: Signature) {
+  def verify(messageId: Hash): Boolean = signature.verify(witness, messageId.asInstanceOf[Base64Data])
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/ChannelActor.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/ChannelActor.scala
@@ -1,0 +1,109 @@
+package ch.epfl.pop.pubsub
+
+import akka.NotUsed
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorRef, ActorSystem, Behavior}
+import akka.stream.scaladsl.{BroadcastHub, Keep, MergeHub, Sink, Source}
+import akka.stream.{KillSwitches, UniqueKillSwitch}
+import ch.epfl.pop.json.JsonMessages.{AnswerErrorMessageServer, AnswerResultIntMessageServer, JsonMessageAnswerServer, PropagateMessageServer}
+import ch.epfl.pop.json.MessageErrorContent
+
+/**
+ * The role of the ChannelActor is to handle the creation of channels and subscribe requests of clients.
+ */
+object ChannelActor {
+
+  /**
+   * Requests to the ChannelActor
+   */
+  sealed trait ChannelMessage
+
+  /**
+   * Request to create a channel
+   * @param channel the channel name
+   * @param replyTo the actor to reply to once the creation is done
+   */
+  final case class CreateMessage(channel: String, replyTo: ActorRef[Boolean]) extends ChannelMessage
+
+  /**
+   * Request to subscribe to a channel
+   * @param channel the channel to subscribe
+   * @param out the entry of the client stream
+   * @param id the id of the request
+   * @param replyTo the actor to reply to once the subscription is done
+   */
+  final case class SubscribeMessage(channel: String, out: Sink[PropagateMessageServer, NotUsed], id: Int, replyTo: ActorRef[ChannelActorAnswer])
+    extends ChannelMessage
+
+
+  /**
+   * An answer from a ChannelActor to a request
+   */
+  sealed trait ChannelActorAnswer
+
+  /**
+   * An answer from a ChannelActor to a subscribe request
+   * @param jsonMessage the answer to send to the client
+   * @param channel the name of the channel the client requested to subscribe to
+   * @param killSwitch a killSwitch used to disconnect the stream when the client request to unsubscribe to a channel
+   */
+  final case class AnswerSubscribe(jsonMessage: JsonMessageAnswerServer, channel : String, killSwitch: Option[UniqueKillSwitch]) extends ChannelActorAnswer with UnsubMessage
+
+
+  /**
+   * Create an actor handling channel creation and subscription
+   *
+   * @param publishExit a source emitting all published messages
+   * @return an actor handling channel creation and subscription
+   */
+
+  def apply(publishExit: Source[PropagateMessageServer, NotUsed])(implicit system :ActorSystem[Nothing]): Behavior[ChannelMessage] = {
+    //Setup root channel
+    val root = "/root"
+    val (entry, exit) = MergeHub.source[PropagateMessageServer].toMat(BroadcastHub.sink)(Keep.both).run()
+    publishExit.filter(_.params.channel == root).runWith(entry)
+
+    channelHandler(Map(root -> exit), publishExit)
+  }
+
+
+  private def channelHandler(channelsOutputs: Map[String, Source[PropagateMessageServer, NotUsed]],
+                             publishExit: Source[PropagateMessageServer, NotUsed]): Behavior[ChannelMessage] = {
+    Behaviors.receive { (ctx, message) =>
+      implicit val system: ActorSystem[Nothing] = ctx.system
+      message match {
+        case CreateMessage(channel,  replyTo) =>
+          if (!channelsOutputs.contains(channel)) {
+            ctx.log.debug("creating channel: " + channel)
+            val (entry, exit) = MergeHub.source[PropagateMessageServer].toMat(BroadcastHub.sink)(Keep.both).run()
+
+            publishExit.filter(_.params.channel == channel).runWith(entry)
+            ctx.log.debug("New channel map: " + (channelsOutputs + (channel -> exit)).toString())
+            replyTo ! true
+            channelHandler(channelsOutputs + (channel -> exit), publishExit)
+
+          }
+          else {
+            replyTo ! false
+            Behaviors.same
+          }
+
+        case SubscribeMessage(channel, out, id, replyTo) =>
+          if (channelsOutputs.contains(channel)) {
+            val channelSource = channelsOutputs(channel)
+            val killSwitch = channelSource
+              .viaMat(KillSwitches.single)(Keep.right)
+              .toMat(out)(Keep.left)
+              .run()
+            replyTo ! AnswerSubscribe(AnswerResultIntMessageServer(id = id), channel, Some(killSwitch))
+          }
+          else {
+            ctx.log.debug(channelsOutputs.toString())
+            val error = MessageErrorContent(-2, "Invalid resource: channel " + channel + " does not exist.")
+            replyTo ! AnswerSubscribe(AnswerErrorMessageServer(error = error, id = Some(id)), channel, None)
+          }
+          Behaviors.same
+      }
+    }
+  }
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/PublishSubscribe.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/PublishSubscribe.scala
@@ -1,0 +1,312 @@
+package ch.epfl.pop.pubsub
+
+import java.util.Base64
+
+import akka.NotUsed
+import akka.actor.typed.scaladsl.AskPattern.{Askable, schedulerFromActorSystem}
+import akka.actor.typed.{ActorRef, ActorSystem}
+import akka.http.scaladsl.model.ws.{Message, TextMessage}
+import akka.stream.scaladsl.{BroadcastHub, Flow, GraphDSL, Keep, Merge, MergeHub, Partition, Sink, Source}
+import akka.stream.typed.scaladsl.ActorFlow
+import akka.stream.{FlowShape, UniformFanInShape, UniqueKillSwitch}
+import akka.util.Timeout
+import ch.epfl.pop.{DBActor, Validate}
+import ch.epfl.pop.DBActor.{DBMessage, Read, Write}
+import ch.epfl.pop.json.JsonMessageParser.{parseMessage, serializeMessage}
+import ch.epfl.pop.json.JsonMessages.{JsonMessagePublishClient, _}
+import ch.epfl.pop.json.JsonUtils.ErrorCodes.InvalidData
+import ch.epfl.pop.json.JsonUtils.{ErrorCodes, JsonMessageParserError}
+import ch.epfl.pop.json.{KeySignPair, MessageContent, MessageContentData, MessageErrorContent, MessageParameters}
+import ch.epfl.pop.pubsub.ChannelActor._
+import java.util
+
+import scala.concurrent.{Await, Future}
+
+
+
+object PublishSubscribe {
+  /**
+   * Create a flow handling parsed JSON messages of a publish-subscribe system.
+   *
+   * @param channelActor    an actor handling channel creation and subscription
+   * @param dbActor an actor handling requests related to the database
+   *
+   * '''Implicit parameters:'''
+   * @param timeout how long should a stream wait for an answer from an actor
+   * @param system the ActorSystem needed to create streams
+   * @param pubEntry a sink where all published messages should be sent
+   * @return a flow handling parsed JSON messages of a publish-subscribe system
+   */
+  def jsonFlow(channelActor: ActorRef[ChannelMessage],
+               dbActor : ActorRef[DBMessage])
+              (implicit timeout: Timeout,
+               system: ActorSystem[Nothing], pubEntry: Sink[PropagateMessageServer, NotUsed]): Flow[JsonMessagePubSubClient, JsonMessageAnswerServer, NotUsed] = {
+
+    val (userSink, userSource) = MergeHub.source[PropagateMessageServer].toMat(BroadcastHub.sink)(Keep.both).run()
+
+    Flow.fromGraph(GraphDSL.create() { implicit builder =>
+      import GraphDSL.Implicits._
+
+      //Initialize Inlet/Outlets
+      val input = builder.add(Flow[JsonMessagePubSubClient])
+      val merge = builder.add(Merge[JsonMessageAnswerServer](4))
+      val output = builder.add(Flow[JsonMessageAnswerServer])
+
+      val Subscribe = 0
+      val Unsubscribe = 3
+      val Publish = 1
+      val Catchup = 2
+      val partitioner = builder.add(Partition[JsonMessagePubSubClient](4,
+        {
+          _ match {
+            case _ : SubscribeMessageClient => Subscribe
+            case _ : UnsubscribeMessageClient => Unsubscribe
+            case m : JsonMessagePublishClient => Publish
+            case _ : CatchupMessageClient => Catchup
+          }
+        }
+      ))
+
+      //ActorFlow handling channel subscription
+      val actorFlow = ActorFlow.ask[JsonMessage, ChannelMessage, ChannelActorAnswer](channelActor) {
+        (message, replyTo) =>
+          message match {
+            case SubscribeMessageClient(params, id, _, _) => SubscribeMessage(params.channel, userSink, id, replyTo)
+          }
+      }
+
+      val unsub = builder.add(unsubHandler())
+      val unsubMap = Flow[JsonMessage].map{case UnsubscribeMessageClient(params, id, _, _) => UnsubRequest(params.channel, id)}
+      val unsubMap2 = Flow[ChannelActorAnswer].map{case a: AnswerSubscribe => a}
+      val publishFlow = Flow[JsonMessage].map(publish(channelActor, dbActor))
+
+      val catchupDB = ActorFlow.ask[JsonMessagePubSubClient, DBMessage, JsonMessageAnswerServer](dbActor) {
+        (message, replyTo) =>
+          message match {
+            case CatchupMessageClient(params, id, _, _) =>
+              DBActor.Catchup(params.channel, id, replyTo)
+          }
+      }
+
+      //Connect the graph
+      input ~> partitioner
+      partitioner.out(Publish) ~> publishFlow ~> merge
+      partitioner.out(Subscribe) ~> actorFlow ~> unsubMap2 ~> unsub
+      partitioner.out(Unsubscribe) ~> unsubMap ~> unsub ~> merge
+      partitioner.out(Catchup) ~> catchupDB ~> merge
+      userSource ~> merge
+      merge ~> output
+
+      FlowShape(input.in, output.out)
+    }
+    )
+  }
+
+  private def publish(actor: ActorRef[ChannelMessage],
+                      dbActor: ActorRef[DBMessage])
+                     (implicit timeout: Timeout,
+                      system: ActorSystem[Nothing], pubEntry: Sink[PropagateMessageServer, NotUsed]): JsonMessage => JsonMessageAnswerServer = {
+
+    def pub(params: MessageParameters, propagate: Boolean) = {
+      val future = dbActor.ask(ref => Write(params.channel, params.message.get, ref))
+      Await.result(future, timeout.duration)
+      if(propagate) {
+        val prop = PropagateMessageServer(params)
+        Source.single(prop).runWith(pubEntry)
+      }
+    }
+
+    def errorOrPublish(params: MessageParameters, id: Int, error: Option[MessageErrorContent]) = {
+      error match {
+        case Some(error) => AnswerErrorMessageServer(Some(id), error)
+        case None =>
+          val content = params.message.get
+          Validate.validate(content) match {
+            case Some(error) => AnswerErrorMessageServer(Some(id), error)
+            case None =>
+              pub(params, true)
+              AnswerResultIntMessageServer(id)
+          }
+      }
+    }
+
+    def pubCreateLao(m: CreateLaoMessageClient) = {
+      val params = m.params
+      val id = m.id
+      Validate.validate(m) match {
+        case Some(error) => AnswerErrorMessageServer(Some(id), error)
+        case None => Validate.validate(params.message.get) match {
+          case Some(error) => AnswerErrorMessageServer(Some(id), error)
+          case None =>
+
+            val highLevelMessage = params.message.get.data
+            val channel = "/root/" + new String(Base64.getEncoder.encode(highLevelMessage.id))
+            val future = actor.ask(ref => CreateMessage(channel, ref))
+
+            if (!Await.result(future, timeout.duration)) {
+              val error = MessageErrorContent(-3, "Channel " + channel + " already exists.")
+              AnswerErrorMessageServer(error = error, id = Some(id))
+            }
+            else {
+              //Publish on the LAO main channel
+              pub(MessageParameters(channel, params.message), false)
+              AnswerResultIntMessageServer(id)
+            }
+        }
+      }
+    }
+
+    def pubWitness(m: WitnessMessageMessageClient) = {
+      val params = m.params
+      val id = m.id
+      val message = params.message.get.data
+      val messageId = message.message_id
+      val witnessKey = params.message.get.sender
+      val signature = message.signature
+      implicit val ec = system.executionContext
+      val future = dbActor.ask(ref => Read(params.channel, Base64.getDecoder.decode(messageId), ref))
+        .flatMap {
+          case Some(message: MessageContent) =>
+            dbActor.ask(ref => Write(params.channel, message.updateWitnesses(KeySignPair(witnessKey, signature)), ref))
+          case None =>
+            system.log.debug("Message id not found in db.")
+            Future(false)
+        }
+      if (Await.result(future, timeout.duration))
+        errorOrPublish(params, id, Validate.validate(m))
+      else {
+        val error = MessageErrorContent(ErrorCodes.InvalidData.id, "The id the witness message refers to does not exist.")
+        AnswerErrorMessageServer(Some(id), error)
+      }
+    }
+
+    _ match {
+        case m @ CreateLaoMessageClient(params, id, _, _) =>
+          pubCreateLao(m)
+        case m @ UpdateLaoMessageClient(params,id,_,_) =>
+          errorOrPublish(params, id, Validate.validate(m))
+        case m @ BroadcastLaoMessageClient(params, id,_,_) =>
+          val future = dbActor.ask(ref => Read(params.channel, params.message.get.data.modification_id, ref))
+          Await.result(future, timeout.duration) match {
+            case None =>
+              AnswerErrorMessageServer(Some(id), MessageErrorContent(InvalidData.id, "Invalid reference to a message_id"))
+            case Some(msgContent: MessageContent) =>
+              errorOrPublish(params, id, Validate.validate(m, msgContent.data))
+          }
+        case m @ WitnessMessageMessageClient(_, _, _, _) =>
+          pubWitness(m)
+        case m @ CreateMeetingMessageClient(params, id, _, _) =>
+          val laoId = Base64.getDecoder.decode(params.channel.slice(6,params.channel.length).getBytes)
+          errorOrPublish(params, id, Validate.validate(m, laoId))
+        case m @ BroadcastMeetingMessageClient(params, id, _ ,_) =>
+          val future = dbActor.ask(ref => Read(params.channel, params.message.get.data.modification_id, ref))
+          Await.result(future, timeout.duration) match {
+            case None => AnswerErrorMessageServer(Some(id), MessageErrorContent(InvalidData.id, "Invalid reference to a message_id"))
+            case Some(msgContent: MessageContent) =>
+              errorOrPublish(params, id, Validate.validate(m, msgContent.data))
+          }
+        case m @ CreateRollCallMessageClient(params, id, _, _) =>
+          val laoId = Base64.getDecoder.decode(params.channel.slice(6,params.channel.length).getBytes)
+          errorOrPublish(params, id, Validate.validate(m, laoId))
+        case m @ OpenRollCallMessageClient(params, id, _ , _) =>
+          errorOrPublish(params, id, Validate.validate(m))
+        case m @ CloseRollCallMessageClient(params, id, _ , _) =>
+          errorOrPublish(params, id, Validate.validate(m))
+
+      }
+  }
+
+  private def unsubHandler() = GraphDSL.create(){ implicit builder =>
+    import GraphDSL.Implicits._
+    val merge = builder.add(Merge[UnsubMessage](2))
+
+    val unsub = Flow[UnsubMessage].statefulMapConcat{() =>
+      var channels: Map[String, UniqueKillSwitch] = Map.empty
+
+      {
+        case AnswerSubscribe(jsonMessage, channel, Some(killSwitch)) =>
+          channels = channels + (channel -> killSwitch)
+          List(jsonMessage)
+
+        case AnswerSubscribe(jsonMessage, _, None) =>
+          List(jsonMessage)
+
+        case UnsubRequest(channel, id) =>
+
+          val message =
+            if (channels.contains(channel)) {
+              channels(channel).shutdown()
+              channels = channels.removed(channel)
+              AnswerResultIntMessageServer(id = id)
+            }
+            else {
+              val error = MessageErrorContent(-2, "Invalid resource: you are not subscribed to channel " + channel + ".")
+              AnswerErrorMessageServer(error = error, id = Some(id))
+            }
+          List(message)
+      }
+    }
+
+    val out = merge.out ~> unsub
+
+    UniformFanInShape(out.outlet, merge.in(0), merge.in(1))
+  }
+
+  /**
+   * Create a flow that handles messages of a publish-subscribe system.
+   *
+   * @param channelActor an actor handling channel creation and subscription
+   * @param dbActor an actor handling requests related to the database
+   *
+   * '''Implicit parameters:'''
+   * @param timeout how long should a stream wait for an answer from an actor
+   * @param system the ActorSystem needed to create streams
+   * @param pubEntry a sink where all published messages should be sent
+   * @return a flow that handles messages of a publish-subscribe system
+   */
+  def messageFlow(actor: ActorRef[ChannelMessage],
+                  dbActor : ActorRef[DBMessage])
+                 (implicit timeout: Timeout,
+                  system: ActorSystem[Nothing], pubEntry: Sink[PropagateMessageServer, NotUsed]): Flow[Message, Message, NotUsed] = {
+    val jFlow = jsonFlow(actor, dbActor)
+    Flow.fromGraph(GraphDSL.create() {
+      implicit builder =>
+        import GraphDSL.Implicits._
+        val input = builder.add(Flow[Message])
+        val output = builder.add(Flow[Message])
+        val partitioner = builder.add(Partition[JsonMessage]( 2, {
+          case _ :JsonMessageAnswerServer => 0
+          case _ => 1
+        }))
+        val merge = builder.add(Merge[JsonMessage](2))
+
+
+        val parser = Flow[Message].map {
+          case TextMessage.Strict(s) => {
+            system.log.debug("Receiving: " + s)
+            parseMessage(s) match {
+              case Left(m) => m
+              case Right(JsonMessageParserError(description, id, errorCode)) =>
+                AnswerErrorMessageServer(id, MessageErrorContent(errorCode.id, description))
+            }
+          }
+        }
+
+        val formatter = Flow[JsonMessage].map{
+          m =>
+            val s = serializeMessage(m)
+            system.log.debug("Sending: " + s)
+            TextMessage.Strict(s)
+        }
+
+        val mapPubSub = Flow[JsonMessage].map{case m: JsonMessagePubSubClient => m}
+
+        input ~> parser ~> partitioner
+        partitioner.out(0) ~> merge
+        partitioner.out(1) ~> mapPubSub ~> jFlow ~> merge
+        merge ~> formatter ~> output
+
+        FlowShape(input.in, output.out)
+    })
+  }
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/Unsub.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/Unsub.scala
@@ -1,0 +1,14 @@
+package ch.epfl.pop.pubsub
+
+/**
+ * A trait used for unsubscribe requests
+ */
+trait UnsubMessage
+
+/**
+ * A request to unsubscribe
+ * @param channel the id of the channel the client want to unsubscribe to
+ * @param id the id of the client request
+ */
+final case class UnsubRequest(channel: String, id : Int) extends UnsubMessage
+

--- a/be2-scala/src/test/scala/ch/epfl/pop/tests/MessageCreationUtils.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/tests/MessageCreationUtils.scala
@@ -1,0 +1,47 @@
+package ch.epfl.pop.tests
+
+
+import ch.epfl.pop.crypto.Hash
+import ch.epfl.pop.json._
+import spray.json.enrichAny
+import com.google.crypto.tink.subtle.Ed25519Sign.KeyPair
+import com.google.crypto.tink.subtle.Ed25519Sign
+import ch.epfl.pop.json.JsonCommunicationProtocol.MessageContentDataFormat
+import java.nio.charset.StandardCharsets.UTF_8
+
+import java.util.Base64
+
+object MessageCreationUtils {
+
+  def b64Encode(b: Array[Byte]): Array[Byte] = Base64.getEncoder.encode(b)
+
+  def b64EncodeToString(b: Array[Byte]): String = Base64.getEncoder.encodeToString(b)
+
+  def b64Decode(s: Base64String): Array[Byte] = Base64.getDecoder.decode(s.getBytes(UTF_8))
+
+  def generateKeyPair(): KeyPair = {
+     val keyPair = KeyPair.newKeyPair()
+     keyPair
+  }
+
+  def sign(kp: KeyPair, data: Array[Byte]): Array[Byte] = sign(kp.getPrivateKey, data)
+
+  def sign(sk: Array[Byte], data: Array[Byte]): Array[Byte] = {
+    new Ed25519Sign(sk).sign(data)
+  }
+
+  def getMessageParams(data: MessageContentData, kp: KeyPair, channel: ChannelName): MessageParameters =
+    getMessageParams(data, kp.getPublicKey, kp.getPrivateKey, channel)
+
+  def getMessageParams(data: MessageContentData, sender: Array[Byte], sk: Array[Byte], channel: ChannelName): MessageParameters = {
+    val dataJson = data.toJson.compactPrint.getBytes
+    val encodedData = b64EncodeToString(dataJson)
+    val signature = sign(sk, dataJson)
+    val messageId = Hash.computeMessageId(encodedData, signature)
+    val witnessSignature: List[KeySignPair] = Nil
+
+    val content = MessageContent(encodedData, data, sender, signature, messageId, witnessSignature)
+    val params = MessageParameters(channel, Some(content))
+    params
+  }
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/tests/ValidateTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/tests/ValidateTest.scala
@@ -1,0 +1,418 @@
+package ch.epfl.pop.tests
+
+import ch.epfl.pop.Validate
+import ch.epfl.pop.crypto.Hash
+import ch.epfl.pop.json.JsonMessages.{BroadcastLaoMessageClient, BroadcastMeetingMessageClient, CloseRollCallMessageClient, CreateLaoMessageClient, CreateMeetingMessageClient, CreateRollCallMessageClient, OpenRollCallMessageClient, UpdateLaoMessageClient, WitnessMessageMessageClient}
+import ch.epfl.pop.json.JsonUtils.MessageContentDataBuilder
+import ch.epfl.pop.json.{Actions, ByteArray, Hash, MessageContent, Methods, Objects}
+import ch.epfl.pop.tests.MessageCreationUtils._
+import com.google.crypto.tink.subtle.Ed25519Sign.KeyPair
+import org.scalatest.FunSuite
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.security.MessageDigest
+import java.util.Base64
+class ValidateTest extends FunSuite {
+
+  /* --------------- VALIDATE MESSAGE CONTENT --------------- */
+
+  test("Validate message content when correct") {
+
+    val kp = generateKeyPair()
+    val msg = "This is my message"
+    val encodedData = b64EncodeToString(msg.getBytes(UTF_8))
+    val signature = sign(kp, msg.getBytes(UTF_8))
+    val id = Hash.computeMessageId(encodedData, signature)
+    val witnessSignatures = Nil
+    val content: MessageContent = MessageContent(encodedData, null, kp.getPublicKey, signature, id, witnessSignatures)
+    assert(Validate.validate(content).isEmpty)
+  }
+
+  test("Validate message content fails with incorrect signature") {
+
+    val pk = generateKeyPair().getPublicKey
+    val msg = "This is my message"
+    val encodedData = b64EncodeToString(msg.getBytes(UTF_8))
+    val signature = "incorrect signature".getBytes
+    val id = Hash.computeMessageId(encodedData, signature)
+    val witnessSignatures = Nil
+    val content: MessageContent = MessageContent(encodedData, null, pk, signature, id, witnessSignatures)
+    assert(Validate.validate(content).nonEmpty)
+  }
+
+  test("Validate message content fails with incorrect id") {
+
+    val kp = generateKeyPair()
+    val msg = "This is my message"
+    val encodedData = b64EncodeToString(msg.getBytes(UTF_8))
+    val signature = sign(kp, msg.getBytes(UTF_8))
+    val id = Hash.computeMessageId(encodedData, "incorrect".getBytes)
+    val witnessSignatures = Nil
+    val content: MessageContent = MessageContent(encodedData, null, kp.getPublicKey, signature, id, witnessSignatures)
+    assert(Validate.validate(content).nonEmpty)
+  }
+
+  /* --------------- VALIDATE CREATE LAO --------------- */
+
+  private val laoName = "My LAO"
+  private val laoCreation = 229388L
+  private val kp: KeyPair = generateKeyPair()
+  private val sk = kp.getPrivateKey
+  private val pk = kp.getPublicKey
+  private val laoOrganizer = kp.getPublicKey
+  private val md = MessageDigest.getInstance("SHA-256")
+  private val laoString = "[" + '"' + Base64.getEncoder.encodeToString(laoOrganizer) + "\",\"" + laoCreation.toString + "\",\"" +
+    laoName + "\"]"
+  private val laoId = md.digest(laoString.getBytes(UTF_8))
+  private val root = "/root"
+  private def createLao(id: Hash = laoId, name: String = laoName, creation: Long = laoCreation,
+                        organizer: ByteArray = laoOrganizer, sender: Array[Byte] = pk): CreateLaoMessageClient = {
+    val data = new MessageContentDataBuilder()
+      .setHeader(Objects.Lao, Actions.Create)
+      .setId(id)
+      .setName(name)
+      .setCreation(creation)
+      .setOrganizer(organizer)
+      .setWitnesses(Nil)
+      .build()
+    val params = getMessageParams(data, sender, sk, root)
+    val create = CreateLaoMessageClient(params, 0, Methods.Publish)
+    create
+  }
+
+  test("Create LAO validation works with correct parameters") {
+
+    val create = createLao()
+    assert(Validate.validate(create).isEmpty)
+  }
+
+  test("Create LAO validation fails with incorrect id") {
+    val create = createLao(id = Array[Byte]())
+    assert(Validate.validate(create).isDefined)
+  }
+
+  test("Create LAO validation fails with incorrect creation timestamp") {
+    val create = createLao(creation = -1)
+    assert(Validate.validate(create).isDefined)
+  }
+
+  test("Create LAO validation fails with incorrect organizer") {
+    val create = createLao(sender = null)
+    assert(Validate.validate(create).isDefined)
+  }
+
+  /* --------------- VALIDATE UPDATE LAO --------------- */
+
+  private val updateLaoLastModified = laoCreation + 1
+  private def updateLao(modified: Long = updateLaoLastModified, sender: Array[Byte] = pk): UpdateLaoMessageClient = {
+    val data = new MessageContentDataBuilder()
+      .setHeader(Objects.Lao, Actions.UpdateProperties)
+      .setId(laoId)
+      .setName(laoName)
+      .setCreation(laoCreation)
+      .setLastModified(modified)
+      .setWitnesses(Nil)
+      .build()
+    val params = getMessageParams(data, sender, sk, root)
+    val update = UpdateLaoMessageClient(params, 0, Methods.Publish)
+    update
+  }
+
+  test("Update LAO validation works with valid parameters") {
+    assert(Validate.validate(updateLao()).isEmpty)
+  }
+
+  test("Update LAO validation fails with invalid modification timestamp") {
+    assert(Validate.validate(updateLao(modified = -1)).isDefined)
+  }
+
+  /* --------------- VALIDATE BROADCAST LAO --------------- */
+
+  private def broadcastLao(modificationId: Hash,id: Hash = laoId, creation: Long = laoCreation, name: String = laoName, lastModified: Long = laoCreation,
+                           organizer: ByteArray = laoOrganizer, sender: Array[Byte] = pk): BroadcastLaoMessageClient = {
+    val data = new MessageContentDataBuilder()
+      .setHeader(Objects.Lao, Actions.State)
+      .setId(id)
+      .setName(name)
+      .setCreation(creation)
+      .setLastModified(lastModified)
+      .setOrganizer(organizer)
+      .setWitnesses(Nil)
+      .setModificationId(modificationId)
+      .setModificationSignatures(Nil)
+      .build()
+    val params = getMessageParams(data, sender, sk, root)
+    val broadcast = BroadcastLaoMessageClient(params, 0, Methods.Publish)
+    broadcast
+  }
+
+  test("Broadcast LAO validation works with valid parameters") {
+    val mod = createLao().params.message.get
+    val broadcast = broadcastLao(mod.message_id)
+    assert(Validate.validate(broadcast, mod.data).isEmpty)
+  }
+
+  test("Broadcast LAO validation fails with LAO id different than in creation message") {
+    val mod = createLao().params.message.get
+    val broadcast = broadcastLao(mod.message_id, id = Array[Byte]())
+    assert(Validate.validate(broadcast, mod.data).nonEmpty)
+  }
+
+  test("Broadcast LAO validation fails with creation timestamp different than in creation message") {
+    val mod = createLao().params.message.get
+    val broadcast = broadcastLao(mod.message_id, creation = laoCreation - 100)
+    assert(Validate.validate(broadcast, mod.data).nonEmpty)
+  }
+
+  test("Broadcast LAO validation fails with last_modified timestamp different than in creation message") {
+    val mod = createLao().params.message.get
+    val broadcast = broadcastLao(mod.message_id, lastModified = laoCreation - 100)
+    assert(Validate.validate(broadcast, mod.data).nonEmpty)
+  }
+
+  test("Broadcast LAO validation fails with name different than in creation message") {
+    val mod = createLao().params.message.get
+    val broadcast = broadcastLao(mod.message_id, name = "I changed the name")
+    assert(Validate.validate(broadcast, mod.data).nonEmpty)
+  }
+
+  test("Broadcast LAO validation fails with organizer different than in creation message") {
+    val mod = createLao().params.message.get
+    val broadcast = broadcastLao(mod.message_id, organizer = Array[Byte]())
+    assert(Validate.validate(broadcast, mod.data).nonEmpty)
+  }
+
+  test("Broadcast LAO validation fails with sender different the organizer") {
+    val mod = createLao().params.message.get
+    val broadcast = broadcastLao(mod.message_id, sender = null)
+    assert(Validate.validate(broadcast, mod.data).nonEmpty)
+  }
+
+  /* --------------- VALIDATE WITNESS --------------- */
+
+  private def witness(key: Option[Array[Byte]] = None): WitnessMessageMessageClient = {
+    val msgToWitness = createLao().params.message.get
+    val witnessKp = generateKeyPair()
+    val signingKey = key match {
+      case Some(sk) => sk
+      case None => witnessKp.getPrivateKey
+    }
+    val msgId = Base64.getEncoder.encode(msgToWitness.message_id)
+    val signature = sign(signingKey, msgToWitness.message_id)
+    val data = new MessageContentDataBuilder()
+      .setHeader(Objects.Message, Actions.Witness)
+      .setMessageId(new String(msgId))
+      .setSignature(signature)
+      .build()
+    val params = getMessageParams(data, witnessKp, root)
+    WitnessMessageMessageClient(params, 0, Methods.Publish)
+  }
+
+  test("Witness validation works with valid parameters") {
+    val witnessMsg = witness()
+    assert(Validate.validate(witnessMsg).isEmpty)
+  }
+
+  test("Witness validation fails with invalid signature") {
+    val witnessMsg = witness(Some(sk))
+    assert(Validate.validate(witnessMsg).nonEmpty)
+  }
+
+  /* --------------- VALIDATE CREATE MEETING --------------- */
+
+  private val meetingName = "My meeting"
+  private val meetingCreation = 98431198L
+  private val meetingId = Hash.computeMeetingId(laoId, meetingCreation, meetingName)
+  private val meetingLocation = "BC Hall"
+  private val meetingStart = 98431198L + 1
+  private val meetingEnd = meetingStart + 1
+
+  private def createMeeting(id: ByteArray = meetingId, creation: Long = meetingCreation, start: Long = meetingStart,
+                            end: Long = meetingEnd): CreateMeetingMessageClient = {
+    val data = new MessageContentDataBuilder()
+      .setHeader(Objects.Meeting, Actions.Create)
+      .setId(id)
+      .setName(meetingName)
+      .setCreation(creation)
+      .setLastModified(creation)
+      .setLocation(meetingLocation)
+      .setStart(start)
+      .setEnd(end)
+      .build()
+    val params = getMessageParams(data, pk, sk, root)
+    CreateMeetingMessageClient(params, 0, Methods.Publish)
+  }
+
+  test("Create meeting validation works with valid parameters") {
+    val meeting = createMeeting()
+    assert(Validate.validate(meeting, laoId).isEmpty)
+  }
+
+  test("Create meeting validation fails with invalid meeting id") {
+    val meeting = createMeeting(id = Array[Byte]())
+    assert(Validate.validate(meeting, laoId).nonEmpty)
+  }
+
+  test("Create meeting validation fails with invalid creation timestamp") {
+    val meeting = createMeeting(creation = -1)
+    assert(Validate.validate(meeting, laoId).nonEmpty)
+  }
+
+  test("Create meeting validation fails with invalid start time") {
+    val meeting = createMeeting(start = meetingCreation - 1000)
+    assert(Validate.validate(meeting, laoId).nonEmpty)
+  }
+
+  test("Create meeting validation fails with invalid end time") {
+    val meeting = createMeeting(end = meetingStart - 1000)
+    assert(Validate.validate(meeting, laoId).nonEmpty)
+  }
+
+  /* --------------- VALIDATE BROADCAST MEETING --------------- */
+
+  private def broadcastMeeting(modificationId: Hash, id: Hash = meetingId, name: String = meetingName,
+                               creation: Long = meetingCreation, start: Long = meetingStart, end: Long = meetingEnd): BroadcastMeetingMessageClient = {
+
+    val data = new MessageContentDataBuilder()
+      .setHeader(Objects.Meeting, Actions.State)
+      .setId(id)
+      .setName(name)
+      .setCreation(creation)
+      .setLastModified(creation)
+      .setLocation(meetingLocation)
+      .setStart(start)
+      .setEnd(end)
+      .setModificationId(modificationId)
+      .setModificationSignatures(Nil)
+      .build()
+    val params = getMessageParams(data, pk, sk, root)
+    BroadcastMeetingMessageClient(params, 0, Methods.Publish)
+  }
+
+  test("Broadcast meeting validation works with valid parameters") {
+    val meetingMsg = createMeeting().params.message.get
+    val state = broadcastMeeting(meetingMsg.message_id)
+    assert(Validate.validate(state, meetingMsg.data).isEmpty)
+  }
+
+  test("Broadcast meeting validation fails with meeting id different than in the creation message") {
+    val meetingMsg = createMeeting().params.message.get
+    val state = broadcastMeeting(meetingMsg.message_id, id = Array[Byte]())
+    assert(Validate.validate(state, meetingMsg.data).nonEmpty)
+  }
+
+  test("Broadcast meeting validation fails with meeting name different than in the creation message") {
+    val meetingMsg = createMeeting().params.message.get
+    val state = broadcastMeeting(meetingMsg.message_id, name = "Changed name")
+    assert(Validate.validate(state, meetingMsg.data).nonEmpty)
+  }
+
+  test("Broadcast meeting validation fails with meeting creation timestamp different than in the creation message") {
+    val meetingMsg = createMeeting().params.message.get
+    val state = broadcastMeeting(meetingMsg.message_id, creation = meetingCreation - 1)
+    assert(Validate.validate(state, meetingMsg.data).nonEmpty)
+  }
+
+  test("Broadcast meeting validation fails with meeting start timestamp different than in the creation message") {
+    val meetingMsg = createMeeting().params.message.get
+    val state = broadcastMeeting(meetingMsg.message_id, start = meetingStart - 1)
+    assert(Validate.validate(state, meetingMsg.data).nonEmpty)
+  }
+
+  test("Broadcast meeting validation fails with meeting end timestamp different than in the creation message") {
+    val meetingMsg = createMeeting().params.message.get
+    val state = broadcastMeeting(meetingMsg.message_id, end = meetingEnd - 1)
+    assert(Validate.validate(state, meetingMsg.data).nonEmpty)
+  }
+
+  /* --------------- VALIDATE CREATE ROLL-CALL --------------- */
+
+  private val rcCreation = 123213213L
+  private val rcStart = rcCreation + 1
+  private val rcName = "My roll-call"
+  private val rcId = Hash.computeRollCallId(laoId, rcCreation, rcName)
+
+  private def createRollCall(id: Hash, creation: Long, start: Long): CreateRollCallMessageClient = {
+  val data = new MessageContentDataBuilder()
+    .setHeader(Objects.RollCall, Actions.Create)
+    .setId(id)
+    .setName(rcName)
+    .setCreation(creation)
+    .setStart(start)
+    .build()
+
+    val params = getMessageParams(data, pk, sk, root)
+    CreateRollCallMessageClient(params, 0, Methods.Publish)
+  }
+
+  test("Create roll-call validation works with valid parameters") {
+    val rcMsg = createRollCall(rcId, rcCreation, rcStart)
+    assert(Validate.validate(rcMsg, laoId).isEmpty)
+  }
+
+  test("Create roll-call validation fails with invalid id") {
+    //Replacing roll-call id by lao id
+    val rcMsg = createRollCall(laoId, rcCreation, rcStart)
+    assert(Validate.validate(rcMsg, laoId).isDefined)
+  }
+
+  test("Create roll-call validation fails with invalid start timestamp") {
+    val rcMsg = createRollCall(laoId, rcCreation, rcCreation - 1)
+    assert(Validate.validate(rcMsg, laoId).isDefined)
+  }
+
+  /* --------------- VALIDATE OPEN ROLL-CALL --------------- */
+
+  private def openRollCall(start: Long): OpenRollCallMessageClient = {
+    val data = new MessageContentDataBuilder()
+      .setHeader(Objects.RollCall, Actions.Open)
+      .setId(rcId)
+      .setStart(start)
+      .build()
+
+    val params = getMessageParams(data, pk, sk, root)
+    OpenRollCallMessageClient(params, 0, Methods.Publish)
+  }
+
+  test("Open roll-call validation works with valid parameters") {
+    val rcMsg = openRollCall(rcStart)
+    assert(Validate.validate(rcMsg).isEmpty)
+  }
+
+  test("Open roll-call validation fails with invalid start timestamp") {
+    val rcMsg = openRollCall(0)
+    assert(Validate.validate(rcMsg).isDefined)
+  }
+
+  /* --------------- VALIDATE CLOSE ROLL-CALL --------------- */
+
+  private val rcEnd = rcStart + 1
+  private def closeRollCall(start: Long, end: Long): CloseRollCallMessageClient = {
+    val data = new MessageContentDataBuilder()
+      .setHeader(Objects.RollCall, Actions.Close)
+      .setId(rcId)
+      .setStart(start)
+      .setEnd(end)
+      .setAttendees(List())
+      .build()
+
+    val params = getMessageParams(data, pk, sk, root)
+    CloseRollCallMessageClient(params, 0, Methods.Publish)
+  }
+
+  test("Close roll-call validation works with valid parameters") {
+    val rcMsg = closeRollCall(rcStart, rcEnd)
+    assert(Validate.validate(rcMsg).isEmpty)
+  }
+
+  test("Close roll-call validation fails with invalid start timestamp") {
+    val rcMsg = closeRollCall(0, rcEnd)
+    assert(Validate.validate(rcMsg).isDefined)
+  }
+
+  test("Close roll-call validation fails with invalid end timestamp") {
+    val rcMsg = closeRollCall(rcStart, rcStart)
+    assert(Validate.validate(rcMsg).isDefined)
+  }
+
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/tests/crypto/HashTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/tests/crypto/HashTest.scala
@@ -1,0 +1,21 @@
+package ch.epfl.pop.tests.crypto
+
+import java.math.BigInteger
+import java.util.Arrays
+import ch.epfl.pop.crypto.Hash
+import org.scalatest.FunSuite
+
+import java.nio.charset.StandardCharsets
+
+class HashTest extends FunSuite{
+
+  test("Verify that the message id computed is correct") {
+    val msg = "{\"type\":\"rollcall\"}"
+    val signature = "signature" // Base64 representation is c2lnbmF0dXJl
+    //SHA-256 hash of ["{\"type\":\"rollcall\"}","c2lnbmF0dXJl"]
+    val correctHash = new BigInteger("d8a4fc4cd72c82df967c932c3182c976772f2f517e84c0659e73d2ca2776bcdb", 16).toByteArray.tail
+    assert(correctHash.length == 32)
+    assert(Arrays.equals(Hash.computeMessageId(msg, signature.getBytes(StandardCharsets.UTF_8)), correctHash))
+  }
+
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/tests/crypto/SignatureTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/tests/crypto/SignatureTest.scala
@@ -1,0 +1,27 @@
+package ch.epfl.pop.tests.crypto
+
+import ch.epfl.pop.crypto.Signature
+import ch.epfl.pop.tests.MessageCreationUtils.{b64EncodeToString, generateKeyPair, sign}
+import org.scalatest.FunSuite
+import java.nio.charset.StandardCharsets.UTF_8
+
+class SignatureTest extends FunSuite {
+
+  test("Verify correct signature") {
+    val msg = "{\"ts\": 1604911874, \"type\":\"rollcall\"}"
+    val kp = generateKeyPair()
+    val sig = sign(kp, msg.getBytes(UTF_8))
+
+    val msgEncoded = b64EncodeToString(msg.getBytes(UTF_8))
+    assert(Signature.verify(msgEncoded, sig, kp.getPublicKey))
+  }
+
+  test("Signature verification fails on incorrect signature") {
+    val msg = "{\"ts\": 1604911874, \"type\":\"rollcall\"}"
+    val pk = generateKeyPair().getPublicKey
+    val sig = "incorrect signature".getBytes()
+
+    val msgEncoded = b64EncodeToString(msg.getBytes(UTF_8))
+    assert(!Signature.verify(msgEncoded, sig, pk))
+  }
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/tests/json/JsonMessageParserTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/tests/json/JsonMessageParserTest.scala
@@ -1,0 +1,1058 @@
+package ch.epfl.pop.tests.json
+
+import ch.epfl.pop.json.JsonMessages._
+import ch.epfl.pop.json.JsonUtils.{ErrorCodes, JsonMessageParserError, JsonMessageParserException, MessageContentDataBuilder}
+import ch.epfl.pop.json.{Actions, Objects, _}
+import spray.json._
+import ch.epfl.pop.json.JsonCommunicationProtocol._
+import org.scalatest.{FunSuite, Matchers}
+import JsonParserTestsUtils._
+import ch.epfl.pop.json.Actions.Actions
+import ch.epfl.pop.json.Methods.Methods
+import ch.epfl.pop.json.Objects.Objects
+
+import scala.util.{Failure, Success, Try}
+
+
+class JsonMessageParserTest extends FunSuite with Matchers {
+
+
+  implicit class RichJsonMessage(m: JsonMessage) {
+    def shouldBeEqualUntilMessageContent(o: JsonMessage): Unit = {
+
+      // Note: this function is useful because ScalaTest cannot compare List of arrays of bytes :/
+      // thus we can't test two messages by using "m1 should equal (m2)"
+
+      @scala.annotation.tailrec
+      def checkListOfByteArray(l1: List[Array[Byte]], l2: List[Array[Byte]]): Unit = {
+        l1.length should equal (l2.length)
+
+        (l1, l2) match {
+          case _ if l1.isEmpty =>
+          case (h1 :: tail1, h2 :: tail2) =>
+            h1 should equal (h2)
+            checkListOfByteArray(tail1, tail2)
+        }
+      }
+
+      @scala.annotation.tailrec
+      def checkListOfKeySigPair(l1: List[KeySignPair], l2: List[KeySignPair]): Unit = {
+        l1.length should equal (l2.length)
+
+        (l1, l2) match {
+          case _ if l1.isEmpty =>
+          case (h1 :: tail1, h2 :: tail2) =>
+            h1.witness should equal (h2.witness)
+            h1.signature should equal (h2.signature)
+            checkListOfKeySigPair(tail1, tail2)
+        }
+      }
+
+
+      val m_1 = this.m
+      val m_2 = o
+
+      m_1 match {
+        case _: PropagateMessageServer =>
+          m_2 shouldBe a [PropagateMessageServer]
+
+          val cm_1 = m_1.asInstanceOf[PropagateMessageServer]
+          val cm_2 = m_2.asInstanceOf[PropagateMessageServer]
+
+          val a1 = CreateLaoMessageClient(cm_1.params, -1, cm_1.method, cm_1.jsonrpc)
+          val a2 = CreateLaoMessageClient(cm_2.params, -1, cm_2.method, cm_2.jsonrpc)
+
+          a1 shouldBeEqualUntilMessageContent a2
+
+
+        case _: JsonMessagePublishClient =>
+          m_2 shouldBe a [JsonMessagePublishClient]
+
+          val cm_1 = m_1.asInstanceOf[JsonMessagePublishClient]
+          val cm_2 = m_2.asInstanceOf[JsonMessagePublishClient]
+
+          cm_1.jsonrpc should equal(cm_2.jsonrpc)
+          cm_1.id should equal(cm_2.id)
+          cm_1.method should equal(cm_2.method)
+
+          cm_1.params.channel should equal (cm_2.params.channel)
+          (cm_1.params.message, cm_2.params.message) match {
+            case (None, None) =>
+
+            case (Some(mc1), Some(mc2)) =>
+              mc1.sender should equal (mc2.sender)
+              mc1.signature should equal (mc2.signature)
+              mc1.message_id should equal (mc2.message_id)
+              checkListOfKeySigPair(mc1.witness_signatures, mc2.witness_signatures)
+
+              mc1.data._object should equal (mc2.data._object)
+              mc1.data.action should equal (mc2.data.action)
+              mc1.data.id should equal (mc2.data.id)
+              mc1.data.name should equal (mc2.data.name)
+              mc1.data.creation should equal (mc2.data.creation)
+              mc1.data.last_modified should equal (mc2.data.last_modified)
+              mc1.data.organizer should equal (mc2.data.organizer)
+              checkListOfByteArray(mc1.data.witnesses, mc2.data.witnesses)
+              mc1.data.message_id should equal (mc2.data.message_id)
+              mc1.data.signature should equal (mc2.data.signature)
+              mc1.data.location should equal (mc2.data.location)
+              mc1.data.start should equal (mc2.data.start)
+              mc1.data.end should equal (mc2.data.end)
+              mc1.data.extra should equal (mc2.data.extra)
+
+            case _ => fail()
+          }
+
+        case _ => throw new UnsupportedOperationException
+      }
+    }
+  }
+
+
+  @scala.annotation.tailrec
+  final def listStringify(value: List[KeySignPair], acc: String = ""): String = {
+    if (value.nonEmpty) {
+      var sep = ""
+      if (value.length > 1) sep = ","
+
+      listStringify(
+        value.tail,
+        acc + "{\"signature\":\"" + encodeBase64String(value.head.signature.map(_.toChar).mkString) +
+        "\",\"witness\":\"" + encodeBase64String(value.head.witness.map(_.toChar).mkString) + "\"}" + sep
+      )
+    }
+    else "[" + acc + "]"
+  }
+
+
+  test("JsonMessageParser.parseMessage|encodeMessage:CreateLaoMessageClient") {
+    var source: String = embeddedMessage(dataCreateLao, channel = "/root")
+    val sp: JsonMessage = JsonMessageParser.parseMessage(source) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    val spd: String = JsonMessageParser.serializeMessage(sp)
+    val spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [CreateLaoMessageClient]
+    spdp shouldBe a [CreateLaoMessageClient]
+    sp shouldBeEqualUntilMessageContent spdp
+
+
+    // no action field
+    source = embeddedMessage(dataCreateLao.replaceFirst("\"action\":[^,]*,", ""), channel = "/root")
+    JsonMessageParser.parseMessage(source) match {
+      case Right(e) =>
+        e.description should equal ("invalid \"MessageContentData\" : fields missing or wrongly formatted")
+      case _ => fail()
+    }
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:UpdateLaoMessageClient") {
+    var source: String = embeddedMessage(dataUpdateLao)
+    val sp: JsonMessage = JsonMessageParser.parseMessage(source) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    val spd: String = JsonMessageParser.serializeMessage(sp)
+    val spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [UpdateLaoMessageClient]
+    spdp shouldBe a [UpdateLaoMessageClient]
+    sp shouldBeEqualUntilMessageContent spdp
+    checkBogusInputs(source)
+
+
+    // last modified not int value
+    source = embeddedMessage(dataUpdateLao.replaceFirst("\"last_modified\":[0-9]*", "\"last_modified\":\"12\""))
+    JsonMessageParser.parseMessage(source) match {
+      case Right(e) =>
+        e.description should equal ("invalid \"updateLaoProperties\" query : field \"last_modified\" missing or wrongly formatted")
+      case _ => fail()
+    }
+
+    // no action field
+    source = embeddedMessage(dataUpdateLao.replaceFirst("\"action\":[^,]*,", ""))
+    JsonMessageParser.parseMessage(source) match {
+      case Right(e) =>
+        e.description should equal ("invalid \"MessageContentData\" : fields missing or wrongly formatted")
+      case _ => fail()
+    }
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:BroadcastLaoMessageClient") {
+    var source: String = embeddedMessage(dataBroadcastLao)
+    val sp: JsonMessage = JsonMessageParser.parseMessage(source) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    val spd: String = JsonMessageParser.serializeMessage(sp)
+    val spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [BroadcastLaoMessageClient]
+    spdp shouldBe a [BroadcastLaoMessageClient]
+    sp shouldBeEqualUntilMessageContent spdp
+    checkBogusInputs(source)
+
+
+    // last modified not int value
+    source = embeddedMessage(dataBroadcastLao.replaceFirst("\"last_modified\":[0-9]*", "\"last_modified\":\"12\""))
+    JsonMessageParser.parseMessage(source) match {
+      case Right(e) =>
+        e.description should startWith ("invalid \"stateBroadcastLao\" query :")
+      case _ => fail()
+    }
+
+    // no action field
+    source = embeddedMessage(dataBroadcastLao.replaceFirst("\"action\":[^,]*,", ""))
+    JsonMessageParser.parseMessage(source) match {
+      case Right(e) =>
+        e.description should equal ("invalid \"MessageContentData\" : fields missing or wrongly formatted")
+      case _ => fail()
+    }
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:WitnessMessageMessageClient") {
+    var source: String = embeddedMessage(dataWitnessMessage)
+    val sp: JsonMessage = JsonMessageParser.parseMessage(source) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    val spd: String = JsonMessageParser.serializeMessage(sp)
+    val spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [WitnessMessageMessageClient]
+    spdp shouldBe a [WitnessMessageMessageClient]
+    sp shouldBeEqualUntilMessageContent spdp
+    checkBogusInputs(source)
+
+
+    // no action field
+    source = embeddedMessage(dataWitnessMessage.replaceFirst("\"action\":[^,]*,", ""))
+    JsonMessageParser.parseMessage(source) match {
+      case Right(e) =>
+        e.description should equal ("invalid \"MessageContentData\" : fields missing or wrongly formatted")
+      case _ => fail()
+    }
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:CreateMeetingMessageClient") {
+    // Meeting with every argument
+    var data: String = dataCreateMeeting
+    var sp: JsonMessage = JsonMessageParser.parseMessage(embeddedMessage(data)) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    var spd: String = JsonMessageParser.serializeMessage(sp)
+    var spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [CreateMeetingMessageClient]
+    spdp shouldBe a [CreateMeetingMessageClient]
+    sp shouldBeEqualUntilMessageContent spdp
+
+
+    // Meeting without location
+    data = data.replaceFirst(",\"location\":\"[a-zA-Z]*\"", "")
+    sp = JsonMessageParser.parseMessage(embeddedMessage(data)) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    spd = JsonMessageParser.serializeMessage(sp)
+    spdp = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [CreateMeetingMessageClient]
+    spdp shouldBe a [CreateMeetingMessageClient]
+    sp shouldBeEqualUntilMessageContent spdp
+
+    // Meeting without location and end
+    data = data.replaceFirst(",\"end\":[0-9]*", "")
+    sp = JsonMessageParser.parseMessage(embeddedMessage(data)) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    spd = JsonMessageParser.serializeMessage(sp)
+    spdp = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [CreateMeetingMessageClient]
+    spdp shouldBe a [CreateMeetingMessageClient]
+    sp shouldBeEqualUntilMessageContent spdp
+
+    // Meeting without location, end and extra
+    data = data.replaceFirst(",\"extra\":\"[a-zA-Z0-9_]*\"", "")
+    sp = JsonMessageParser.parseMessage(embeddedMessage(data)) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    spd = JsonMessageParser.serializeMessage(sp)
+    spdp = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [CreateMeetingMessageClient]
+    spdp shouldBe a [CreateMeetingMessageClient]
+    sp shouldBeEqualUntilMessageContent spdp
+
+
+    // Meeting without start (should not work)
+    data = data.replaceFirst(",\"start\":[0-9]*", "")
+    try {
+      sp = JsonMessageParser.parseMessage(embeddedMessage(data)) match {
+        case Left(_) => fail()
+        case Right(_) => throw JsonMessageParserException("")
+      }
+    }
+    catch { case _: JsonMessageParserException => }
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:BroadcastMeetingMessageClient") {
+    var source: String = embeddedMessage(dataBroadcastMeeting)
+    val sp: JsonMessage = JsonMessageParser.parseMessage(source) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    val spd: String = JsonMessageParser.serializeMessage(sp)
+    val spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [BroadcastMeetingMessageClient]
+    spdp shouldBe a [BroadcastMeetingMessageClient]
+    sp shouldBeEqualUntilMessageContent spdp
+    checkBogusInputs(source)
+
+
+    // last modified not int value
+    source = embeddedMessage(dataBroadcastMeeting.replaceFirst("\"last_modified\":[0-9]*", "\"last_modified\":\"12\""))
+    JsonMessageParser.parseMessage(source) match {
+      case Right(e) =>
+        e.description should startWith ("invalid \"stateBroadcastMeeting\" query :")
+      case _ => fail()
+    }
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:CreateRollCallMessageClient") {
+    // roll call with every argument
+    var data: String = dataCreateRollCall
+    var sp: JsonMessage = JsonMessageParser.parseMessage(embeddedMessage(data)) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    var spd: String = JsonMessageParser.serializeMessage(sp)
+    var spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [CreateRollCallMessageClient]
+    spdp shouldBe a [CreateRollCallMessageClient]
+    sp shouldBeEqualUntilMessageContent spdp
+    sp.asInstanceOf[CreateRollCallMessageClient].params.message match {
+      case Some(mc) => mc.data.action.toString should fullyMatch regex """create"""
+      case None => fail()
+    }
+
+    // roll call without description
+    data = data.replaceFirst(",\"roll_call_description\":\"[a-zA-Z]*\"", "")
+    sp = JsonMessageParser.parseMessage(embeddedMessage(data)) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    spd = JsonMessageParser.serializeMessage(sp)
+    spdp = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [CreateRollCallMessageClient]
+    spdp shouldBe a [CreateRollCallMessageClient]
+    sp shouldBeEqualUntilMessageContent spdp
+
+    // roll call without description and scheduled
+    data = data.replaceFirst(",\"scheduled\":[0-9]*", "")
+    sp = JsonMessageParser.parseMessage(embeddedMessage(data)) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    spd = JsonMessageParser.serializeMessage(sp)
+    spdp = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [CreateRollCallMessageClient]
+    spdp shouldBe a [CreateRollCallMessageClient]
+    sp shouldBeEqualUntilMessageContent spdp
+
+    // roll call without description, scheduled and start
+    data = data.replaceFirst(",\"start\":[0-9]*", "")
+    sp = JsonMessageParser.parseMessage(embeddedMessage(data)) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    spd = JsonMessageParser.serializeMessage(sp)
+    spdp = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [CreateRollCallMessageClient]
+    spdp shouldBe a [CreateRollCallMessageClient]
+    sp shouldBeEqualUntilMessageContent spdp
+
+    // roll call without description, scheduled, start and location (should fail)
+    var dataW: String = data.replaceFirst(",\"location\":\"[A-Za-z]*\"", "")
+    try {
+      sp = JsonMessageParser.parseMessage(embeddedMessage(dataW)) match {
+        case Left(_) => fail()
+        case Right(_) => throw JsonMessageParserException("")
+      }
+    }
+    catch { case _: JsonMessageParserException => }
+
+    // roll call without description, scheduled, start and action (should fail)
+    dataW = data.replaceFirst(",\"action\":\"[A-Za-z]*\"", "")
+    try {
+      sp = JsonMessageParser.parseMessage(embeddedMessage(dataW)) match {
+        case Left(_) => fail()
+        case Right(_) => throw JsonMessageParserException("")
+      }
+    }
+    catch { case _: JsonMessageParserException => }
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:OpenRollCallMessageClient") {
+    // roll call with every argument
+    val data: String = dataOpenRollCall
+    var sp: JsonMessage = JsonMessageParser.parseMessage(embeddedMessage(data)) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    val spd: String = JsonMessageParser.serializeMessage(sp)
+    val spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [OpenRollCallMessageClient]
+    spdp shouldBe a [OpenRollCallMessageClient]
+    sp shouldBeEqualUntilMessageContent spdp
+    sp.asInstanceOf[OpenRollCallMessageClient].params.message match {
+      case Some(mc) => mc.data.action.toString should fullyMatch regex """open"""
+      case None => fail()
+    }
+
+    // roll call without start (should fail)
+    var dataW: String = data.replaceFirst(",\"start\":[0-9]*", "")
+    try {
+      sp = JsonMessageParser.parseMessage(embeddedMessage(dataW)) match {
+        case Left(_) => fail()
+        case Right(_) => throw JsonMessageParserException("")
+      }
+    }
+    catch { case _: JsonMessageParserException => }
+
+    // roll call without id (should fail)
+    dataW = data.replaceFirst(",\"id\":\"[A-Za-z0-9=+/]*\"", "")
+    try {
+      sp = JsonMessageParser.parseMessage(embeddedMessage(dataW)) match {
+        case Left(_) => fail()
+        case Right(_) => throw JsonMessageParserException("")
+      }
+    }
+    catch { case _: JsonMessageParserException => }
+
+    // roll call with invalid action (should fail)
+    dataW = _dataRollCall
+      .replaceFirst("F_ACTION", Actions.State.toString)
+      .replaceFirst("FF_MODIFICATION", "\"start\":3000,")
+    JsonMessageParser.parseMessage(embeddedMessage(dataW)) match {
+      case Right(e) =>
+        e.description should equal (s"""invalid roll call query : action "${Actions.State.toString}" is unrecognizable""")
+      case _ => fail()
+    }
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:ReopenRollCallMessageClient") {
+    // Note: this message doesn't really exit. It is part of "OpenRollCallMessageClient"
+
+    // roll call with every argument
+    val data: String = dataReopenRollCall
+    var sp: JsonMessage = JsonMessageParser.parseMessage(embeddedMessage(data)) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    val spd: String = JsonMessageParser.serializeMessage(sp)
+    val spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [OpenRollCallMessageClient]
+    spdp shouldBe a [OpenRollCallMessageClient]
+    sp shouldBeEqualUntilMessageContent spdp
+    sp.asInstanceOf[OpenRollCallMessageClient].params.message match {
+      case Some(mc) => mc.data.action.toString should fullyMatch regex """reopen"""
+      case None => fail()
+    }
+
+    // roll call without start (should fail)
+    var dataW: String = data.replaceFirst(",\"start\":[0-9]*", "")
+    try {
+      sp = JsonMessageParser.parseMessage(embeddedMessage(dataW)) match {
+        case Left(_) => fail()
+        case Right(_) => throw JsonMessageParserException("")
+      }
+    }
+    catch { case _: JsonMessageParserException => }
+
+    // roll call without id (should fail)
+    dataW = data.replaceFirst(",\"id\":\"[A-Za-z0-9=+/]*\"", "")
+    try {
+      sp = JsonMessageParser.parseMessage(embeddedMessage(dataW)) match {
+        case Left(_) => fail()
+        case Right(_) => throw JsonMessageParserException("")
+      }
+    }
+    catch { case _: JsonMessageParserException => }
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:CloseRollCallMessageClient") {
+    // roll call with every argument
+    val data: String = dataCloseRollCall
+    var sp: JsonMessage = JsonMessageParser.parseMessage(embeddedMessage(data)) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    val spd: String = JsonMessageParser.serializeMessage(sp)
+    val spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [CloseRollCallMessageClient]
+    spdp shouldBe a [CloseRollCallMessageClient]
+    sp shouldBeEqualUntilMessageContent spdp
+    sp.asInstanceOf[CloseRollCallMessageClient].params.message match {
+      case Some(mc) => mc.data.action.toString should fullyMatch regex """close"""
+      case None => fail()
+    }
+
+    // roll call without start (should fail)
+    var dataW: String = data.replaceFirst(",\"start\":[0-9]*", "")
+    try {
+      sp = JsonMessageParser.parseMessage(embeddedMessage(dataW)) match {
+        case Left(_) => fail()
+        case Right(_) => throw JsonMessageParserException("")
+      }
+    }
+    catch { case _: JsonMessageParserException => }
+
+    // roll call without end (should fail)
+    dataW = data.replaceFirst(",\"end\":[0-9]*", "")
+    try {
+      sp = JsonMessageParser.parseMessage(embeddedMessage(dataW)) match {
+        case Left(_) => fail()
+        case Right(_) => throw JsonMessageParserException("")
+      }
+    }
+    catch { case _: JsonMessageParserException => }
+
+    // roll call without attendees (should fail)
+    dataW = data.replaceFirst(",\"attendees\":\\[[A-Za-z0-9,\"=]*\\]", "")
+    try {
+      sp = JsonMessageParser.parseMessage(embeddedMessage(dataW)) match {
+        case Left(_) => fail()
+        case Right(_) => throw JsonMessageParserException("")
+      }
+    }
+    catch { case _: JsonMessageParserException => }
+
+    // roll call without id (should fail)
+    dataW = data.replaceFirst(",\"id\":\"[A-Za-z0-9=+/]*\"", "")
+    try {
+      sp = JsonMessageParser.parseMessage(embeddedMessage(dataW)) match {
+        case Left(_) => fail()
+        case Right(_) => throw JsonMessageParserException("")
+      }
+    }
+    catch { case _: JsonMessageParserException => }
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:PropagateMessageServer") {
+    val source: String = s"""{
+                            |    "jsonrpc": "2.0",
+                            |    "method": "broadcast",
+                            |    "params": {
+                            |        "channel": "channel_id",
+                            |        "message": $MessageContentExample
+                            |    }
+                            |  }
+                            |""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+
+    val sp: JsonMessage = JsonMessageParser.parseMessage(source) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    val spd: String = JsonMessageParser.serializeMessage(sp)
+    val spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [PropagateMessageServer]
+    spdp shouldBe a [PropagateMessageServer]
+    sp shouldBeEqualUntilMessageContent spdp
+    checkBogusInputs(source)
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:SubscribeMessageClient") {
+    val source: String = """{
+                           |    "jsonrpc": "2.0",
+                           |    "method": "subscribe",
+                           |    "params": {
+                           |        "channel": "channel_id"
+                           |    },
+                           |    "id": 3
+                           |  }
+                           |""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+
+    val sp: JsonMessage = JsonMessageParser.parseMessage(source) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    val spd: String = JsonMessageParser.serializeMessage(sp)
+    val spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    assert(sp === spdp)
+    assert(sp.isInstanceOf[SubscribeMessageClient])
+    assert(spdp.isInstanceOf[SubscribeMessageClient])
+    checkBogusInputs(source)
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:UnsubscribeMessageClient") {
+    val source: String = """{
+                           |    "jsonrpc": "2.0",
+                           |    "method": "unsubscribe",
+                           |    "params": {
+                           |        "channel": "channel_id"
+                           |    },
+                           |    "id": 3
+                           |  }
+                           |""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+
+    val sp: JsonMessage = JsonMessageParser.parseMessage(source) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    val spd: String = JsonMessageParser.serializeMessage(sp)
+    val spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    assert(sp === spdp)
+    assert(sp.isInstanceOf[UnsubscribeMessageClient])
+    assert(spdp.isInstanceOf[UnsubscribeMessageClient])
+    checkBogusInputs(source)
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:CatchupMessageClient") {
+    val source: String = """{
+                           |    "jsonrpc": "2.0",
+                           |    "method": "catchup",
+                           |    "params": {
+                           |        "channel": "channel_id"
+                           |    },
+                           |    "id": 3
+                           |  }
+                           |""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+
+    val sp: JsonMessage = JsonMessageParser.parseMessage(source) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    val spd: String = JsonMessageParser.serializeMessage(sp)
+    val spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    assert(sp === spdp)
+    assert(sp.isInstanceOf[CatchupMessageClient])
+    assert(spdp.isInstanceOf[CatchupMessageClient])
+    checkBogusInputs(source)
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:AnswerResultIntMessageServer") {
+    val source: String = embeddedServerAnswer(Some(0), None, id = 13)
+    val sp: JsonMessage = JsonMessageParser.parseMessage(source) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    val spd: String = JsonMessageParser.serializeMessage(sp)
+    val spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [AnswerResultIntMessageServer]
+    spdp shouldBe a [AnswerResultIntMessageServer]
+    assertResult(source)(spd)
+    checkBogusInputs(source)
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:AnswerResultArrayMessageServer") {
+    var source: String = s"""{
+                            |    "id": 99,
+                            |    "jsonrpc": "2.0",
+                            |    "result": F_MESSAGES
+                            |  }
+                            |""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+
+    val sourceFull: String = source.replaceFirst("F_MESSAGES", "[]")
+    var sp: JsonMessage = JsonMessageParser.parseMessage(sourceFull) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    var spd: String = JsonMessageParser.serializeMessage(sp)
+    val spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+      case Left(m) => m
+      case _ => fail()
+    }
+
+    sp shouldBe a [AnswerResultArrayMessageServer]
+    spdp shouldBe a [AnswerResultArrayMessageServer]
+    spd should equal (sourceFull)
+
+
+    // 1 message and empty witness list
+    val data: MessageContentData = new MessageContentDataBuilder().setHeader(Objects.Message, Actions.Witness).setId("2".getBytes).setStart(22L).build()
+    val encodedData: Base64String = JsonUtils.ENCODER.encode(data.toJson.compactPrint.getBytes).map(_.toChar).mkString
+    var m: MessageContent = MessageContent(encodedData, data, "skey".getBytes, "sign".getBytes, "mid".getBytes, List())
+    sp = AnswerResultArrayMessageServer(99, List(m))
+    spd = JsonMessageParser.serializeMessage(sp)
+
+    val rd: String = """eyJvYmplY3QiOiJtZXNzYWdlIiwiYWN0aW9uIjoid2l0bmVzcyIsImlkIjoiTWc9PSIsInN0YXJ0IjoyMn0="""
+    var r: String = s"""[{"data":"$rd","message_id":"bWlk","sender":"c2tleQ==","signature":"c2lnbg==","witness_signatures":[]}]"""
+
+    assertResult(source.replaceFirst("F_MESSAGES", r))(spd)
+    assert(rd === JsonUtils.ENCODER.encode(data.toJson.toString().getBytes).map(_.toChar).mkString)
+    assert(JsonUtils.DECODER.decode(rd).map(_.toChar).mkString === data.toJson.toString())
+
+
+    // 1 message and non-empty witness list
+    val sig: List[KeySignPair] = List(
+      KeySignPair("ceb_prop_1".getBytes, "ceb_1".getBytes),
+      KeySignPair("ceb_prop_2".getBytes, "ceb_2".getBytes),
+      KeySignPair("ceb_prop_3".getBytes, "ceb_3".getBytes)
+    )
+    m = MessageContent(encodedData, data, "skey".getBytes, "sign".getBytes, "mid".getBytes, sig)
+    sp = AnswerResultArrayMessageServer(99, List(m))
+    spd = JsonMessageParser.serializeMessage(sp)
+
+    r = s"""[{"data":"$rd","message_id":"bWlk","sender":"c2tleQ==","signature":"c2lnbg==","witness_signatures":${listStringify(sig)}}]"""
+
+    assertResult(source.replaceFirst("F_MESSAGES", r))(spd)
+    assert(rd === JsonUtils.ENCODER.encode(data.toJson.toString().getBytes).map(_.toChar).mkString)
+    assert(JsonUtils.DECODER.decode(rd).map(_.toChar).mkString === data.toJson.toString())
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:AnswerErrorMessageServer") {
+    val source: String = s"""{
+                            |    "error": {
+                            |       "code": ERR_CODE,
+                            |       "description": "err"
+                            |    },
+                            |    ID
+                            |    "jsonrpc": "2.0"
+                            |  }
+                            |""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+
+    for (i <- -5 until 0) {
+      val sourceErrorCode: String = source.replaceFirst("ERR_CODE", String.valueOf(i))
+      val sourceSomeId: String = sourceErrorCode.replaceFirst("ID", "\"id\":" + String.valueOf(3 * i) + ",")
+      val sourceNoneId: String = sourceErrorCode.replaceFirst("ID", "\"id\":null,")
+
+      var sp: JsonMessage = JsonMessageParser.parseMessage(sourceSomeId) match {
+        case Left(m) => m
+        case _ => fail()
+      }
+
+      var spd: String = JsonMessageParser.serializeMessage(sp)
+      var spdp: JsonMessage = JsonMessageParser.parseMessage(spd) match {
+        case Left(m) => m
+        case _ => fail()
+      }
+
+      assertResult(sourceSomeId)(spd)
+      sp shouldBe a [AnswerErrorMessageServer]
+      spdp shouldBe a [AnswerErrorMessageServer]
+      assertResult(sourceSomeId)(spd)
+      checkBogusInputs(sourceSomeId)
+
+
+      sp = JsonMessageParser.parseMessage(sourceNoneId) match {
+        case Left(m) => m
+        case _ => fail()
+      }
+
+      spd = JsonMessageParser.serializeMessage(sp)
+      spdp = JsonMessageParser.parseMessage(spd) match {
+        case Left(m) => m
+        case _ => fail()
+      }
+
+      assertResult(sourceNoneId)(spd)
+      sp shouldBe a [AnswerErrorMessageServer]
+      spdp shouldBe a [AnswerErrorMessageServer]
+      assertResult(sourceNoneId)(spd)
+      checkBogusInputs(sourceNoneId)
+    }
+
+    // If error has invalid id (not JsNull or JsNumber) => should fail
+    val sCode: String = source.replaceFirst("ERR_CODE", "-3")
+    var s: String = sCode.replaceFirst("ID", "\"id\":\"12\",")
+    var e = the [JsonMessageParserException] thrownBy s.parseJson.convertTo[AnswerErrorMessageServer]
+    e.getMessage should equal ("invalid \"AnswerErrorMessageServer\" : id field wrongly formatted")
+    s = sCode.replaceFirst("ID", "\"id\":[12],")
+    e = the [JsonMessageParserException] thrownBy s.parseJson.convertTo[AnswerErrorMessageServer]
+    e.getMessage should equal ("invalid \"AnswerErrorMessageServer\" : id field wrongly formatted")
+    s = sCode.replaceFirst("ID", "\"id\":{\"id\":12},")
+    e = the [JsonMessageParserException] thrownBy s.parseJson.convertTo[AnswerErrorMessageServer]
+    e.getMessage should equal ("invalid \"AnswerErrorMessageServer\" : id field wrongly formatted")
+
+    // If error has wrong type (not JsObject) => should fail
+    val errorMatcherRegex: String = "\"error\":\\{[^\\}]*\\}"
+    val sourceErrorCode: String = source.replaceFirst("ID", "\"id\":123,")
+
+    var sourceWrongErrorType: String = sourceErrorCode.replaceFirst(errorMatcherRegex, "\"error\":10")
+    JsonMessageParser.parseMessage(sourceWrongErrorType) match {
+      case Right(e) =>
+        e.description should equal ("invalid message : message contains a \"error\" field, but its type is unknown")
+      case _ => fail()
+    }
+
+    e = the [JsonMessageParserException] thrownBy sourceWrongErrorType.parseJson.convertTo[AnswerErrorMessageServer]
+    e.getMessage should equal ("invalid \"AnswerErrorMessageServer\" : fields missing or wrongly formatted")
+
+    sourceWrongErrorType = sourceErrorCode.replaceFirst(errorMatcherRegex, "\"error\":\"10\"")
+    JsonMessageParser.parseMessage(sourceWrongErrorType) match {
+      case Right(e) =>
+        e.description should equal ("invalid message : message contains a \"error\" field, but its type is unknown")
+      case _ => fail()
+    }
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:\"bogus answer message\"") {
+    val source: String = s"""{
+                            |    "error": {
+                            |       "code": ERR_CODE,
+                            |       "description": "err"
+                            |    },
+                            |    ID
+                            |    "jsonrpc": "2.0",
+                            |    "result": 0
+                            |  }
+                            |""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+
+    for (i <- -20 to 20) {
+      val sourceErrorCode: String = source.replaceFirst("ERR_CODE", String.valueOf(i))
+      val sourceSomeId: String = sourceErrorCode.replaceFirst("ID", "\"id\":" + String.valueOf(3 * i) + ",")
+      val sourceNoneId: String = sourceErrorCode.replaceFirst("ID", "\"id\":null,")
+
+      var sp: JsonMessageParserError = JsonMessageParser.parseMessage(sourceSomeId) match {
+        case Right(m) => m
+        case _ => fail()
+      }
+      sp shouldBe a [JsonMessageParserError]
+
+      sp = JsonMessageParser.parseMessage(sourceNoneId) match {
+        case Right(m) => m
+        case _ => fail()
+      }
+      sp shouldBe a [JsonMessageParserError]
+    }
+  }
+
+  test("JsonMessageParser.parseMessage:Exceptions") {
+    var source: String = embeddedMessage(dataOpenRollCallBuggy)
+    val expected: JsonMessageParserError = JsonMessageParserError(ErrorCodes.InvalidData.toString, Some(0), ErrorCodes.InvalidData)
+    val sp: JsonMessageParserError = JsonMessageParser.parseMessage(source) match {
+      case Right(e) => e
+      case _ => fail()
+    }
+
+    sp shouldBe a [JsonMessageParserError]
+    sp should equal (expected)
+
+
+    source = s"""{
+                |    "jsonrpc": "2.0",
+                |    "id": 12345
+                |  }
+                |""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+
+    JsonMessageParser.parseMessage(source) match {
+      case Right(e) => e.description should equal ("invalid message : fields missing or wrongly formatted")
+      case _ => fail()
+    }
+
+
+    // invalid message content type
+    source = "{\"data\":\"myData\"}"
+    val e = the [JsonMessageParserException] thrownBy source.parseJson.convertTo[MessageContent]
+    e.getMessage should equal ("invalid \"MessageContent\" : fields missing or wrongly formatted")
+
+
+    // invalid (object, action) pair
+    val wrongAction: String = Actions.Open.toString
+    source = embeddedMessage(dataWitnessMessage.replaceFirst("\"action\":[^,]*", s""""action":"$wrongAction""""))
+    JsonMessageParser.parseMessage(source) match {
+      case Right(e) =>
+        e.description should equal (s"""invalid message : invalid (object = ${Objects.Message.toString}, action = $wrongAction) pair""")
+      case _ => fail()
+    }
+
+
+    // no MessageContent for a publish method
+    source = """{"jsonrpc":"2.0","method":"publish","params":{"channel":"/root/lao_id"},"id":0}"""
+    JsonMessageParser.parseMessage(source) match {
+      case Right(e) =>
+        e.description should equal ("missing MessageContent in MessageParameter for JsonMessagePublishClient")
+      case _ => fail()
+    }
+
+
+    // no params for a publish method but id readable
+    val newId: Int = 678
+    source = s"""{"jsonrpc":"2.0","method":"publish","id":$newId}"""
+    JsonMessageParser.parseMessage(source) match {
+      case Right(e) =>
+        e.description should equal ("invalid MessageParameters : fields missing or wrongly formatted")
+        e.id should equal (Some(newId))
+      case _ => fail()
+    }
+  }
+
+  test("JsonMessageParser.encodeMessage:Exceptions") {
+    val sp: JsonMessage = null
+
+    try {
+      JsonMessageParser.serializeMessage(sp)
+      fail()
+    } catch {
+      case e: SerializationException => e.getMessage should equal ("Json serializer failed : invalid input message")
+      case _: Throwable => fail()
+    }
+  }
+
+  test("JsonMessageParser.parseMessage|encodeMessage:Enumerations") {
+
+    def quoteIfy(str: String): String = s""""$str""""
+    val UNKNOWN_ENUM_VALUE: String = quoteIfy("string-not-in-enum")
+
+    Methods.values.forall(v => {
+      val padded = quoteIfy(v.toString)
+      val converted = padded.parseJson.convertTo[Methods]
+      val reversed  = converted.toJson
+
+      reversed shouldBe a [JsString]
+      reversed.toString should equal (padded)
+      true
+    })
+
+    Try(UNKNOWN_ENUM_VALUE.parseJson.convertTo[Methods]) match {
+      case Success(_) => fail()
+      case Failure(e) =>
+        e shouldBe a [DeserializationException]
+        e.getMessage should equal ("invalid \"method\" field : unrecognized")
+      case _ => fail()
+    }
+
+
+    Objects.values.forall(v => {
+      val padded = quoteIfy(v.toString)
+      val converted = padded.parseJson.convertTo[Objects]
+      val reversed  = converted.toJson
+
+      reversed shouldBe a [JsString]
+      reversed.toString should equal (padded)
+      true
+    })
+
+    Try(UNKNOWN_ENUM_VALUE.parseJson.convertTo[Objects]) match {
+      case Success(_) => fail()
+      case Failure(e) =>
+        e shouldBe a [DeserializationException]
+        e.getMessage should equal ("invalid \"object\" field : unrecognized")
+      case _ => fail()
+    }
+
+
+    Actions.values.forall(v => {
+      val padded = quoteIfy(v.toString)
+      val converted = padded.parseJson.convertTo[Actions]
+      val reversed  = converted.toJson
+
+      reversed shouldBe a [JsString]
+      reversed.toString should equal (padded)
+      true
+    })
+
+    Try(UNKNOWN_ENUM_VALUE.parseJson.convertTo[Actions]) match {
+      case Success(_) => fail()
+      case Failure(e) =>
+        e shouldBe a [DeserializationException]
+        e.getMessage should equal ("invalid \"action\" field : unrecognized")
+      case _ => fail()
+    }
+  }
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/tests/json/JsonParserTestsUtils.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/tests/json/JsonParserTestsUtils.scala
@@ -1,0 +1,277 @@
+package ch.epfl.pop.tests.json
+
+import java.util.Base64
+
+import ch.epfl.pop.json.JsonMessages.JsonMessage
+import ch.epfl.pop.json.JsonUtils.JsonMessageParserError
+import ch.epfl.pop.json.{Actions, ChannelName, JsonMessageParser, Methods, Objects}
+
+import scala.util.Random
+import org.scalatest.{FunSuite, Matchers}
+
+
+object JsonParserTestsUtils extends FunSuite with Matchers {
+
+  val ERROR_MESSAGE: String = "error_for_error_code_above"
+
+
+  def encodeBase64String(s: String): String = Base64.getEncoder.encode(s.getBytes()).map(_.toChar).mkString
+
+
+  val MessageContentExample: String = """{
+                                        |            "data": "eyJvYmplY3QiOiJsYW8iLCJhY3Rpb24iOiJ1cGRhdGVfcHJvcGVydGllcyIsImlkIjoiWVdGaCIsIm5hbWUiOiJNYSBMYW8iLCJjcmVhdGlvbiI6NDU0NSwibGFzdF9tb2RpZmllZCI6NDU0NSwib3JnYW5pemVyIjoiWW1JIiwid2l0bmVzc2VzIjpbIk1UST0iLCAiTVRNPSJdfQ==",
+                                        |            "sender": "NTMwZEU4",
+                                        |            "signature": "NTEwMA==",
+                                        |            "message_id": "MWQw",
+                                        |            "witness_signatures": [
+                                        |              { "signature": "Y2ViMQ==", "witness": "Y2ViX3Byb3BfMQ==" },
+                                        |              { "signature": "Y2ViMg==", "witness": "Y2ViX3Byb3BfMg==" },
+                                        |              { "signature": "Y2ViMw==", "witness": "Y2ViX3Byb3BfMw==" }
+                                        |            ]
+                                        |        }""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+
+
+  val _dataLao: String = s"""{
+                            |    "object": "${Objects.Lao.toString}",
+                            |    "action": "F_ACTION",
+                            |    FF_MODIFICATION
+                            |    "id": "OTk5",
+                            |    "name": "name",
+                            |    "creation": 222,
+                            |    "last_modified": 222,
+                            |    "organizer": "OTA5",
+                            |    "witnesses": ["MTEx"]
+                            |}""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+
+  val _dataMeeting: String = s"""{
+                                |    "object": "${Objects.Meeting.toString}",
+                                |    "action": "F_ACTION",
+                                |    FF_MODIFICATION
+                                |    "id": "ODg4",
+                                |    "name": "nameMeeting",
+                                |    "creation": 333,
+                                |    "last_modified": 333,
+                                |    "location": "Paris",
+                                |    "start": 400,
+                                |    "end": 500,
+                                |    "extra": "extra_stuff"
+                                |}""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+
+
+  val _dataRollCall: String = s"""{
+                            |    "object": "${Objects.RollCall.toString}",
+                            |    "action": "F_ACTION",
+                            |    FF_MODIFICATION
+                            |    "id": "OTk5"
+                            |}""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+
+
+  val _dataRollCallBuggy: String = s"""{
+                                 |    "object": "${Objects.RollCall.toString}",
+                                 |    "action": "F_ACTION",
+                                 |    FF_MODIFICATION
+                                 |    "id": "c2Fsd@XQ="
+                                 |}""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+
+
+  val dataUpdateLao: String = s"""{
+                                 |    "object": "${Objects.Lao.toString}",
+                                 |    "action": "${Actions.UpdateProperties.toString}",
+                                 |    "name": "name6",
+                                 |    "id": "ODg4",
+                                 |    "last_modified": 2226,
+                                 |    "witnesses": ["MTEx", "MTExNgo="]
+                                 |}""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+
+  val dataWitnessMessage: String = s"""{
+                                      |    "object": "${Objects.Message.toString}",
+                                      |    "action": "${Actions.Witness.toString}",
+                                      |    "message_id": "YmVlZgo=",
+                                      |    "signature": "OTA5MAo="
+                                      |}""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+
+
+  val dataCreateLao: String = _dataLao
+    .replaceFirst("F_ACTION", Actions.Create.toString)
+    .replaceFirst("FF_MODIFICATION", "")
+    .replaceFirst("\"last_modified\":[0-9]*,", "")
+  val dataBroadcastLao: String = _dataLao
+    .replaceFirst("F_ACTION", Actions.State.toString)
+    .replaceFirst(
+      "FF_MODIFICATION",
+      "\"modification_id\":\"NDU2\",\"modification_signatures\":[{\"witness\":\"Y2xlZjE=\",\"signature\":\"amUgc2lnbmU=\"},{\"witness\":\"Y2xlZjI=\",\"signature\":\"amUgc2lnbmUgYXVzc2k=\"}],"
+    )
+  val dataCreateMeeting: String = _dataMeeting
+    .replaceFirst("F_ACTION", Actions.Create.toString)
+    .replaceFirst("FF_MODIFICATION", "")
+    .replaceFirst("\"last_modified\":[0-9]*,", "")
+  val dataBroadcastMeeting: String = _dataMeeting
+    .replaceFirst("F_ACTION", Actions.State.toString)
+    .replaceFirst(
+      "FF_MODIFICATION",
+      "\"modification_id\":\"NDU2\",\"modification_signatures\":[{\"witness\":\"Y2xlZjE=\",\"signature\":\"amUgc2lnbmU=\"},{\"witness\":\"Y2xlZjI=\",\"signature\":\"amUgc2lnbmUgYXVzc2k=\"}],"
+    )
+  val dataCreateRollCall: String = _dataRollCall
+    .replaceFirst("F_ACTION", Actions.Create.toString)
+    .replaceFirst("FF_MODIFICATION", "\"name\":\"MonRollCall\",\"creation\":1234,\"start\":1500,\"scheduled\":1450,\"location\":\"INF\",\"roll_call_description\":\"description\",")
+  val dataOpenRollCall: String = _dataRollCall
+    .replaceFirst("F_ACTION", Actions.Open.toString)
+    .replaceFirst("FF_MODIFICATION", "\"start\":2000,")
+  val dataReopenRollCall: String = _dataRollCall
+    .replaceFirst("F_ACTION", Actions.Reopen.toString)
+    .replaceFirst("FF_MODIFICATION", "\"start\":3000,")
+  val dataCloseRollCall: String = _dataRollCall
+    .replaceFirst("F_ACTION", Actions.Close.toString)
+    .replaceFirst("FF_MODIFICATION", "\"start\":4000,\"end\":5000,\"attendees\":[\"Y2xlZjE=\",\"Y2xlZjI=\"],")
+  val dataOpenRollCallBuggy: String = _dataRollCallBuggy
+    .replaceFirst("F_ACTION", Actions.Open.toString)
+    .replaceFirst("FF_MODIFICATION", "\"start\":2000,")
+
+
+  def embeddedMessage(
+                       data: String,
+                       method: Methods.Methods = Methods.Publish,
+                       channel: ChannelName = "/root/lao_id",
+                       id: Int = 0
+                     ): String = {
+    s"""{
+       |    "jsonrpc": "2.0",
+       |    "method": "${method.toString}",
+       |    "params": {
+       |        "channel": "$channel",
+       |        "message": {
+       |            "data": "${Base64.getEncoder.encode(data.getBytes).map(_.toChar).mkString}",
+       |            "sender": "NTMwZEU4",
+       |            "signature": "NTEwMA==",
+       |            "message_id": "MWQw",
+       |            "witness_signatures": [
+       |              { "signature": "Y2ViMQ==", "witness": "Y2ViX3Byb3BfMQ==" },
+       |              { "signature": "Y2ViMg==", "witness": "Y2ViX3Byb3BfMg==" },
+       |              { "signature": "Y2ViMw==", "witness": "Y2ViX3Byb3BfMw==" }
+       |            ]
+       |        }
+       |    },
+       |    "id": $id
+       |  }
+       |""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+  }
+
+  def embeddedServerAnswer(result: Option[Int], error: Option[String] = Some(ERROR_MESSAGE), code: Int = 0, id: Int = 0): String = {
+    (result, error) match {
+      case (Some(r), None) =>
+        val additional: String = s""""result": $r"""
+        s"""{
+           |    "id": $id,
+           |    "jsonrpc": "2.0",
+           |    $additional
+           |  }
+           |""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+      case (None, Some(e)) =>
+        val additional: String = s""""error": {"code": $code, "description": "$e"}"""
+        s"""{
+           |    $additional,
+           |    "id": $id,
+           |    "jsonrpc": "2.0"
+           |  }
+           |""".stripMargin.filterNot((c: Char) => c.isWhitespace)
+      case _ => throw new IllegalArgumentException("Impossible argument combination in embeddedServerAnswer")
+    }
+  }
+
+  def checkBogusInputs(source: String): Unit = {
+
+    val RANDOM_GENERATOR = new Random(2020)
+
+    def altereString(str: String): String = {
+      if (str.isEmpty) "alteredString"
+      else str.tail
+    }
+
+    def randomInt: Int = RANDOM_GENERATOR.nextInt()
+
+    val arrEmpty: String = """[]"""
+    val arr: String = """["MTu", "T0x"]"""
+
+    def patternString(kw: String): String = s""""$kw":"[^,]*""""
+    def patternAfterString(kw: String, newValue: String): String = s""""$kw":$newValue"""
+
+    def performBogusTest(s: String): Unit = {
+      JsonMessageParser.parseMessage(s) match {
+        case Left(_) => fail()
+        case Right(e) => e shouldBe a [JsonMessageParserError]
+      }
+    }
+
+    def checkBatchTestsString(kw: String): Unit = {
+      val pattern: String = s""""$kw":"[^,]*""""
+      def patternAfter(newValue: String): String = s""""$kw":$newValue"""
+
+      if (source.contains(kw)) {
+        performBogusTest(source.replaceFirst(pattern, patternAfter("\"3.0\"")))
+        performBogusTest(source.replaceFirst(pattern, patternAfter("\"string\"")))
+        performBogusTest(source.replaceFirst(pattern, patternAfter("2.0")))
+        performBogusTest(source.replaceFirst(pattern, patternAfter("")))
+        performBogusTest(source.replaceFirst(pattern, patternAfter("s|{@sopOIJ34≠")))
+        performBogusTest(source.replaceFirst(pattern, patternAfter(arrEmpty)))
+        performBogusTest(source.replaceFirst(pattern, patternAfter(arr)))
+        performBogusTest(source.replaceFirst(pattern, patternAfter(randomInt.toString)))
+      }
+    }
+
+    def checkBatchTestsInt(kw: String, canBeNull: Boolean = false): Unit = {
+      val pattern: String = s""""$kw":[0-9]*"""
+      def patternAfter(newValue: String): String = s""""$kw":$newValue"""
+
+      if (source.contains(kw)) {
+        performBogusTest(source.replaceFirst(pattern, patternAfter("\"3.0\"")))
+        performBogusTest(source.replaceFirst(pattern, patternAfter("\"3\"")))
+        performBogusTest(source.replaceFirst(pattern, patternAfter("\"string\"")))
+        if (!canBeNull) performBogusTest(source.replaceFirst(pattern, patternAfter("")))
+        performBogusTest(source.replaceFirst(pattern, patternAfter("s|{@sopOIJ34≠")))
+      }
+    }
+
+    def checkBatchWithArrays(source: String, kw: String, pattern: String): Unit = {
+      performBogusTest(source.replaceFirst(pattern, patternAfterString(kw, randomInt.toString)))
+      performBogusTest(source.replaceFirst(pattern, patternAfterString(kw, arrEmpty)))
+      performBogusTest(source.replaceFirst(pattern, patternAfterString(kw, arr)))
+    }
+
+    def checkBatchWithNonBase64(source: String, kw: String): Unit = {
+      performBogusTest(source.replaceFirst(patternString(kw), patternAfterString(kw, "not-A-Base64-String")))
+    }
+
+    if (source.contains("jsonrpc")) {
+      val kw: String = "jsonrpc"
+      checkBatchTestsString(kw)
+    }
+    if (source.contains("\"method\":")) checkBatchTestsString("method")
+    if (source.contains("\"id\":") && source.contains("\"error\":")) checkBatchTestsInt("id", canBeNull = true)
+    else if (source.contains("\"id\":")) checkBatchTestsInt("id")
+
+    if (source.contains("\"params\":")) {
+      if (source.contains("\"channel\":")) {
+        val kw: String = "channel"
+        val pattern: String = """"KW":"[^,]*"""".replaceFirst("KW", kw)
+
+        checkBatchWithArrays(source, kw, pattern)
+      }
+
+      if (source.contains("\"message\":")) {
+        if (source.contains("\"data\":")) {
+          checkBatchWithNonBase64(source, "data")
+
+          // could also check inside
+        }
+        if (source.contains("\"sender\":")) checkBatchWithNonBase64(source, "sender")
+        if (source.contains("\"signature\":")) checkBatchWithNonBase64(source, "signature")
+        if (source.contains("\"message_id\":")) checkBatchWithNonBase64(source, "message_id")
+        if (source.contains("\"witness_signatures\":")) {
+          // could check that all values are base64 strings
+        }
+      }
+    }
+    if (source.contains("\"result\":")) checkBatchTestsInt("result")
+    if (source.contains("\"error\":")) { /* no bogus test possible : checks done later */ }
+  }
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/tests/pubsub/PubSubTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/tests/pubsub/PubSubTest.scala
@@ -1,0 +1,465 @@
+package ch.epfl.pop.tests.pubsub
+
+
+import akka.NotUsed
+import ch.epfl.pop.tests.MessageCreationUtils.{b64Decode, b64Encode, b64EncodeToString, generateKeyPair, getMessageParams, sign}
+
+import java.io.File
+import java.security.MessageDigest
+import java.util.Base64
+import java.util.concurrent.TimeUnit
+import akka.actor.typed.scaladsl.AskPattern._
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorRef, ActorSystem, Props, SpawnProtocol}
+import akka.stream.{ClosedShape, SourceShape}
+import akka.stream.scaladsl.{Broadcast, BroadcastHub, Flow, GraphDSL, Keep, Merge, MergeHub, Partition, RunnableGraph, Sink, Source}
+import akka.util.Timeout
+import ch.epfl.pop
+import ch.epfl.pop.DBActor
+import ch.epfl.pop.DBActor.DBMessage
+import ch.epfl.pop.crypto.{Hash, Signature}
+import ch.epfl.pop.json.JsonMessages._
+import ch.epfl.pop.json.{Actions, Base64String, ChannelName, KeySignPair, MessageContent, MessageContentData, MessageErrorContent, MessageParameters, Methods, Objects, Signature}
+import ch.epfl.pop.pubsub.{ChannelActor, PublishSubscribe}
+import org.iq80.leveldb.Options
+import org.scalatest.FunSuite
+import ch.epfl.pop.json.JsonUtils.{ErrorCodes, MessageContentDataBuilder}
+import org.scalactic.Equality
+import com.google.crypto.tink.subtle.Ed25519Sign.KeyPair
+
+import java.nio.charset.StandardCharsets
+import java.util
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.math.pow
+import scala.reflect.io.Directory
+
+class PubSubTest extends FunSuite {
+
+  private def sendAndVerify(messages: List[(Option[JsonMessagePubSubClient], Option[JsonMessageAnswerServer])]): Unit = {
+    sendAndVerify(messages.map { case (m, o) => (m, o, 0) }, 1)
+  }
+
+  private def sendAndVerify(messages: List[(Option[JsonMessagePubSubClient], Option[JsonMessageAnswerServer], Int)], numberProcesses: Int): Unit = {
+    val root = Behaviors.setup[SpawnProtocol.Command] { context =>
+      SpawnProtocol()
+    }
+
+    val DatabasePath: String = "database_test"
+    val file = new File(DatabasePath)
+    //Reset db from previous tests
+    val directory = new Directory(file)
+    directory.deleteRecursively()
+
+    implicit val system: ActorSystem[SpawnProtocol.Command] = ActorSystem[SpawnProtocol.Command](root, "test")
+    implicit val timeout: Timeout = Timeout(1, TimeUnit.SECONDS)
+    val (pubEntry, actor, dbActor) = setup(DatabasePath)
+
+    val options: Options = new Options()
+    options.createIfMissing(true)
+
+    val flows = (1 to numberProcesses).map(_ => PublishSubscribe.jsonFlow(actor, dbActor)(timeout, system, pubEntry))
+
+    //Generates a list of answers from the publish-subscribe given a list of requests
+    val g: Source[JsonMessageAnswerServer, NotUsed] = Source.fromGraph(GraphDSL.create() { implicit builder =>
+      import GraphDSL.Implicits._
+
+      //Send the next message when receiving an answer
+      val tester = Flow[JsonMessageAnswerServer].statefulMapConcat{ () =>
+        var current = messages.tail
+
+        { answer =>
+          current match {
+            case msg :: tail =>
+              current = tail
+              msg._1 match {
+                case Some(clientMsg) => (msg._3, clientMsg) :: Nil
+                case None => Nil
+              }
+            case Nil =>
+              Nil
+          }
+        }
+      }
+      val merge = builder.add(Merge[JsonMessageAnswerServer](flows.length))
+      val mergePart = builder.add(Merge[(Int, JsonMessagePubSubClient)](2))
+      val broadcast = builder.add(Broadcast[JsonMessageAnswerServer](2))
+      val partitioner = builder.add(Partition[(Int, JsonMessagePubSubClient)](flows.length, _._1))
+      val removeIndex = Flow[(Int, JsonMessagePubSubClient)].map(_._2)
+      val start = Source.single((messages.head._3, messages.head._1.get))
+
+      flows.zipWithIndex.foreach(f => partitioner.out(f._2) ~> removeIndex ~> f._1 ~> merge)
+      merge ~> broadcast
+      broadcast.out(0) ~> tester ~> mergePart
+      start ~> mergePart
+      mergePart ~> partitioner
+      SourceShape(broadcast.out(1))
+    }
+    )
+
+    val sink: Sink[JsonMessageAnswerServer, Future[Iterable[JsonMessageAnswerServer]]] = Sink.collection
+    val future = g.take(messages.length).runWith(sink)
+    val rcvMsg = Await.result(future, 5.seconds)
+
+    val expectedMsg = messages.flatMap(_._2)
+    assert(expectedMsg.size == rcvMsg.size)
+    expectedMsg.foreach { msg =>
+      assert(rcvMsg.exists(_ === msg))
+    }
+  }
+
+  //We need a special case for catchup, because arrays are compared by reference by default
+  private implicit val catchupEq: Equality[JsonMessageAnswerServer] = new Equality[JsonMessageAnswerServer] {
+    override def areEqual(a: JsonMessageAnswerServer, b: Any): Boolean = (a, b) match {
+      case (
+        AnswerResultArrayMessageServer(id1, messages1, _),
+        AnswerResultArrayMessageServer(id2, messages2, _)
+        ) =>
+        id1 == id2 &&
+          messages1.length == messages2.length &&
+          messages1.forall(
+            //As there is no specified order in the list, we need to check at least one element is equals
+            m1 => messages2.exists(m2 => messageEqual(m1, m2))
+          )
+      case _ => a == b
+    }
+
+    private def messageEqual(msg1: MessageContent, msg2: MessageContent): Boolean = {
+      msg1.encodedData == msg2.encodedData &&
+      util.Arrays.equals(msg1.sender, msg2.sender) &&
+        util.Arrays.equals(msg1.signature, msg2.signature) &&
+        util.Arrays.equals(msg1.message_id, msg2.message_id) &&
+        msg1.witness_signatures.length == msg2.witness_signatures.length &&
+        msg1.witness_signatures.zip(msg2.witness_signatures).forall(s => util.Arrays.equals(s._1.witness, s._2.witness)
+          && util.Arrays.equals(s._1.signature, s._2.signature)
+        )
+    }
+
+  }
+
+
+  private def setup(databasePath : String)(implicit system: ActorSystem[SpawnProtocol.Command], timeout: Timeout) = {
+    implicit val ec: ExecutionContext = system.executionContext
+
+    val (entry, exit) = MergeHub.source[PropagateMessageServer].toMat(BroadcastHub.sink)(Keep.both).run()
+    val futureActor: Future[ActorRef[ChannelActor.ChannelMessage]] = system.ask(SpawnProtocol.Spawn(pop.pubsub.ChannelActor(exit),
+      "actor", Props.empty, _))
+    val actor = Await.result(futureActor, 5.seconds)
+    val futureDBActor: Future[ActorRef[DBMessage]] = system.ask(SpawnProtocol.Spawn(DBActor(databasePath), "actorDB", Props.empty, _))
+    val dbActor = Await.result(futureDBActor, 5.seconds)
+
+    (entry, actor, dbActor)
+  }
+
+
+
+  private def getCreateLao(kp: KeyPair, id : Int, laoName: String): CreateLaoMessageClient = {
+
+    val creationTime = pow(2,24).toLong
+    val digest = MessageDigest.getInstance("SHA-256")
+    val pk = kp.getPublicKey
+    val data = "[" +
+    '"' + b64EncodeToString(pk) + "\",\"" +
+    creationTime.toString + "\",\"" +
+    laoName + "\"]"
+    val laoID = digest.digest(data.getBytes(StandardCharsets.UTF_8))
+
+    val laoData : MessageContentData = new MessageContentDataBuilder()
+      .setHeader(Objects.Lao, Actions.Create)
+      .setId(laoID)
+      .setName(laoName)
+      .setCreation(creationTime)
+      .setLastModified(creationTime)
+      .setOrganizer(pk)
+      .setWitnesses(Nil)
+      .build()
+
+    val channel = "/root"
+    val params = getMessageParams(laoData, kp, channel)
+    CreateLaoMessageClient(params, id, Methods.Publish)
+  }
+
+  private def createLaoSetup(kp: KeyPair, name: String = "The best LAO in the world", startingId: Int = 0) = {
+    val createLao = getCreateLao(kp, startingId + 0, name)
+    val laoID =  new String(Base64.getEncoder.encode(createLao.params.message.get.data.id))
+    val channel = "/root/" +laoID
+
+    val state = getBroadcastState(createLao, kp, channel, startingId + 2)
+    val prop = getPropagate(state.params)
+
+    val l: List[(Option[JsonMessagePubSubClient], Option[JsonMessageAnswerServer])] =
+      List((Some(createLao), Some(AnswerResultIntMessageServer(startingId + 0))),
+        (Some(SubscribeMessageClient(MessageParameters(channel, None), startingId + 1)), Some(AnswerResultIntMessageServer(startingId + 1))),
+        (Some(state), Some(AnswerResultIntMessageServer(startingId + 2))),
+        (None, Some(prop))
+      )
+
+    (l, laoID)
+  }
+
+  private def getBroadcastState(create: CreateLaoMessageClient, kp: KeyPair, channel : ChannelName, id: Int): BroadcastLaoMessageClient = {
+
+    val dataCreate = create.params.message.get.data
+    val dataBroadcast = new MessageContentDataBuilder()
+      .setHeader(Objects.Lao, Actions.State)
+      .setId(dataCreate.id)
+      .setName(dataCreate.name)
+      .setCreation(dataCreate.creation)
+      .setLastModified(dataCreate.creation)
+      .setOrganizer(dataCreate.organizer)
+      .setWitnesses(Nil)
+      .setModificationId(create.params.message.get.message_id)
+      .setModificationSignatures(Nil)
+      .build()
+
+    val params = getMessageParams(dataBroadcast, kp, channel)
+    val content = params.message.get
+    println("Broadcast info")
+    println("Content: " + content.encodedData)
+    println("Signature: " + util.Arrays.toString(content.signature))
+    println("Sender: " + util.Arrays.toString(content.sender))
+    println(Signature.verify(content.encodedData, content.signature, content.sender))
+    BroadcastLaoMessageClient(params, id, Methods.Publish)
+  }
+
+  private def getPropagate(params: MessageParameters): PropagateMessageServer = {
+    PropagateMessageServer(params)
+  }
+
+  def getCreateMeeting(laoId: Base64String, kp: KeyPair, id: Int) : CreateMeetingMessageClient = {
+    val name = "My awesome meeting"
+    val creationTime = pow(2,24).toLong
+    val location = "Zoom"
+    val digest = MessageDigest.getInstance("SHA-256")
+    println("Create meeting")
+    println("LaoId: " + util.Arrays.toString(Base64.getDecoder.decode(laoId.getBytes())))
+    println("Creation time: " + creationTime)
+    println("Name: " + name)
+
+    val eventId = Hash.computeMeetingId(Base64.getDecoder.decode(laoId), creationTime, name)
+    val data = new MessageContentDataBuilder()
+      .setHeader(Objects.Meeting, Actions.Create)
+      .setId(eventId)
+      .setName(name)
+      .setCreation(creationTime)
+      .setLastModified(creationTime)
+      .setLocation(location)
+      .setStart(1222222222L)
+      .setEnd(1222222222L + 1L)
+      .build()
+    val channel = "/root/" + laoId
+    val params = getMessageParams(data, kp, channel)
+    println(util.Arrays.equals(Hash.computeMeetingId(Base64.getDecoder.decode(laoId.getBytes()), creationTime, name), params.message.get.data.id))
+    CreateMeetingMessageClient(params, id, Methods.Publish)
+  }
+
+  private def getWitnessMessage(messageId: Base64String, kp: KeyPair, channel: ChannelName, id: Int) = {
+    val signature = sign(kp, b64Decode(messageId))
+
+    val data = new MessageContentDataBuilder()
+      .setHeader(Objects.Message, Actions.Witness)
+      .setMessageId(messageId)
+      .setSignature(signature)
+      .build()
+    val params = getMessageParams(data, kp, channel)
+    WitnessMessageMessageClient(params, id, Methods.Publish)
+  }
+
+  test("Create a LAO, subscribe to its channel and publish the state") {
+    val kp = generateKeyPair()
+    val (l, _) = createLaoSetup(kp)
+    sendAndVerify(l)
+  }
+
+  test("Create a channel, subscribe to it and publish multiple messages") {
+    val kp = generateKeyPair()
+    val (l, laoID) = createLaoSetup(kp)
+
+    val meeting = getCreateMeeting(laoID, kp, 4)
+
+    val messages = List(
+      (Some(meeting),Some(AnswerResultIntMessageServer(4))),
+      (None, Some(getPropagate(meeting.params)))
+    )
+    sendAndVerify(l ::: messages)
+  }
+
+  test("Create multiple LAOs, subscribe to their channel and publish multiple messages") {
+    val kp = generateKeyPair()
+    val (l1, laoID1) = createLaoSetup(kp)
+    val (l2, laoID2) = createLaoSetup(kp, "My new LAO", 3)
+
+    val msg1 = getCreateMeeting(laoID1,kp, 4)
+    val msg2 = getCreateMeeting(laoID2, kp, 5)
+
+    val messages : List[(Option[JsonMessagePubSubClient], Option[JsonMessageAnswerServer])] = List(
+      (Some(msg1), Some(AnswerResultIntMessageServer(4))),
+      (None, Some(getPropagate(msg1.params))),
+      (Some(msg2), Some(AnswerResultIntMessageServer(5))),
+      (None, Some(getPropagate(msg2.params)))
+    )
+
+    sendAndVerify(l1 ::: l2 ::: messages)
+
+  }
+
+  test("Two process subscribe and publish on the same channel") {
+    val kp1 = generateKeyPair()
+    val kp2 = generateKeyPair()
+    val (l, laoID) = createLaoSetup(kp1)
+    val channel = "/root/" + laoID
+    val meeting1 = getCreateMeeting(laoID, kp1, 4)
+    val meeting2 = getCreateMeeting(laoID, kp2, 1)
+
+    val messages: List[(Option[JsonMessagePubSubClient], Option[JsonMessageAnswerServer], Int)] = List(
+      (Some(SubscribeMessageClient(MessageParameters(channel, None), 0)), Some(AnswerResultIntMessageServer(0)), 1),
+      (Some(meeting1), Some(AnswerResultIntMessageServer(4)), 0),
+      (None, Some(getPropagate(meeting1.params)), 0),
+      (None, Some(getPropagate(meeting1.params)), 1),
+      (Some(meeting2), Some(AnswerResultIntMessageServer(1)), 1),
+      (None, Some(getPropagate(meeting2.params)), 1),
+      (None, Some(getPropagate(meeting2.params)), 0)
+    )
+
+    sendAndVerify(l.map{ case (msg, ans) => (msg, ans, 0)} ::: messages, 2)
+  }
+
+  test("Error when subscribing to a channel that does not exist") {
+    val l = List(
+      (Some(SubscribeMessageClient(MessageParameters("/root/unknow", None), 0)),
+      Some(AnswerErrorMessageServer(Some(0), MessageErrorContent(-2, "Invalid resource: channel /root/unknow does not exist."))))
+    )
+    sendAndVerify(l)
+  }
+
+  test("Error when creating an existing LAO") {
+    val kp = generateKeyPair()
+    val laoName = "My LAO"
+    val (l1, _) = createLaoSetup(kp, laoName)
+    val createMsg = getCreateLao(kp, 3, laoName)
+    val laoID =  new String(Base64.getEncoder.encode(createMsg.params.message.get.data.id))
+    val l = List(
+      (Some(createMsg), Some(AnswerErrorMessageServer(Some(3), MessageErrorContent(-3, "Channel /root/"
+        + laoID +  " already exists."))))
+    )
+    sendAndVerify(l1 ::: l)
+  }
+
+
+
+  test("Don't receive messages when unsubscribing from a channel") {
+    val kp = generateKeyPair()
+    val (l1, laoId) = createLaoSetup(kp)
+    val channel = "/root/" + laoId
+    val meeting1 = getCreateMeeting(laoId, kp, 4)
+    val meeting2 = getCreateMeeting(laoId, kp, 5)
+
+    val messages = List(
+      (Some(UnsubscribeMessageClient(MessageParameters(channel, None), 3)), Some(AnswerResultIntMessageServer(3))),
+      (Some(meeting1), Some(AnswerResultIntMessageServer(4))),
+      (None, None)
+    )
+    val root = Behaviors.setup[SpawnProtocol.Command] { context =>
+      SpawnProtocol()
+    }
+
+    val l = l1 ::: messages
+
+    val DatabasePath: String = "database_test"
+    val file = new File(DatabasePath)
+    //Reset db from previous tests
+    val directory = new Directory(file)
+    directory.deleteRecursively()
+
+    implicit val system: ActorSystem[SpawnProtocol.Command] = ActorSystem[SpawnProtocol.Command](root, "test")
+    implicit val timeout: Timeout = Timeout(1, TimeUnit.SECONDS)
+    val (pubEntry, actor, dbActor) = setup(DatabasePath)
+
+    val options: Options = new Options()
+    options.createIfMissing(true)
+
+    val in = l.map(_._1).flatten
+    val out = l.map(_._2).flatten
+
+    val flow = PublishSubscribe.jsonFlow(actor, dbActor)(timeout, system, pubEntry).take(out.length)
+    val sink: Sink[JsonMessage, Future[Seq[JsonMessage]]] = Sink.fold(Seq.empty[JsonMessage])(_ :+ _)
+
+    val future = Source(in).throttle(1, 200.milli).via(flow).runWith(sink)
+    val res = Await.result(future, 5.seconds)
+    assert(res == out)
+  }
+
+  test("Unsubscribe from a channel you are not subscribed to fails") {
+    val l = List(
+      (Some(UnsubscribeMessageClient(MessageParameters("/root/notsubscribed", None), 0)),
+        Some(AnswerErrorMessageServer(Some(0), MessageErrorContent(-2, "Invalid resource: you are not subscribed to channel /root/notsubscribed."))))
+    )
+    sendAndVerify(l)
+  }
+
+  test("Catchup messages on a channel") {
+    val kp = generateKeyPair()
+    val createLao = getCreateLao(kp, 0, "My LAO")
+    val laoId =  new String(Base64.getEncoder.encode(createLao.params.message.get.data.id))
+    val channel = "/root/" + laoId
+    val state = getBroadcastState(createLao, kp, channel, 1)
+    val catchup = CatchupMessageClient(MessageParameters(channel, None), 2)
+    val res = List(createLao.params.message.get, state.params.message.get)
+
+    val l = List(
+      (Some(createLao), Some(AnswerResultIntMessageServer(0))),
+      (Some(state), Some(AnswerResultIntMessageServer(1))),
+      (Some(catchup), Some(AnswerResultArrayMessageServer(2, res)))
+    )
+    sendAndVerify(l)
+  }
+
+  private def createLaoAndWitness() = {
+    val kpOrga = generateKeyPair()
+    val kpWitness = generateKeyPair()
+
+    val createLao = getCreateLao(kpOrga,0, "LAOOOOO")
+    val messageId = new String(b64Encode(createLao.params.message.get.message_id))
+    val channel = "/root/" + new String(b64Encode(createLao.params.message.get.data.id))
+    val witnessLaoCreation = getWitnessMessage(messageId, kpWitness, channel, 0)
+
+    (createLao, witnessLaoCreation)
+
+  }
+
+  test("Create a LAO and witness it") {
+    val (createLao, witnessLaoCreation) = createLaoAndWitness()
+    val l = List(
+      (Some(createLao), Some(AnswerResultIntMessageServer(0))),
+      (Some(witnessLaoCreation), Some(AnswerResultIntMessageServer(0)))
+    )
+    sendAndVerify(l)
+  }
+
+  test("Witness an unknown message") {
+    val kpWitness = generateKeyPair()
+    val witnessInvalid = getWitnessMessage("", kpWitness, "", 0)
+    val l = List(
+      (Some(witnessInvalid),
+        Some(AnswerErrorMessageServer(Some(0), MessageErrorContent(ErrorCodes.InvalidData.id, "The id the witness message refers to does not exist."))))
+    )
+    sendAndVerify(l)
+  }
+
+  test("Signatures are added to messages when witnessing") {
+    val (createLao, witnessLaoCreation) = createLaoAndWitness()
+    val key = witnessLaoCreation.params.message.get.sender
+    val signature = witnessLaoCreation.params.message.get.data.signature
+    val createLaoUpdated = createLao.params.message.get.updateWitnesses(KeySignPair(key, signature))
+
+    val catchup = CatchupMessageClient(MessageParameters(witnessLaoCreation.params.channel, None), 1)
+    val res = List(createLaoUpdated, witnessLaoCreation.params.message.get)
+
+    val l = List(
+      (Some(createLao), Some(AnswerResultIntMessageServer(0))),
+      (Some(witnessLaoCreation), Some(AnswerResultIntMessageServer(0))),
+      (Some(catchup), Some(AnswerResultArrayMessageServer(1, res)))
+    )
+    sendAndVerify(l)
+  }
+}


### PR DESCRIPTION
Here's the first step regarding be2-scala refactoring:
- 33da60a : Copied archived be2-scala project into current version. **No need to review this commit**
- d07dc34 : Added a `model` folder following all other sub-projects structure. **A few notes**:
   - I tried to take the best of both worlds (between fe2 and fe1)
   - The `data/` folder is very similar to both projects. I also defined types which are not present in fe2
   - I decided to follow fe1 path regarding the data builder since it seemed to resemble more the Scala way of doing it
- fc1531f8 : Added `Message` level model (same as both front-ends)
- 15cf438a : *Applied Céline's review comments*
- 6a005c2e : *Moved `Parsable` trait to its rightful place above in the hierarchy*
- 7deab3e7 : Added `Method`  level model (same as both front-ends but extracted the redundant "message" of fe2)
    - ⚠️ contains an error (forgot to add companion objects to all files. See cf7e9fb6)
- bad4298b : *Moved Matching trait higher in the hierarchy*
- 5eda5e0e : Added requests/responses creation model
- 90ff1961 : *Renamed ParamsSimple into Params (because `ParamsWithMessages` are (extends) `Params` and not simple params)*
- cf7e9fb6 : Added missing companion objects for method models (cannot enforce `buildFromJson` without companion object since the method is "static")

*Note*: I noticed that fe2 is *exactly* following the protocol hierarchy. Some of them were not needed anymore/simplified due to protocol changes (e.g. `MessageGeneral` becomes `Message`, `GenericMessage` becomes `JsonRpcMessage`, and changed `Error` messages a bit)

---
ℹ️ The data builder is inside an object (which is probably not the best way of doing it, but I haven't found a better way for now)