### PR TITLE
refactored client to make sockets more generic to add different sockets

### DIFF
--- a/be1-go/cli/organizer/organizer.go
+++ b/be1-go/cli/organizer/organizer.go
@@ -20,9 +20,9 @@ var upgrader = websocket.Upgrader{
 }
 
 // Serve parses the CLI arguments and spawns a hub and a websocket server.
-func Serve(c *cli.Context) error {
-	port := c.Int("port")
-	pk := c.String("public-key")
+func Serve(context *cli.Context) error {
+	port := context.Int("port")
+	pk := context.String("public-key")
 
 	if pk == "" {
 		return xerrors.Errorf("organizer's public key is required")

--- a/be1-go/cli/organizer/organizer.go
+++ b/be1-go/cli/organizer/organizer.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-var Upgrader = websocket.Upgrader{
+var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
 	CheckOrigin:     func(r *http.Request) bool { return true },
@@ -60,7 +60,7 @@ func Serve(c *cli.Context) error {
 }
 
 func serveWs(h hub.Hub, w http.ResponseWriter, r *http.Request) {
-	conn, err := Upgrader.Upgrade(w, r, nil)
+	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		log.Printf("failed to upgrade connection: %v", err)
 		return

--- a/be1-go/cli/pop.go
+++ b/be1-go/cli/pop.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 	"os"
-	"student20_pop/cli/witness"
+	"student20_pop/cli/organizer"
 
 	"github.com/urfave/cli/v2"
 )
@@ -35,7 +35,7 @@ func main() {
 								Value:   9000,
 							},
 						},
-						Action: witness.WitnessServe,
+						Action: organizer.Serve,
 					},
 				},
 			},

--- a/be1-go/cli/pop.go
+++ b/be1-go/cli/pop.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 	"os"
-	"student20_pop/cli/organizer"
+	"student20_pop/cli/witness"
 
 	"github.com/urfave/cli/v2"
 )
@@ -35,7 +35,7 @@ func main() {
 								Value:   9000,
 							},
 						},
-						Action: organizer.Serve,
+						Action: witness.WitnessServe,
 					},
 				},
 			},

--- a/be1-go/hub/base_channel.go
+++ b/be1-go/hub/base_channel.go
@@ -15,7 +15,7 @@ type baseChannel struct {
 	hub *organizerHub
 
 	clientsMu sync.RWMutex
-	clients   map[*Client]struct{}
+	clients   map[*ClientSocket]struct{}
 
 	inboxMu sync.RWMutex
 	inbox   map[string]message.Message
@@ -32,12 +32,12 @@ func createBaseChannel(h *organizerHub, channelID string) *baseChannel {
 	return &baseChannel{
 		hub:       h,
 		channelID: channelID,
-		clients:   make(map[*Client]struct{}),
+		clients:   make(map[*ClientSocket]struct{}),
 		inbox:     make(map[string]message.Message),
 	}
 }
 
-func (c *baseChannel) Subscribe(client *Client, msg message.Subscribe) error {
+func (c *baseChannel) Subscribe(client *ClientSocket, msg message.Subscribe) error {
 	log.Printf("received a subscribe with id: %d", msg.ID)
 	c.clientsMu.Lock()
 	defer c.clientsMu.Unlock()
@@ -47,7 +47,7 @@ func (c *baseChannel) Subscribe(client *Client, msg message.Subscribe) error {
 	return nil
 }
 
-func (c *baseChannel) Unsubscribe(client *Client, msg message.Unsubscribe) error {
+func (c *baseChannel) Unsubscribe(client *ClientSocket, msg message.Unsubscribe) error {
 	log.Printf("received an unsubscribe with id: %d", msg.ID)
 
 	c.clientsMu.Lock()

--- a/be1-go/hub/hub.go
+++ b/be1-go/hub/hub.go
@@ -1,6 +1,8 @@
 package hub
 
-import "student20_pop/message"
+import (
+	"student20_pop/message"
+)
 
 // Hub defines the methods a PoP server must implement to receive messages
 // and handle clients.
@@ -9,21 +11,21 @@ type Hub interface {
 
 	Recv(msg IncomingMessage)
 
-	RemoveClient(client *Client)
+	RemoveClientSocket(client *ClientSocket)
 }
 
 // IncomingMessage wraps the raw message from the websocket connection and pairs
 // it with a `Client` instance.
 type IncomingMessage struct {
-	Client  *Client
+	Socket  *Socket
 	Message []byte
 }
 
 // Channel represents a PoP channel - like a LAO.
 type Channel interface {
-	Subscribe(client *Client, msg message.Subscribe) error
+	Subscribe(client *ClientSocket, msg message.Subscribe) error
 
-	Unsubscribe(client *Client, msg message.Unsubscribe) error
+	Unsubscribe(client *ClientSocket, msg message.Unsubscribe) error
 
 	Publish(msg message.Publish) error
 

--- a/be1-go/hub/hub.go
+++ b/be1-go/hub/hub.go
@@ -17,7 +17,7 @@ type Hub interface {
 // IncomingMessage wraps the raw message from the websocket connection and pairs
 // it with a `Client` instance.
 type IncomingMessage struct {
-	Socket  *Socket
+	Socket  *baseSocket
 	Message []byte
 }
 

--- a/be1-go/hub/organizer.go
+++ b/be1-go/hub/organizer.go
@@ -35,7 +35,7 @@ func NewOrganizerHub(public kyber.Point) Hub {
 }
 
 // RemoveClient removes the client from this hub.
-func (o *organizerHub) RemoveClient(client *Client) {
+func (o *organizerHub) RemoveClientSocket(client *ClientSocket) {
 	o.RLock()
 	defer o.RUnlock()
 
@@ -53,7 +53,10 @@ func (o *organizerHub) Recv(msg IncomingMessage) {
 func (o *organizerHub) handleIncomingMessage(incomingMessage *IncomingMessage) {
 	log.Printf("organizerHub::handleIncomingMessage: %s", incomingMessage.Message)
 
-	client := incomingMessage.Client
+	socket := incomingMessage.Socket
+	client := &ClientSocket {
+		Socket: *socket,
+	}
 
 	// unmarshal the message
 	genericMsg := &message.GenericMessage{}

--- a/be1-go/hub/organizer.go
+++ b/be1-go/hub/organizer.go
@@ -60,7 +60,7 @@ func (o *organizerHub) handleIncomingMessage(incomingMessage *IncomingMessage) {
 			hub:        socket.hub,
 			conn:       socket.conn,
 			send:       socket.send,
-			Wait:       socket.Wait,
+			Wait:       sync.WaitGroup{},
 		},
 	}
 

--- a/be1-go/hub/organizer.go
+++ b/be1-go/hub/organizer.go
@@ -173,11 +173,10 @@ func (o *organizerHub) handleMessageFromClient(incomingMessage *IncomingMessage)
 
 func (o *organizerHub) handleMessageFromWitness(incomingMessage *IncomingMessage) {
 	//TODO
-	return
 }
 
 func (o *organizerHub) handleIncomingMessage(incomingMessage *IncomingMessage) {
-	log.Printf("organizerHub::handleIncomingMessage: %s", incomingMessage.Message)
+	log.Printf("organizerHub::handleMessageFromClient: %s", incomingMessage.Message)
 
 	switch (incomingMessage.Socket.socketType) {
 	case clientSocket:

--- a/be1-go/hub/organizer.go
+++ b/be1-go/hub/organizer.go
@@ -172,7 +172,8 @@ func (o *organizerHub) handleMessageFromClient(incomingMessage *IncomingMessage)
 }
 
 func handleMessageFromWitness(incomingMessage *IncomingMessage) {
-
+	//TODO
+	return
 }
 
 func (o *organizerHub) handleIncomingMessage(incomingMessage *IncomingMessage) {

--- a/be1-go/hub/organizer.go
+++ b/be1-go/hub/organizer.go
@@ -54,8 +54,14 @@ func (o *organizerHub) handleIncomingMessage(incomingMessage *IncomingMessage) {
 	log.Printf("organizerHub::handleIncomingMessage: %s", incomingMessage.Message)
 
 	socket := incomingMessage.Socket
-	client := &ClientSocket {
-		Socket: *socket,
+	client := ClientSocket{
+		Socket{
+			socketType: clientSocket,
+			hub:        socket.hub,
+			conn:       socket.conn,
+			send:       socket.send,
+			Wait:       socket.Wait,
+		},
 	}
 
 	// unmarshal the message
@@ -144,9 +150,9 @@ func (o *organizerHub) handleIncomingMessage(incomingMessage *IncomingMessage) {
 	// TODO: use constants
 	switch method {
 	case "subscribe":
-		err = channel.Subscribe(client, *query.Subscribe)
+		err = channel.Subscribe(&client, *query.Subscribe)
 	case "unsubscribe":
-		err = channel.Unsubscribe(client, *query.Unsubscribe)
+		err = channel.Unsubscribe(&client, *query.Unsubscribe)
 	case "publish":
 		err = channel.Publish(*query.Publish)
 	case "message":

--- a/be1-go/hub/organizer.go
+++ b/be1-go/hub/organizer.go
@@ -50,18 +50,9 @@ func (o *organizerHub) Recv(msg IncomingMessage) {
 	o.messageChan <- msg
 }
 
-func (o *organizerHub) handleIncomingMessage(incomingMessage *IncomingMessage) {
-	log.Printf("organizerHub::handleIncomingMessage: %s", incomingMessage.Message)
-
-	socket := incomingMessage.Socket
+func (o *organizerHub) handleMessageFromClient(incomingMessage *IncomingMessage) {
 	client := ClientSocket{
-		Socket{
-			socketType: clientSocket,
-			hub:        socket.hub,
-			conn:       socket.conn,
-			send:       socket.send,
-			Wait:       sync.WaitGroup{},
-		},
+		incomingMessage.Socket,
 	}
 
 	// unmarshal the message
@@ -178,6 +169,24 @@ func (o *organizerHub) handleIncomingMessage(incomingMessage *IncomingMessage) {
 	}
 
 	client.SendResult(id, result)
+}
+
+func handleMessageFromWitness(incomingMessage *IncomingMessage) {
+
+}
+
+func (o *organizerHub) handleIncomingMessage(incomingMessage *IncomingMessage) {
+	log.Printf("organizerHub::handleIncomingMessage: %s", incomingMessage.Message)
+
+	switch (incomingMessage.Socket.socketType) {
+	case clientSocket:
+		o.handleMessageFromClient(incomingMessage)
+		return
+	case witnessSocket:
+		handleMessageFromWitness(incomingMessage)
+		return
+	}
+
 }
 
 func (o *organizerHub) Start(done chan struct{}) {

--- a/be1-go/hub/organizer.go
+++ b/be1-go/hub/organizer.go
@@ -171,7 +171,7 @@ func (o *organizerHub) handleMessageFromClient(incomingMessage *IncomingMessage)
 	client.SendResult(id, result)
 }
 
-func handleMessageFromWitness(incomingMessage *IncomingMessage) {
+func (o *organizerHub) handleMessageFromWitness(incomingMessage *IncomingMessage) {
 	//TODO
 	return
 }
@@ -184,7 +184,10 @@ func (o *organizerHub) handleIncomingMessage(incomingMessage *IncomingMessage) {
 		o.handleMessageFromClient(incomingMessage)
 		return
 	case witnessSocket:
-		handleMessageFromWitness(incomingMessage)
+		o.handleMessageFromWitness(incomingMessage)
+		return
+	default:
+		log.Printf("error: invalid socket type")
 		return
 	}
 

--- a/be1-go/hub/socket.go
+++ b/be1-go/hub/socket.go
@@ -57,7 +57,7 @@ func (s *baseSocket) ReadPump() {
 
 	s.Wait.Add(1)
 
-	log.Printf("listening for messages from socket")
+	log.Printf("listening for messages from %s", s.socketType)
 
 	s.conn.SetReadLimit(maxMessageSize)
 	s.conn.SetReadDeadline(time.Now().Add(pongWait))

--- a/be1-go/hub/socket_types.go
+++ b/be1-go/hub/socket_types.go
@@ -1,0 +1,46 @@
+package hub
+
+import (
+	"github.com/gorilla/websocket"
+	"sync"
+)
+
+// socket types
+const (
+	clientSocket = "client"
+	organizerSocket = "organizer"
+	witnessSocket = "witness"
+)
+
+type ClientSocket struct {
+	Socket
+}
+
+// NewClient returns an instance of a Socket.
+func NewClientSocket (h Hub, conn *websocket.Conn) *ClientSocket {
+	return &ClientSocket {
+		Socket {
+			socketType: clientSocket,
+			hub:  h,
+			conn: conn,
+			send: make(chan []byte, 256),
+			Wait: sync.WaitGroup{},
+		},
+	}
+}
+
+type OrganizerSocket struct {
+	Socket
+}
+
+func NewOrganizerSocket(h Hub, conn *websocket.Conn) *OrganizerSocket {
+	return &OrganizerSocket {
+		Socket {
+			socketType: organizerSocket,
+			hub:  h,
+			conn: conn,
+			send: make(chan []byte, 256),
+			Wait: sync.WaitGroup{},
+		},
+	}
+}

--- a/be1-go/hub/socket_types.go
+++ b/be1-go/hub/socket_types.go
@@ -6,57 +6,51 @@ import (
 )
 
 // socket types
+type SocketType string
+
 const (
-	clientSocket = "client"
-	organizerSocket = "organizer"
-	witnessSocket = "witness"
+	clientSocket SocketType = "client"
+	organizerSocket SocketType= "organizer"
+	witnessSocket SocketType= "witness"
 )
 
-type ClientSocket struct {
-	Socket
+func newSocket(socketType SocketType, h Hub, conn *websocket.Conn) *baseSocket {
+	return &baseSocket {
+		socketType: socketType,
+		hub:  h,
+		conn: conn,
+		send: make(chan []byte, 256),
+		Wait: sync.WaitGroup{},
+	}
 }
 
-// NewClient returns an instance of a Socket.
+type ClientSocket struct {
+	*baseSocket
+}
+
+// NewClient returns an instance of a baseSocket.
 func NewClientSocket (h Hub, conn *websocket.Conn) *ClientSocket {
-	return &ClientSocket {
-		Socket {
-			socketType: clientSocket,
-			hub:  h,
-			conn: conn,
-			send: make(chan []byte, 256),
-			Wait: sync.WaitGroup{},
-		},
+	return &ClientSocket{
+		newSocket(clientSocket, h, conn),
 	}
 }
 
 type OrganizerSocket struct {
-	Socket
+	*baseSocket
 }
 
 func NewOrganizerSocket(h Hub, conn *websocket.Conn) *OrganizerSocket {
 	return &OrganizerSocket {
-		Socket {
-			socketType: organizerSocket,
-			hub:  h,
-			conn: conn,
-			send: make(chan []byte, 256),
-			Wait: sync.WaitGroup{},
-		},
+		newSocket(organizerSocket, h, conn),
 	}
 }
 
 type WitnessSocket struct {
-	Socket
+	*baseSocket
 }
 
 func NewWitnessSocket(h Hub, conn *websocket.Conn) *WitnessSocket {
 	return &WitnessSocket {
-		Socket {
-			socketType: witnessSocket,
-			hub:  h,
-			conn: conn,
-			send: make(chan []byte, 256),
-			Wait: sync.WaitGroup{},
-		},
+		newSocket(witnessSocket, h, conn),
 	}
 }

--- a/be1-go/hub/socket_types.go
+++ b/be1-go/hub/socket_types.go
@@ -44,3 +44,19 @@ func NewOrganizerSocket(h Hub, conn *websocket.Conn) *OrganizerSocket {
 		},
 	}
 }
+
+type WitnessSocket struct {
+	Socket
+}
+
+func NewWitnessSocket(h Hub, conn *websocket.Conn) *WitnessSocket {
+	return &WitnessSocket {
+		Socket {
+			socketType: witnessSocket,
+			hub:  h,
+			conn: conn,
+			send: make(chan []byte, 256),
+			Wait: sync.WaitGroup{},
+		},
+	}
+}


### PR DESCRIPTION
I renamed the Client type Socket and created a type ClientSocket composed of a Socket (struct embedding) in order to allow the creation of types OrganizerSocket and WitnessSocket, to enable connections firstly between an organizer, witnesses and clients.