### PR TITLE
Updated the tests in accordance to the protocol change from PR #287

### DIFF
--- a/fe1-web/__tests__/model/network/FromJsonData.test.ts
+++ b/fe1-web/__tests__/model/network/FromJsonData.test.ts
@@ -118,7 +118,7 @@ describe('=== fromJsonData checks ===', () => {
     proposed_start: time,
     proposed_end: CLOSE_TIMESTAMP,
     location: location,
-    description: 'description du rc',
+    description: 'Roll Call description',
   };
 
   const sampleOpenRollCall: Partial<OpenRollCall> = {
@@ -182,7 +182,7 @@ describe('=== fromJsonData checks ===', () => {
   const dataCreateRollCall: string = dataRollCall
     .replace('F_ACTION', ActionType.CREATE)
     .replace('FF_MODIFICATION', `"id": "${rollCallId.toString()}","name":"${name}","creation":${time},
-    "proposed_start":${time},"proposed_end":${CLOSE_TIMESTAMP},"location":"${location}","description":"description du rc"`);
+    "proposed_start":${time},"proposed_end":${CLOSE_TIMESTAMP},"location":"${location}","description":"Roll Call description"`);
   const dataOpenRollCall: string = dataRollCall
     .replace('F_ACTION', ActionType.OPEN)
     .replace('FF_MODIFICATION', `"update_id":"${rollCallId.toString()}","opens":"${rollCallId.toString()}","opened_at":${time}`);

--- a/fe1-web/__tests__/model/network/FromJsonData.test.ts
+++ b/fe1-web/__tests__/model/network/FromJsonData.test.ts
@@ -115,8 +115,8 @@ describe('=== fromJsonData checks ===', () => {
     id: rollCallId,
     name: name,
     creation: time,
-    proposed_start: time,
-    proposed_end: CLOSE_TIMESTAMP,
+    proposedStart: time,
+    proposedEnd: CLOSE_TIMESTAMP,
     location: location,
     description: 'description du rc',
   };
@@ -124,25 +124,25 @@ describe('=== fromJsonData checks ===', () => {
   const sampleOpenRollCall: Partial<OpenRollCall> = {
     object: ObjectType.ROLL_CALL,
     action: ActionType.OPEN,
-    update_id: rollCallId,
+    updateId: rollCallId,
     opens: rollCallId,
-    opened_at: time,
+    openedAt: time,
   };
 
   const sampleReopenRollCall: Partial<OpenRollCall> = {
     object: ObjectType.ROLL_CALL,
     action: ActionType.REOPEN,
-    update_id: rollCallId,
+    updateId: rollCallId,
     opens: rollCallId,
-    opened_at: time,
+    openedAt: time,
   };
 
   const sampleCloseRollCall: Partial<CloseRollCall> = {
     object: ObjectType.ROLL_CALL,
     action: ActionType.CLOSE,
-    update_id: rollCallId,
+    updateId: rollCallId,
     closes: rollCallId,
-    closed_at: CLOSE_TIMESTAMP,
+    closedAt: CLOSE_TIMESTAMP,
     attendees: [],
   };
 
@@ -329,8 +329,8 @@ describe('=== fromJsonData checks ===', () => {
           id: rollCallId,
           name: name,
           creation: STANDARD_TIMESTAMP,
-          proposed_start: STANDARD_TIMESTAMP,
-          proposed_end: CLOSE_TIMESTAMP,
+          proposedStart: STANDARD_TIMESTAMP,
+          proposedEnd: CLOSE_TIMESTAMP,
           location: 'Lausanne',
         };
         expect(new CreateRollCall(temp)).toBeJsonEqual(temp);
@@ -340,8 +340,8 @@ describe('=== fromJsonData checks ===', () => {
           id: rollCallId,
           name: name,
           creation: STANDARD_TIMESTAMP,
-          proposed_start: STANDARD_TIMESTAMP,
-          proposed_end: FUTURE_TIMESTAMP,
+          proposedStart: STANDARD_TIMESTAMP,
+          proposedEnd: FUTURE_TIMESTAMP,
           location: 'Lausanne',
           description: 'Roll Call creation',
         };
@@ -364,9 +364,9 @@ describe('=== fromJsonData checks ===', () => {
         temp = {
           object: ObjectType.ROLL_CALL,
           action: ActionType.CLOSE,
-          update_id: rollCallId,
+          updateId: rollCallId,
           closes: rollCallId,
-          closed_at: FUTURE_TIMESTAMP,
+          closedAt: FUTURE_TIMESTAMP,
           attendees: [sampleKey1, sampleKey2],
         };
         expect(new CloseRollCall(temp)).toBeJsonEqual(temp);

--- a/fe1-web/__tests__/model/network/FromJsonData.test.ts
+++ b/fe1-web/__tests__/model/network/FromJsonData.test.ts
@@ -115,9 +115,10 @@ describe('=== fromJsonData checks ===', () => {
     id: rollCallId,
     name: name,
     creation: time,
-    start: time,
+    proposed_start: time,
+    proposed_end: CLOSE_TIMESTAMP,
     location: location,
-    roll_call_description: 'description du rc',
+    description: 'description du rc',
   };
 
   const sampleOpenRollCall: Partial<OpenRollCall> = {
@@ -125,7 +126,7 @@ describe('=== fromJsonData checks ===', () => {
     action: ActionType.OPEN,
     update_id: rollCallId,
     opens: rollCallId,
-    start: time,
+    opened_at: time,
   };
 
   const sampleReopenRollCall: Partial<OpenRollCall> = {
@@ -133,7 +134,7 @@ describe('=== fromJsonData checks ===', () => {
     action: ActionType.REOPEN,
     update_id: rollCallId,
     opens: rollCallId,
-    start: time,
+    opened_at: time,
   };
 
   const sampleCloseRollCall: Partial<CloseRollCall> = {
@@ -141,7 +142,7 @@ describe('=== fromJsonData checks ===', () => {
     action: ActionType.CLOSE,
     update_id: rollCallId,
     closes: rollCallId,
-    end: FUTURE_TIMESTAMP,
+    closed_at: FUTURE_TIMESTAMP,
     attendees: [],
   };
 

--- a/fe1-web/__tests__/model/network/FromJsonData.test.ts
+++ b/fe1-web/__tests__/model/network/FromJsonData.test.ts
@@ -181,7 +181,8 @@ describe('=== fromJsonData checks ===', () => {
     );
   const dataCreateRollCall: string = dataRollCall
     .replace('F_ACTION', ActionType.CREATE)
-    .replace('FF_MODIFICATION', `"id": "${rollCallId.toString()}","name":"${name}","creation":${time},"proposed_start":${time},"proposed_end":${CLOSE_TIMESTAMP},"location":"${location}","description":"description du rc"`);
+    .replace('FF_MODIFICATION', `"id": "${rollCallId.toString()}","name":"${name}","creation":${time},
+    "proposed_start":${time},"proposed_end":${CLOSE_TIMESTAMP},"location":"${location}","description":"description du rc"`);
   const dataOpenRollCall: string = dataRollCall
     .replace('F_ACTION', ActionType.OPEN)
     .replace('FF_MODIFICATION', `"update_id":"${rollCallId.toString()}","opens":"${rollCallId.toString()}","opened_at":${time}`);

--- a/fe1-web/__tests__/model/network/FromJsonData.test.ts
+++ b/fe1-web/__tests__/model/network/FromJsonData.test.ts
@@ -115,8 +115,8 @@ describe('=== fromJsonData checks ===', () => {
     id: rollCallId,
     name: name,
     creation: time,
-    proposedStart: time,
-    proposedEnd: CLOSE_TIMESTAMP,
+    proposed_start: time,
+    proposed_end: CLOSE_TIMESTAMP,
     location: location,
     description: 'description du rc',
   };
@@ -124,25 +124,25 @@ describe('=== fromJsonData checks ===', () => {
   const sampleOpenRollCall: Partial<OpenRollCall> = {
     object: ObjectType.ROLL_CALL,
     action: ActionType.OPEN,
-    updateId: rollCallId,
+    update_id: rollCallId,
     opens: rollCallId,
-    openedAt: time,
+    opened_at: time,
   };
 
   const sampleReopenRollCall: Partial<OpenRollCall> = {
     object: ObjectType.ROLL_CALL,
     action: ActionType.REOPEN,
-    updateId: rollCallId,
+    update_id: rollCallId,
     opens: rollCallId,
-    openedAt: time,
+    opened_at: time,
   };
 
   const sampleCloseRollCall: Partial<CloseRollCall> = {
     object: ObjectType.ROLL_CALL,
     action: ActionType.CLOSE,
-    updateId: rollCallId,
+    update_id: rollCallId,
     closes: rollCallId,
-    closedAt: CLOSE_TIMESTAMP,
+    closed_at: CLOSE_TIMESTAMP,
     attendees: [],
   };
 
@@ -329,8 +329,8 @@ describe('=== fromJsonData checks ===', () => {
           id: rollCallId,
           name: name,
           creation: STANDARD_TIMESTAMP,
-          proposedStart: STANDARD_TIMESTAMP,
-          proposedEnd: CLOSE_TIMESTAMP,
+          proposed_start: STANDARD_TIMESTAMP,
+          proposed_end: CLOSE_TIMESTAMP,
           location: 'Lausanne',
         };
         expect(new CreateRollCall(temp)).toBeJsonEqual(temp);
@@ -340,8 +340,8 @@ describe('=== fromJsonData checks ===', () => {
           id: rollCallId,
           name: name,
           creation: STANDARD_TIMESTAMP,
-          proposedStart: STANDARD_TIMESTAMP,
-          proposedEnd: FUTURE_TIMESTAMP,
+          proposed_start: STANDARD_TIMESTAMP,
+          proposed_end: FUTURE_TIMESTAMP,
           location: 'Lausanne',
           description: 'Roll Call creation',
         };
@@ -364,9 +364,9 @@ describe('=== fromJsonData checks ===', () => {
         temp = {
           object: ObjectType.ROLL_CALL,
           action: ActionType.CLOSE,
-          updateId: rollCallId,
+          update_id: rollCallId,
           closes: rollCallId,
-          closedAt: FUTURE_TIMESTAMP,
+          closed_at: FUTURE_TIMESTAMP,
           attendees: [sampleKey1, sampleKey2],
         };
         expect(new CloseRollCall(temp)).toBeJsonEqual(temp);

--- a/fe1-web/__tests__/model/network/FromJsonData.test.ts
+++ b/fe1-web/__tests__/model/network/FromJsonData.test.ts
@@ -142,7 +142,7 @@ describe('=== fromJsonData checks ===', () => {
     action: ActionType.CLOSE,
     update_id: rollCallId,
     closes: rollCallId,
-    closed_at: FUTURE_TIMESTAMP,
+    closed_at: CLOSE_TIMESTAMP,
     attendees: [],
   };
 
@@ -181,16 +181,16 @@ describe('=== fromJsonData checks ===', () => {
     );
   const dataCreateRollCall: string = dataRollCall
     .replace('F_ACTION', ActionType.CREATE)
-    .replace('FF_MODIFICATION', `"id": "${rollCallId.toString()}","name":"${name}","creation":${time},"start":${time},"location":"${location}","roll_call_description":"description du rc"`);
+    .replace('FF_MODIFICATION', `"id": "${rollCallId.toString()}","name":"${name}","creation":${time},"proposed_start":${time},"proposed_end":${CLOSE_TIMESTAMP},"location":"${location}","description":"description du rc"`);
   const dataOpenRollCall: string = dataRollCall
     .replace('F_ACTION', ActionType.OPEN)
-    .replace('FF_MODIFICATION', `"update_id":"${rollCallId.toString()}","opens":"${rollCallId.toString()}","start":${time}`);
+    .replace('FF_MODIFICATION', `"update_id":"${rollCallId.toString()}","opens":"${rollCallId.toString()}","opened_at":${time}`);
   const dataReopenRollCall: string = dataRollCall
     .replace('F_ACTION', ActionType.REOPEN)
-    .replace('FF_MODIFICATION', `"update_id":"${rollCallId.toString()}","opens":"${rollCallId.toString()}","start":${time}`);
+    .replace('FF_MODIFICATION', `"update_id":"${rollCallId.toString()}","opens":"${rollCallId.toString()}","opened_at":${time}`);
   const dataCloseRollCall: string = dataRollCall
     .replace('F_ACTION', ActionType.CLOSE)
-    .replace('FF_MODIFICATION', `"update_id":"${rollCallId.toString()}","closes":"${rollCallId.toString()}","end":${FUTURE_TIMESTAMP.toString()},"attendees":[]`);
+    .replace('FF_MODIFICATION', `"update_id":"${rollCallId.toString()}","closes":"${rollCallId.toString()}","closed_at":${CLOSE_TIMESTAMP},"attendees":[]`);
 
   beforeAll(() => {
     storeInit();
@@ -329,7 +329,8 @@ describe('=== fromJsonData checks ===', () => {
           id: rollCallId,
           name: name,
           creation: STANDARD_TIMESTAMP,
-          start: time,
+          proposed_start: STANDARD_TIMESTAMP,
+          proposed_end: CLOSE_TIMESTAMP,
           location: 'Lausanne',
         };
         expect(new CreateRollCall(temp)).toBeJsonEqual(temp);
@@ -339,8 +340,10 @@ describe('=== fromJsonData checks ===', () => {
           id: rollCallId,
           name: name,
           creation: STANDARD_TIMESTAMP,
-          scheduled: time,
+          proposed_start: STANDARD_TIMESTAMP,
+          proposed_end: FUTURE_TIMESTAMP,
           location: 'Lausanne',
+          description: 'Roll Call creation',
         };
         expect(new CreateRollCall(temp)).toBeJsonEqual(temp);
       });
@@ -363,7 +366,7 @@ describe('=== fromJsonData checks ===', () => {
           action: ActionType.CLOSE,
           update_id: rollCallId,
           closes: rollCallId,
-          end: FUTURE_TIMESTAMP,
+          closed_at: FUTURE_TIMESTAMP,
           attendees: [sampleKey1, sampleKey2],
         };
         expect(new CloseRollCall(temp)).toBeJsonEqual(temp);

--- a/fe1-web/__tests__/network/MessageApi.test.ts
+++ b/fe1-web/__tests__/network/MessageApi.test.ts
@@ -335,9 +335,10 @@ function checkDataOpenRollCall(obj: MessageData) {
   const data: OpenRollCall = obj as OpenRollCall;
 
   expect(data).toBeObject();
-  expect(data).toContainKeys([...defaultDataFields, 'update_id', 'opened_at']);
+  expect(data).toContainKeys([...defaultDataFields, 'update_id', 'opens', 'opened_at']);
 
   expect(data.update_id).toBeBase64();
+  expect(data.opens).toBeBase64();
 
   expect(data.opened_at).toBeNumberObject();
   expect(data.opened_at.valueOf()).toBeGreaterThan(0);
@@ -355,10 +356,10 @@ function checkDataReopenRollCall(obj: MessageData) {
 
   const data: ReopenRollCall = obj as ReopenRollCall;
 
-  expect(data).toContainKeys([...defaultDataFields, 'id', 'opened_at']);
+  expect(data).toContainKeys([...defaultDataFields, 'id', 'opens', 'opened_at']);
 
   expect(data.update_id).toBeBase64();
-
+  expect(data.opens).toBeBase64();
   expect(data.opened_at).toBeNumberObject();
   expect(data.opened_at.valueOf()).toBeGreaterThan(0);
 

--- a/fe1-web/__tests__/network/MessageApi.test.ts
+++ b/fe1-web/__tests__/network/MessageApi.test.ts
@@ -308,7 +308,6 @@ function checkDataCreateRollCall(obj: MessageData) {
   // @ts-ignore
   expect(data.proposed_start.valueOf() + 1).toBeGreaterThan(data.creation.valueOf());
 
-
   expect(data.proposed_end).toBeNumberObject();
   // @ts-ignore
   expect(data.proposed_end.valueOf()).toBeGreaterThan(0);

--- a/fe1-web/__tests__/network/MessageApi.test.ts
+++ b/fe1-web/__tests__/network/MessageApi.test.ts
@@ -303,19 +303,19 @@ function checkDataCreateRollCall(obj: MessageData) {
   expect(data.creation.valueOf()).toBeGreaterThan(0);
 
   if ('proposed_start' in data) {
-    expect(data.proposed_start).toBeNumberObject();
+    expect(data.proposedStart).toBeNumberObject();
     // @ts-ignore
-    expect(data.proposed_start.valueOf()).toBeGreaterThan(0);
+    expect(data.proposedStart.valueOf()).toBeGreaterThan(0);
     // @ts-ignore
-    expect(data.proposed_start.valueOf() + 1).toBeGreaterThan(data.creation.valueOf());
+    expect(data.proposedStart.valueOf() + 1).toBeGreaterThan(data.creation.valueOf());
   }
 
   if ('proposed_end' in data) {
-    expect(data.proposed_end).toBeNumberObject();
+    expect(data.proposedEnd).toBeNumberObject();
     // @ts-ignore
-    expect(data.proposed_end.valueOf()).toBeGreaterThan(0);
+    expect(data.proposedEnd.valueOf()).toBeGreaterThan(0);
     // @ts-ignore
-    expect(data.proposed_end.valueOf() + 1).toBeGreaterThan(data.creation.valueOf());
+    expect(data.proposedEnd.valueOf() + 1).toBeGreaterThan(data.creation.valueOf());
   }
 
   expect(data.location).toBeString();
@@ -341,14 +341,14 @@ function checkDataOpenRollCall(obj: MessageData) {
   expect(data).toBeObject();
   expect(data).toContainKeys([...defaultDataFields, 'update_id', 'opened_at']);
 
-  expect(data.update_id).toBeBase64();
+  expect(data.updateId).toBeBase64();
 
-  expect(data.opened_at).toBeNumberObject();
-  expect(data.opened_at.valueOf()).toBeGreaterThan(0);
+  expect(data.openedAt).toBeNumberObject();
+  expect(data.openedAt.valueOf()).toBeGreaterThan(0);
 
   // check id
   const expected = Hash.fromStringArray('R', OpenedLaoStore.get().id.toString(), '444', 'r-cName'); // 444 and r-cName are for now hardocded in the APi
-  expect(data.update_id).toEqual(expected);
+  expect(data.updateId).toEqual(expected);
 }
 
 // FIXME remove eslint warning when function used
@@ -361,14 +361,14 @@ function checkDataReopenRollCall(obj: MessageData) {
 
   expect(data).toContainKeys([...defaultDataFields, 'id', 'opened_at']);
 
-  expect(data.update_id).toBeBase64();
+  expect(data.updateId).toBeBase64();
 
-  expect(data.opened_at).toBeNumberObject();
-  expect(data.opened_at.valueOf()).toBeGreaterThan(0);
+  expect(data.openedAt).toBeNumberObject();
+  expect(data.openedAt.valueOf()).toBeGreaterThan(0);
 
   // check id
   const expected = Hash.fromStringArray('R', OpenedLaoStore.get().id.toString(), '444', 'r-cName'); // 444 and r-cName are for now hardocded in the APi
-  expect(data.update_id).toEqual(expected);
+  expect(data.updateId).toEqual(expected);
 }
 
 // FIXME remove eslint warning when function used
@@ -382,17 +382,17 @@ function checkDataCloseRollCall(obj: MessageData) {
   expect(data).toBeObject();
   expect(data).toContainKeys([...defaultDataFields, 'update_id', 'closes', 'closed_at', 'attendees']);
 
-  expect(data.update_id).toBeBase64();
+  expect(data.updateId).toBeBase64();
 
-  expect(data.closed_at).toBeNumberObject();
-  expect(data.closed_at.valueOf()).toBeGreaterThan(0);
+  expect(data.closedAt).toBeNumberObject();
+  expect(data.closedAt.valueOf()).toBeGreaterThan(0);
 
   expect(data.attendees).toBeBase64Array();
   expect(data.attendees).toBeDistinctArray();
 
   // check id
   const expected = Hash.fromStringArray('R', OpenedLaoStore.get().id.toString(), '444', 'r-cName'); // 444 and r-cName are for now hardocded in the APi
-  expect(data.update_id).toEqual(expected);
+  expect(data.updateId).toEqual(expected);
 }
 
 describe('=== WebsocketApi tests ===', () => {

--- a/fe1-web/__tests__/network/MessageApi.test.ts
+++ b/fe1-web/__tests__/network/MessageApi.test.ts
@@ -454,15 +454,10 @@ describe('=== WebsocketApi tests ===', () => {
 
     it('should create the correct request for requestCreateRollCall', async () => {
       setMockCheck(checkDataCreateRollCall);
-      const mockScheduledTime = new Timestamp(mockStartTime.valueOf() + 1);
       const mockDescription = 'random description';
-      await msApi.requestCreateRollCall(mockEventName, mockLocation, mockStartTime);
-      await msApi.requestCreateRollCall(mockEventName, mockLocation, undefined, mockScheduledTime);
+      await msApi.requestCreateRollCall(mockEventName, mockLocation, mockStartTime, mockEndTime);
       await msApi.requestCreateRollCall(
-        mockEventName, mockLocation, mockStartTime, undefined, mockDescription,
-      );
-      await msApi.requestCreateRollCall(
-        mockEventName, mockLocation, undefined, mockScheduledTime, mockDescription,
+        mockEventName, mockLocation, mockStartTime, mockEndTime, mockDescription,
       );
     });
     /*

--- a/fe1-web/__tests__/network/MessageApi.test.ts
+++ b/fe1-web/__tests__/network/MessageApi.test.ts
@@ -302,21 +302,18 @@ function checkDataCreateRollCall(obj: MessageData) {
   expect(data.creation).toBeNumberObject();
   expect(data.creation.valueOf()).toBeGreaterThan(0);
 
-  if ('proposed_start' in data) {
-    expect(data.proposedStart).toBeNumberObject();
-    // @ts-ignore
-    expect(data.proposedStart.valueOf()).toBeGreaterThan(0);
-    // @ts-ignore
-    expect(data.proposedStart.valueOf() + 1).toBeGreaterThan(data.creation.valueOf());
-  }
+  expect(data.proposed_start).toBeNumberObject();
+  // @ts-ignore
+  expect(data.proposed_start.valueOf()).toBeGreaterThan(0);
+  // @ts-ignore
+  expect(data.proposed_start.valueOf() + 1).toBeGreaterThan(data.creation.valueOf());
 
-  if ('proposed_end' in data) {
-    expect(data.proposedEnd).toBeNumberObject();
-    // @ts-ignore
-    expect(data.proposedEnd.valueOf()).toBeGreaterThan(0);
-    // @ts-ignore
-    expect(data.proposedEnd.valueOf() + 1).toBeGreaterThan(data.creation.valueOf());
-  }
+
+  expect(data.proposed_end).toBeNumberObject();
+  // @ts-ignore
+  expect(data.proposed_end.valueOf()).toBeGreaterThan(0);
+  // @ts-ignore
+  expect(data.proposed_end.valueOf() + 1).toBeGreaterThan(data.creation.valueOf());
 
   expect(data.location).toBeString();
   expect(data.location).toBe(mockLocation);
@@ -341,14 +338,14 @@ function checkDataOpenRollCall(obj: MessageData) {
   expect(data).toBeObject();
   expect(data).toContainKeys([...defaultDataFields, 'update_id', 'opened_at']);
 
-  expect(data.updateId).toBeBase64();
+  expect(data.update_id).toBeBase64();
 
-  expect(data.openedAt).toBeNumberObject();
-  expect(data.openedAt.valueOf()).toBeGreaterThan(0);
+  expect(data.opened_at).toBeNumberObject();
+  expect(data.opened_at.valueOf()).toBeGreaterThan(0);
 
   // check id
   const expected = Hash.fromStringArray('R', OpenedLaoStore.get().id.toString(), '444', 'r-cName'); // 444 and r-cName are for now hardocded in the APi
-  expect(data.updateId).toEqual(expected);
+  expect(data.update_id).toEqual(expected);
 }
 
 // FIXME remove eslint warning when function used
@@ -361,14 +358,14 @@ function checkDataReopenRollCall(obj: MessageData) {
 
   expect(data).toContainKeys([...defaultDataFields, 'id', 'opened_at']);
 
-  expect(data.updateId).toBeBase64();
+  expect(data.update_id).toBeBase64();
 
-  expect(data.openedAt).toBeNumberObject();
-  expect(data.openedAt.valueOf()).toBeGreaterThan(0);
+  expect(data.opened_at).toBeNumberObject();
+  expect(data.opened_at.valueOf()).toBeGreaterThan(0);
 
   // check id
   const expected = Hash.fromStringArray('R', OpenedLaoStore.get().id.toString(), '444', 'r-cName'); // 444 and r-cName are for now hardocded in the APi
-  expect(data.updateId).toEqual(expected);
+  expect(data.update_id).toEqual(expected);
 }
 
 // FIXME remove eslint warning when function used
@@ -382,17 +379,17 @@ function checkDataCloseRollCall(obj: MessageData) {
   expect(data).toBeObject();
   expect(data).toContainKeys([...defaultDataFields, 'update_id', 'closes', 'closed_at', 'attendees']);
 
-  expect(data.updateId).toBeBase64();
+  expect(data.update_id).toBeBase64();
 
-  expect(data.closedAt).toBeNumberObject();
-  expect(data.closedAt.valueOf()).toBeGreaterThan(0);
+  expect(data.closed_at).toBeNumberObject();
+  expect(data.closed_at.valueOf()).toBeGreaterThan(0);
 
   expect(data.attendees).toBeBase64Array();
   expect(data.attendees).toBeDistinctArray();
 
   // check id
   const expected = Hash.fromStringArray('R', OpenedLaoStore.get().id.toString(), '444', 'r-cName'); // 444 and r-cName are for now hardocded in the APi
-  expect(data.updateId).toEqual(expected);
+  expect(data.update_id).toEqual(expected);
 }
 
 describe('=== WebsocketApi tests ===', () => {

--- a/fe1-web/__tests__/network/MessageApi.test.ts
+++ b/fe1-web/__tests__/network/MessageApi.test.ts
@@ -292,12 +292,7 @@ function checkDataCreateRollCall(obj: MessageData) {
   const data: CreateRollCall = obj as CreateRollCall;
 
   expect(data).toBeObject();
-  expect(data).toContainKeys([...defaultDataFields, 'id', 'name', 'creation', 'location']);
-
-  const startInData = 'start' in data;
-  const scheduledInData = 'scheduled' in data;
-  const xor = !(startInData && scheduledInData) && (startInData || scheduledInData);
-  expect(xor).toBe(true);
+  expect(data).toContainKeys([...defaultDataFields, 'id', 'name', 'creation', 'location', 'proposed_start', 'proposed_end']);
 
   expect(data.id).toBeBase64();
 
@@ -307,27 +302,27 @@ function checkDataCreateRollCall(obj: MessageData) {
   expect(data.creation).toBeNumberObject();
   expect(data.creation.valueOf()).toBeGreaterThan(0);
 
-  if ('start' in data) {
-    expect(data.start).toBeNumberObject();
+  if ('proposed_start' in data) {
+    expect(data.proposed_start).toBeNumberObject();
     // @ts-ignore
-    expect(data.start.valueOf()).toBeGreaterThan(0);
+    expect(data.proposed_start.valueOf()).toBeGreaterThan(0);
     // @ts-ignore
-    expect(data.start.valueOf() + 1).toBeGreaterThan(data.creation.valueOf());
+    expect(data.proposed_start.valueOf() + 1).toBeGreaterThan(data.creation.valueOf());
   }
 
-  if ('scheduled' in data) {
-    expect(data.scheduled).toBeNumberObject();
+  if ('proposed_end' in data) {
+    expect(data.proposed_end).toBeNumberObject();
     // @ts-ignore
-    expect(data.scheduled.valueOf()).toBeGreaterThan(0);
+    expect(data.proposed_end.valueOf()).toBeGreaterThan(0);
     // @ts-ignore
-    expect(data.scheduled.valueOf() + 1).toBeGreaterThan(data.creation.valueOf());
+    expect(data.proposed_end.valueOf() + 1).toBeGreaterThan(data.creation.valueOf());
   }
 
   expect(data.location).toBeString();
   expect(data.location).toBe(mockLocation);
 
-  if ('roll_call_description' in data) {
-    expect(data.roll_call_description).toBeString();
+  if ('description' in data) {
+    expect(data.description).toBeString();
   }
 
   // check id
@@ -344,12 +339,12 @@ function checkDataOpenRollCall(obj: MessageData) {
   const data: OpenRollCall = obj as OpenRollCall;
 
   expect(data).toBeObject();
-  expect(data).toContainKeys([...defaultDataFields, 'id', 'start']);
+  expect(data).toContainKeys([...defaultDataFields, 'update_id', 'opened_at']);
 
   expect(data.update_id).toBeBase64();
 
-  expect(data.start).toBeNumberObject();
-  expect(data.start.valueOf()).toBeGreaterThan(0);
+  expect(data.opened_at).toBeNumberObject();
+  expect(data.opened_at.valueOf()).toBeGreaterThan(0);
 
   // check id
   const expected = Hash.fromStringArray('R', OpenedLaoStore.get().id.toString(), '444', 'r-cName'); // 444 and r-cName are for now hardocded in the APi
@@ -364,12 +359,12 @@ function checkDataReopenRollCall(obj: MessageData) {
 
   const data: ReopenRollCall = obj as ReopenRollCall;
 
-  expect(data).toContainKeys([...defaultDataFields, 'id', 'start']);
+  expect(data).toContainKeys([...defaultDataFields, 'id', 'opened_at']);
 
   expect(data.update_id).toBeBase64();
 
-  expect(data.start).toBeNumberObject();
-  expect(data.start.valueOf()).toBeGreaterThan(0);
+  expect(data.opened_at).toBeNumberObject();
+  expect(data.opened_at.valueOf()).toBeGreaterThan(0);
 
   // check id
   const expected = Hash.fromStringArray('R', OpenedLaoStore.get().id.toString(), '444', 'r-cName'); // 444 and r-cName are for now hardocded in the APi
@@ -385,12 +380,12 @@ function checkDataCloseRollCall(obj: MessageData) {
   const data: CloseRollCall = obj as CloseRollCall;
 
   expect(data).toBeObject();
-  expect(data).toContainKeys([...defaultDataFields, 'id', 'start', 'end', 'attendees']);
+  expect(data).toContainKeys([...defaultDataFields, 'update_id', 'closes', 'closed_at', 'attendees']);
 
   expect(data.update_id).toBeBase64();
 
-  expect(data.end).toBeNumberObject();
-  expect(data.end.valueOf()).toBeGreaterThan(0);
+  expect(data.closed_at).toBeNumberObject();
+  expect(data.closed_at.valueOf()).toBeGreaterThan(0);
 
   expect(data.attendees).toBeBase64Array();
   expect(data.attendees).toBeDistinctArray();

--- a/fe1-web/ingestion/handlers/RollCall.ts
+++ b/fe1-web/ingestion/handlers/RollCall.ts
@@ -34,7 +34,7 @@ function handleRollCallCreateMessage(msg: Message): boolean {
     location: rcMsgData.location,
     description: rcMsgData.description,
     creation: rcMsgData.creation,
-    start: rcMsgData.proposedStart,
+    start: rcMsgData.proposed_start,
     ongoing: false,
   });
 
@@ -67,8 +67,8 @@ function handleRollCallOpenMessage(msg: Message): boolean {
 
   const rc = new RollCall({
     ...oldRC,
-    idAlias: rcMsgData.updateId,
-    start: rcMsgData.openedAt,
+    idAlias: rcMsgData.update_id,
+    start: rcMsgData.opened_at,
     ongoing: true,
   });
 
@@ -101,8 +101,8 @@ function handleRollCallCloseMessage(msg: Message): boolean {
 
   const rc = new RollCall({
     ...oldRC,
-    idAlias: rcMsgData.updateId,
-    end: rcMsgData.closedAt,
+    idAlias: rcMsgData.update_id,
+    end: rcMsgData.closed_at,
     ongoing: false,
     attendees: rcMsgData.attendees,
   });

--- a/fe1-web/ingestion/handlers/RollCall.ts
+++ b/fe1-web/ingestion/handlers/RollCall.ts
@@ -34,7 +34,7 @@ function handleRollCallCreateMessage(msg: Message): boolean {
     location: rcMsgData.location,
     description: rcMsgData.description,
     creation: rcMsgData.creation,
-    start: rcMsgData.proposed_start,
+    start: rcMsgData.proposedStart,
     ongoing: false,
   });
 
@@ -67,8 +67,8 @@ function handleRollCallOpenMessage(msg: Message): boolean {
 
   const rc = new RollCall({
     ...oldRC,
-    idAlias: rcMsgData.update_id,
-    start: rcMsgData.opened_at,
+    idAlias: rcMsgData.updateId,
+    start: rcMsgData.openedAt,
     ongoing: true,
   });
 
@@ -101,8 +101,8 @@ function handleRollCallCloseMessage(msg: Message): boolean {
 
   const rc = new RollCall({
     ...oldRC,
-    idAlias: rcMsgData.update_id,
-    end: rcMsgData.closed_at,
+    idAlias: rcMsgData.updateId,
+    end: rcMsgData.closedAt,
     ongoing: false,
     attendees: rcMsgData.attendees,
   });

--- a/fe1-web/ingestion/handlers/RollCall.ts
+++ b/fe1-web/ingestion/handlers/RollCall.ts
@@ -1,12 +1,14 @@
-import { Message } from 'model/network/method/message';
+import {Message} from 'model/network/method/message';
 import {
-  ActionType, ObjectType, CreateRollCall, OpenRollCall, CloseRollCall,
+  ActionType,
+  CloseRollCall,
+  CreateRollCall,
+  ObjectType,
+  OpenRollCall,
 } from 'model/network/method/message/data';
-import { RollCall } from 'model/objects';
-import {
-  getStore, dispatch, addEvent, updateEvent, makeCurrentLao,
-} from 'store';
-import { hasWitnessSignatureQuorum, getEventFromId } from './Utils';
+import {RollCall, RollCallStatus} from 'model/objects';
+import {addEvent, dispatch, getStore, makeCurrentLao, updateEvent,} from 'store';
+import {getEventFromId, hasWitnessSignatureQuorum} from './Utils';
 
 const getCurrentLao = makeCurrentLao();
 
@@ -34,8 +36,9 @@ function handleRollCallCreateMessage(msg: Message): boolean {
     location: rcMsgData.location,
     description: rcMsgData.description,
     creation: rcMsgData.creation,
-    start: rcMsgData.proposed_start,
-    ongoing: false,
+    proposed_start: rcMsgData.proposed_start,
+    proposed_end: rcMsgData.proposed_end,
+    status: RollCallStatus.CREATED,
   });
 
   dispatch(addEvent(lao.id, rc.toState()));
@@ -68,8 +71,8 @@ function handleRollCallOpenMessage(msg: Message): boolean {
   const rc = new RollCall({
     ...oldRC,
     idAlias: rcMsgData.update_id,
-    start: rcMsgData.opened_at,
-    ongoing: true,
+    opened_at: rcMsgData.opened_at,
+    status: RollCallStatus.OPENED,
   });
 
   dispatch(updateEvent(lao.id, rc.toState()));
@@ -102,8 +105,8 @@ function handleRollCallCloseMessage(msg: Message): boolean {
   const rc = new RollCall({
     ...oldRC,
     idAlias: rcMsgData.update_id,
-    end: rcMsgData.closed_at,
-    ongoing: false,
+    closed_at: rcMsgData.closed_at,
+    status: RollCallStatus.CLOSED,
     attendees: rcMsgData.attendees,
   });
 

--- a/fe1-web/ingestion/handlers/RollCall.ts
+++ b/fe1-web/ingestion/handlers/RollCall.ts
@@ -1,4 +1,4 @@
-import {Message} from 'model/network/method/message';
+import { Message } from 'model/network/method/message';
 import {
   ActionType,
   CloseRollCall,
@@ -6,9 +6,11 @@ import {
   ObjectType,
   OpenRollCall,
 } from 'model/network/method/message/data';
-import {RollCall, RollCallStatus} from 'model/objects';
-import {addEvent, dispatch, getStore, makeCurrentLao, updateEvent,} from 'store';
-import {getEventFromId, hasWitnessSignatureQuorum} from './Utils';
+import { RollCall, RollCallStatus } from 'model/objects';
+import {
+  addEvent, dispatch, getStore, makeCurrentLao, updateEvent,
+} from 'store';
+import { getEventFromId, hasWitnessSignatureQuorum } from './Utils';
 
 const getCurrentLao = makeCurrentLao();
 

--- a/fe1-web/ingestion/handlers/RollCall.ts
+++ b/fe1-web/ingestion/handlers/RollCall.ts
@@ -28,16 +28,14 @@ function handleRollCallCreateMessage(msg: Message): boolean {
 
   const rcMsgData = msg.messageData as CreateRollCall;
 
-  const ongoing = (!!rcMsgData.scheduled);
-
   const rc = new RollCall({
     id: rcMsgData.id,
     name: rcMsgData.name,
     location: rcMsgData.location,
-    description: rcMsgData.roll_call_description,
+    description: rcMsgData.description,
     creation: rcMsgData.creation,
-    start: ongoing ? rcMsgData.start : rcMsgData.scheduled,
-    ongoing: ongoing,
+    start: rcMsgData.proposed_start,
+    ongoing: false,
   });
 
   dispatch(addEvent(lao.id, rc.toState()));
@@ -70,7 +68,7 @@ function handleRollCallOpenMessage(msg: Message): boolean {
   const rc = new RollCall({
     ...oldRC,
     idAlias: rcMsgData.update_id,
-    start: rcMsgData.start,
+    start: rcMsgData.opened_at,
     ongoing: true,
   });
 
@@ -104,7 +102,7 @@ function handleRollCallCloseMessage(msg: Message): boolean {
   const rc = new RollCall({
     ...oldRC,
     idAlias: rcMsgData.update_id,
-    end: rcMsgData.end,
+    end: rcMsgData.closed_at,
     ongoing: false,
     attendees: rcMsgData.attendees,
   });

--- a/fe1-web/model/network/method/message/data/rollCall/CloseRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/CloseRollCall.ts
@@ -16,16 +16,16 @@ export class CloseRollCall implements MessageData {
 
   public readonly closes: Hash;
 
-  public readonly end: Timestamp;
+  public readonly closed_at: Timestamp;
 
   public readonly attendees: PublicKey[];
 
   constructor(msg: Partial<CloseRollCall>) {
-    if (!msg.end) {
+    if (!msg.closed_at) {
       throw new ProtocolError("Undefined 'end' parameter encountered during 'CloseRollCall'");
     }
-    checkTimestampStaleness(msg.end);
-    this.end = msg.end;
+    checkTimestampStaleness(msg.closed_at);
+    this.closed_at = msg.closed_at;
 
     if (!msg.attendees) {
       throw new ProtocolError("Undefined 'attendees' parameter encountered during 'CloseRollCall'");
@@ -65,7 +65,7 @@ export class CloseRollCall implements MessageData {
 
     return new CloseRollCall({
       ...obj,
-      end: new Timestamp(obj.end),
+      closed_at: new Timestamp(obj.end),
       attendees: obj.attendees.map((key: string) => new PublicKey(key)),
       update_id: new Hash(obj.update_id),
       closes: new Hash(obj.closes),

--- a/fe1-web/model/network/method/message/data/rollCall/CloseRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/CloseRollCall.ts
@@ -12,20 +12,20 @@ export class CloseRollCall implements MessageData {
 
   public readonly action: ActionType = ActionType.CLOSE;
 
-  public readonly update_id: Hash;
+  public readonly updateId: Hash;
 
   public readonly closes: Hash;
 
-  public readonly closed_at: Timestamp;
+  public readonly closedAt: Timestamp;
 
   public readonly attendees: PublicKey[];
 
   constructor(msg: Partial<CloseRollCall>) {
-    if (!msg.closed_at) {
-      throw new ProtocolError("Undefined 'closed_at' parameter encountered during 'CloseRollCall'");
+    if (!msg.closedAt) {
+      throw new ProtocolError("Undefined 'closedAt' parameter encountered during 'CloseRollCall'");
     }
-    checkTimestampStaleness(msg.closed_at);
-    this.closed_at = msg.closed_at;
+    checkTimestampStaleness(msg.closedAt);
+    this.closedAt = msg.closedAt;
 
     if (!msg.attendees) {
       throw new ProtocolError("Undefined 'attendees' parameter encountered during 'CloseRollCall'");
@@ -33,7 +33,7 @@ export class CloseRollCall implements MessageData {
     checkAttendees(msg.attendees);
     this.attendees = [...msg.attendees];
 
-    if (!msg.update_id) {
+    if (!msg.updateId) {
       throw new ProtocolError("Undefined 'update_id' parameter encountered during 'CloseRollCall'");
     }
 
@@ -48,7 +48,7 @@ export class CloseRollCall implements MessageData {
       throw new ProtocolError(
         'Invalid \'id\' parameter encountered during \'CloseRollCall\': unexpected id value
       '); */
-    this.update_id = msg.update_id;
+    this.updateId = msg.updateId;
 
     if (!msg.closes) {
       throw new ProtocolError("Undefined 'closes' parameter encountered during 'CloseRollCall'");
@@ -65,9 +65,9 @@ export class CloseRollCall implements MessageData {
 
     return new CloseRollCall({
       ...obj,
-      closed_at: new Timestamp(obj.closed_at),
+      closedAt: new Timestamp(obj.closed_at),
       attendees: obj.attendees.map((key: string) => new PublicKey(key)),
-      update_id: new Hash(obj.update_id),
+      updateId: new Hash(obj.update_id),
       closes: new Hash(obj.closes),
     });
   }

--- a/fe1-web/model/network/method/message/data/rollCall/CloseRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/CloseRollCall.ts
@@ -22,7 +22,7 @@ export class CloseRollCall implements MessageData {
 
   constructor(msg: Partial<CloseRollCall>) {
     if (!msg.closed_at) {
-      throw new ProtocolError("Undefined 'closedAt' parameter encountered during 'CloseRollCall'");
+      throw new ProtocolError("Undefined 'closed_at' parameter encountered during 'CloseRollCall'");
     }
     checkTimestampStaleness(msg.closed_at);
     this.closed_at = msg.closed_at;

--- a/fe1-web/model/network/method/message/data/rollCall/CloseRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/CloseRollCall.ts
@@ -22,7 +22,7 @@ export class CloseRollCall implements MessageData {
 
   constructor(msg: Partial<CloseRollCall>) {
     if (!msg.closed_at) {
-      throw new ProtocolError("Undefined 'end' parameter encountered during 'CloseRollCall'");
+      throw new ProtocolError("Undefined 'closed_at' parameter encountered during 'CloseRollCall'");
     }
     checkTimestampStaleness(msg.closed_at);
     this.closed_at = msg.closed_at;
@@ -65,7 +65,7 @@ export class CloseRollCall implements MessageData {
 
     return new CloseRollCall({
       ...obj,
-      closed_at: new Timestamp(obj.end),
+      closed_at: new Timestamp(obj.closed_at),
       attendees: obj.attendees.map((key: string) => new PublicKey(key)),
       update_id: new Hash(obj.update_id),
       closes: new Hash(obj.closes),

--- a/fe1-web/model/network/method/message/data/rollCall/CloseRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/CloseRollCall.ts
@@ -12,20 +12,20 @@ export class CloseRollCall implements MessageData {
 
   public readonly action: ActionType = ActionType.CLOSE;
 
-  public readonly updateId: Hash;
+  public readonly update_id: Hash;
 
   public readonly closes: Hash;
 
-  public readonly closedAt: Timestamp;
+  public readonly closed_at: Timestamp;
 
   public readonly attendees: PublicKey[];
 
   constructor(msg: Partial<CloseRollCall>) {
-    if (!msg.closedAt) {
+    if (!msg.closed_at) {
       throw new ProtocolError("Undefined 'closedAt' parameter encountered during 'CloseRollCall'");
     }
-    checkTimestampStaleness(msg.closedAt);
-    this.closedAt = msg.closedAt;
+    checkTimestampStaleness(msg.closed_at);
+    this.closed_at = msg.closed_at;
 
     if (!msg.attendees) {
       throw new ProtocolError("Undefined 'attendees' parameter encountered during 'CloseRollCall'");
@@ -33,7 +33,7 @@ export class CloseRollCall implements MessageData {
     checkAttendees(msg.attendees);
     this.attendees = [...msg.attendees];
 
-    if (!msg.updateId) {
+    if (!msg.update_id) {
       throw new ProtocolError("Undefined 'update_id' parameter encountered during 'CloseRollCall'");
     }
 
@@ -48,7 +48,7 @@ export class CloseRollCall implements MessageData {
       throw new ProtocolError(
         'Invalid \'id\' parameter encountered during \'CloseRollCall\': unexpected id value
       '); */
-    this.updateId = msg.updateId;
+    this.update_id = msg.update_id;
 
     if (!msg.closes) {
       throw new ProtocolError("Undefined 'closes' parameter encountered during 'CloseRollCall'");
@@ -65,9 +65,9 @@ export class CloseRollCall implements MessageData {
 
     return new CloseRollCall({
       ...obj,
-      closedAt: new Timestamp(obj.closed_at),
+      closed_at: new Timestamp(obj.closed_at),
       attendees: obj.attendees.map((key: string) => new PublicKey(key)),
-      updateId: new Hash(obj.update_id),
+      update_id: new Hash(obj.update_id),
       closes: new Hash(obj.closes),
     });
   }

--- a/fe1-web/model/network/method/message/data/rollCall/CreateRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/CreateRollCall.ts
@@ -61,7 +61,9 @@ export class CreateRollCall implements MessageData {
     }
     this.location = msg.location;
 
-    if (msg.description) { this.description = msg.description; }
+    if (msg.description) {
+      this.description = msg.description;
+    }
 
     if (!msg.id) {
       throw new ProtocolError("Undefined 'id' parameter encountered during 'CreateRollCall'");

--- a/fe1-web/model/network/method/message/data/rollCall/CreateRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/CreateRollCall.ts
@@ -18,9 +18,9 @@ export class CreateRollCall implements MessageData {
 
   public readonly creation: Timestamp;
 
-  public readonly proposedStart: Timestamp;
+  public readonly proposed_start: Timestamp;
 
-  public readonly proposedEnd: Timestamp;
+  public readonly proposed_end: Timestamp;
 
   public readonly location: string;
 
@@ -38,23 +38,23 @@ export class CreateRollCall implements MessageData {
     checkTimestampStaleness(msg.creation);
     this.creation = msg.creation;
 
-    if (!msg.proposedStart) {
-      throw new ProtocolError("Undefined 'proposedStart' parameter encountered during 'CreateRollCall'");
-    } else if (msg.proposedStart < msg.creation) {
+    if (!msg.proposed_start) {
+      throw new ProtocolError("Undefined 'proposed_start' parameter encountered during 'CreateRollCall'");
+    } else if (msg.proposed_start < msg.creation) {
       throw new ProtocolError('Invalid timestamp encountered:'
           + " 'proposed_start' parameter smaller than 'creation'");
     }
-    checkTimestampStaleness(msg.proposedStart);
-    this.proposedStart = msg.proposedStart;
+    checkTimestampStaleness(msg.proposed_start);
+    this.proposed_start = msg.proposed_start;
 
-    if (!msg.proposedEnd) {
-      throw new ProtocolError("Undefined 'proposedEnd' parameter encountered during 'CreateRollCall'");
-    } else if (msg.proposedEnd < msg.proposedStart) {
+    if (!msg.proposed_end) {
+      throw new ProtocolError("Undefined 'proposed_end' parameter encountered during 'CreateRollCall'");
+    } else if (msg.proposed_end < msg.proposed_start) {
       throw new ProtocolError('Invalid timestamp encountered:'
-        + " 'proposedEnd' parameter smaller than 'proposedStart'");
+        + " 'proposed_end' parameter smaller than 'proposed_start'");
     }
-    checkTimestampStaleness(msg.proposedEnd);
-    this.proposedEnd = msg.proposedEnd;
+    checkTimestampStaleness(msg.proposed_end);
+    this.proposed_end = msg.proposed_end;
 
     if (!msg.location) {
       throw new ProtocolError("Undefined 'location' parameter encountered during 'CreateRollCall'");
@@ -87,8 +87,8 @@ export class CreateRollCall implements MessageData {
     return new CreateRollCall({
       ...obj,
       creation: new Timestamp(obj.creation),
-      proposedStart: new Timestamp(obj.proposed_start),
-      proposedEnd: new Timestamp(obj.proposed_end),
+      proposed_start: new Timestamp(obj.proposed_start),
+      proposed_end: new Timestamp(obj.proposed_end),
       id: new Hash(obj.id),
     });
   }

--- a/fe1-web/model/network/method/message/data/rollCall/CreateRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/CreateRollCall.ts
@@ -18,9 +18,9 @@ export class CreateRollCall implements MessageData {
 
   public readonly creation: Timestamp;
 
-  public readonly proposed_start: Timestamp;
+  public readonly proposedStart: Timestamp;
 
-  public readonly proposed_end: Timestamp;
+  public readonly proposedEnd: Timestamp;
 
   public readonly location: string;
 
@@ -38,30 +38,30 @@ export class CreateRollCall implements MessageData {
     checkTimestampStaleness(msg.creation);
     this.creation = msg.creation;
 
-    if (!msg.proposed_start) {
-      throw new ProtocolError("Undefined 'proposed_start' parameter encountered during 'CreateRollCall'");
-    } else if (msg.proposed_start < msg.creation) {
+    if (!msg.proposedStart) {
+      throw new ProtocolError("Undefined 'proposedStart' parameter encountered during 'CreateRollCall'");
+    } else if (msg.proposedStart < msg.creation) {
       throw new ProtocolError('Invalid timestamp encountered:'
           + " 'proposed_start' parameter smaller than 'creation'");
     }
-    checkTimestampStaleness(msg.proposed_start);
-    this.proposed_start = msg.proposed_start;
+    checkTimestampStaleness(msg.proposedStart);
+    this.proposedStart = msg.proposedStart;
 
-    if (!msg.proposed_end) {
-      throw new ProtocolError("Undefined 'proposed_end' parameter encountered during 'CreateRollCall'");
-    } else if (msg.proposed_end < msg.proposed_start) {
+    if (!msg.proposedEnd) {
+      throw new ProtocolError("Undefined 'proposedEnd' parameter encountered during 'CreateRollCall'");
+    } else if (msg.proposedEnd < msg.proposedStart) {
       throw new ProtocolError('Invalid timestamp encountered:'
-        + " 'proposed_end' parameter smaller than 'proposed_start'");
+        + " 'proposedEnd' parameter smaller than 'proposedStart'");
     }
-    checkTimestampStaleness(msg.proposed_end);
-    this.proposed_end = msg.proposed_end;
+    checkTimestampStaleness(msg.proposedEnd);
+    this.proposedEnd = msg.proposedEnd;
 
     if (!msg.location) {
       throw new ProtocolError("Undefined 'location' parameter encountered during 'CreateRollCall'");
     }
     this.location = msg.location;
 
-    if (msg.description) this.description = msg.description;
+    if (msg.description) { this.description = msg.description; }
 
     if (!msg.id) {
       throw new ProtocolError("Undefined 'id' parameter encountered during 'CreateRollCall'");
@@ -87,8 +87,8 @@ export class CreateRollCall implements MessageData {
     return new CreateRollCall({
       ...obj,
       creation: new Timestamp(obj.creation),
-      proposed_start: new Timestamp(obj.proposed_start),
-      proposed_end: new Timestamp(obj.proposed_end),
+      proposedStart: new Timestamp(obj.proposed_start),
+      proposedEnd: new Timestamp(obj.proposed_end),
       id: new Hash(obj.id),
     });
   }

--- a/fe1-web/model/network/method/message/data/rollCall/CreateRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/CreateRollCall.ts
@@ -18,15 +18,13 @@ export class CreateRollCall implements MessageData {
 
   public readonly creation: Timestamp;
 
-  // only set if the roll call is to be opened immediately
-  public readonly start?: Timestamp;
+  public readonly proposed_start: Timestamp;
 
-  // only set if the roll call *will* be opened in the future
-  public readonly scheduled?: Timestamp;
+  public readonly proposed_end: Timestamp;
 
   public readonly location: string;
 
-  public readonly roll_call_description?: string;
+  public readonly description?: string;
 
   constructor(msg: Partial<CreateRollCall>) {
     if (!msg.name) {
@@ -40,34 +38,24 @@ export class CreateRollCall implements MessageData {
     checkTimestampStaleness(msg.creation);
     this.creation = msg.creation;
 
-    if ((msg.start && msg.scheduled) || (!msg.start && !msg.scheduled)) {
-      // if both are present or neither
-      throw new ProtocolError("The 'CreateRollCall' data should include"
-        + "  either 'start' or 'scheduled' values, but not both");
+    if (!msg.proposed_start) {
+      throw new ProtocolError("Undefined 'proposed_start' parameter encountered during 'CreateRollCall'");
     }
+    checkTimestampStaleness(msg.proposed_start);
+    this.proposed_start = msg.proposed_start;
 
-    if (msg.start) {
-      if (msg.start < msg.creation) {
-        throw new ProtocolError('Invalid timestamp encountered:'
-          + " 'start' parameter smaller than 'creation'");
-      }
-      this.start = msg.start;
+    if (!msg.proposed_end) {
+      throw new ProtocolError("Undefined 'proposed_end' parameter encountered during 'CreateRollCall'");
     }
-
-    if (msg.scheduled) {
-      if (msg.scheduled < msg.creation) {
-        throw new ProtocolError('Invalid timestamp encountered:'
-          + " 'scheduled' parameter smaller than 'creation'");
-      }
-      this.scheduled = msg.scheduled;
-    }
+    checkTimestampStaleness(msg.proposed_end);
+    this.proposed_end = msg.proposed_end;
 
     if (!msg.location) {
       throw new ProtocolError("Undefined 'location' parameter encountered during 'CreateRollCall'");
     }
     this.location = msg.location;
 
-    if (msg.roll_call_description) this.roll_call_description = msg.roll_call_description;
+    if (msg.description) this.description = msg.description;
 
     if (!msg.id) {
       throw new ProtocolError("Undefined 'id' parameter encountered during 'CreateRollCall'");
@@ -93,8 +81,8 @@ export class CreateRollCall implements MessageData {
     return new CreateRollCall({
       ...obj,
       creation: new Timestamp(obj.creation),
-      start: (obj.start !== undefined) ? new Timestamp(obj.start) : undefined,
-      scheduled: (obj.scheduled !== undefined) ? new Timestamp(obj.scheduled) : undefined,
+      proposed_start: new Timestamp(obj.proposed_start),
+      proposed_end: new Timestamp(obj.proposed_end),
       id: new Hash(obj.id),
     });
   }

--- a/fe1-web/model/network/method/message/data/rollCall/CreateRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/CreateRollCall.ts
@@ -40,12 +40,18 @@ export class CreateRollCall implements MessageData {
 
     if (!msg.proposed_start) {
       throw new ProtocolError("Undefined 'proposed_start' parameter encountered during 'CreateRollCall'");
+    } else if (msg.proposed_start < msg.creation) {
+      throw new ProtocolError('Invalid timestamp encountered:'
+          + " 'proposed_start' parameter smaller than 'creation'");
     }
     checkTimestampStaleness(msg.proposed_start);
     this.proposed_start = msg.proposed_start;
 
     if (!msg.proposed_end) {
       throw new ProtocolError("Undefined 'proposed_end' parameter encountered during 'CreateRollCall'");
+    } else if (msg.proposed_end < msg.proposed_start) {
+      throw new ProtocolError('Invalid timestamp encountered:'
+        + " 'proposed_end' parameter smaller than 'proposed_start'");
     }
     checkTimestampStaleness(msg.proposed_end);
     this.proposed_end = msg.proposed_end;

--- a/fe1-web/model/network/method/message/data/rollCall/OpenRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/OpenRollCall.ts
@@ -17,13 +17,13 @@ export class OpenRollCall implements MessageData {
 
   constructor(msg: Partial<OpenRollCall>) {
     if (!msg.opened_at) {
-      throw new ProtocolError("Undefined 'openedAt' parameter encountered during 'OpenRollCall'");
+      throw new ProtocolError("Undefined 'opened_at' parameter encountered during 'OpenRollCall'");
     }
     checkTimestampStaleness(msg.opened_at);
     this.opened_at = msg.opened_at;
 
     if (!msg.update_id) {
-      throw new ProtocolError("Undefined 'updateId' parameter encountered during 'OpenRollCall'");
+      throw new ProtocolError("Undefined 'update_Id' parameter encountered during 'OpenRollCall'");
     }
     this.update_id = msg.update_id;
 

--- a/fe1-web/model/network/method/message/data/rollCall/OpenRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/OpenRollCall.ts
@@ -9,23 +9,23 @@ export class OpenRollCall implements MessageData {
 
   public readonly action: ActionType = ActionType.OPEN;
 
-  public readonly update_id: Hash;
+  public readonly updateId: Hash;
 
   public readonly opens: Hash;
 
-  public readonly opened_at: Timestamp;
+  public readonly openedAt: Timestamp;
 
   constructor(msg: Partial<OpenRollCall>) {
-    if (!msg.opened_at) {
-      throw new ProtocolError("Undefined 'opened_at' parameter encountered during 'OpenRollCall'");
+    if (!msg.openedAt) {
+      throw new ProtocolError("Undefined 'openedAt' parameter encountered during 'OpenRollCall'");
     }
-    checkTimestampStaleness(msg.opened_at);
-    this.opened_at = msg.opened_at;
+    checkTimestampStaleness(msg.openedAt);
+    this.openedAt = msg.openedAt;
 
-    if (!msg.update_id) {
-      throw new ProtocolError("Undefined 'update_id' parameter encountered during 'OpenRollCall'");
+    if (!msg.updateId) {
+      throw new ProtocolError("Undefined 'updateId' parameter encountered during 'OpenRollCall'");
     }
-    this.update_id = msg.update_id;
+    this.updateId = msg.updateId;
 
     if (!msg.opens) {
       throw new ProtocolError("Undefined 'opens' parameter encountered during 'OpenRollCall'");
@@ -42,8 +42,8 @@ export class OpenRollCall implements MessageData {
 
     return new OpenRollCall({
       ...obj,
-      opened_at: new Timestamp(obj.opened_at),
-      update_id: new Hash(obj.update_id),
+      openedAt: new Timestamp(obj.opened_at),
+      updateId: new Hash(obj.update_id),
       opens: new Hash(obj.opens),
     });
   }

--- a/fe1-web/model/network/method/message/data/rollCall/OpenRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/OpenRollCall.ts
@@ -13,14 +13,14 @@ export class OpenRollCall implements MessageData {
 
   public readonly opens: Hash;
 
-  public readonly start: Timestamp;
+  public readonly opened_at: Timestamp;
 
   constructor(msg: Partial<OpenRollCall>) {
-    if (!msg.start) {
-      throw new ProtocolError("Undefined 'start' parameter encountered during 'OpenRollCall'");
+    if (!msg.opened_at) {
+      throw new ProtocolError("Undefined 'opened_at' parameter encountered during 'OpenRollCall'");
     }
-    checkTimestampStaleness(msg.start);
-    this.start = msg.start;
+    checkTimestampStaleness(msg.opened_at);
+    this.opened_at = msg.opened_at;
 
     if (!msg.update_id) {
       throw new ProtocolError("Undefined 'update_id' parameter encountered during 'OpenRollCall'");
@@ -42,7 +42,7 @@ export class OpenRollCall implements MessageData {
 
     return new OpenRollCall({
       ...obj,
-      start: new Timestamp(obj.start),
+      opened_at: new Timestamp(obj.opened_at),
       update_id: new Hash(obj.update_id),
       opens: new Hash(obj.opens),
     });

--- a/fe1-web/model/network/method/message/data/rollCall/OpenRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/OpenRollCall.ts
@@ -9,23 +9,23 @@ export class OpenRollCall implements MessageData {
 
   public readonly action: ActionType = ActionType.OPEN;
 
-  public readonly updateId: Hash;
+  public readonly update_id: Hash;
 
   public readonly opens: Hash;
 
-  public readonly openedAt: Timestamp;
+  public readonly opened_at: Timestamp;
 
   constructor(msg: Partial<OpenRollCall>) {
-    if (!msg.openedAt) {
+    if (!msg.opened_at) {
       throw new ProtocolError("Undefined 'openedAt' parameter encountered during 'OpenRollCall'");
     }
-    checkTimestampStaleness(msg.openedAt);
-    this.openedAt = msg.openedAt;
+    checkTimestampStaleness(msg.opened_at);
+    this.opened_at = msg.opened_at;
 
-    if (!msg.updateId) {
+    if (!msg.update_id) {
       throw new ProtocolError("Undefined 'updateId' parameter encountered during 'OpenRollCall'");
     }
-    this.updateId = msg.updateId;
+    this.update_id = msg.update_id;
 
     if (!msg.opens) {
       throw new ProtocolError("Undefined 'opens' parameter encountered during 'OpenRollCall'");
@@ -42,8 +42,8 @@ export class OpenRollCall implements MessageData {
 
     return new OpenRollCall({
       ...obj,
-      openedAt: new Timestamp(obj.opened_at),
-      updateId: new Hash(obj.update_id),
+      opened_at: new Timestamp(obj.opened_at),
+      update_id: new Hash(obj.update_id),
       opens: new Hash(obj.opens),
     });
   }

--- a/fe1-web/model/network/method/message/data/rollCall/ReopenRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/ReopenRollCall.ts
@@ -10,21 +10,21 @@ export class ReopenRollCall implements MessageData {
 
   public readonly action: ActionType = ActionType.REOPEN;
 
-  public readonly update_id: Hash;
+  public readonly updateId: Hash;
 
   public readonly opens: Hash;
 
-  public readonly opened_at: Timestamp;
+  public readonly openedAt: Timestamp;
 
   constructor(msg: Partial<ReopenRollCall>) {
-    if (!msg.opened_at) {
-      throw new ProtocolError("Undefined 'start' parameter encountered during 'ReopenRollCall'");
+    if (!msg.openedAt) {
+      throw new ProtocolError("Undefined 'openedAt' parameter encountered during 'ReopenRollCall'");
     }
-    checkTimestampStaleness(msg.opened_at);
-    this.opened_at = new Timestamp(msg.opened_at.toString());
+    checkTimestampStaleness(msg.openedAt);
+    this.openedAt = new Timestamp(msg.openedAt.toString());
 
-    if (!msg.update_id) {
-      throw new ProtocolError("Undefined 'update_id' parameter encountered during 'ReopenRollCall'");
+    if (!msg.updateId) {
+      throw new ProtocolError("Undefined 'updateId' parameter encountered during 'ReopenRollCall'");
     }
 
     // FIXME: implementation not finished, get event from storage,
@@ -39,7 +39,7 @@ export class ReopenRollCall implements MessageData {
         'Invalid \'id\' parameter encountered during \'CreateLao\': unexpected id value'
       );
     */
-    this.update_id = new Hash(msg.update_id.toString());
+    this.updateId = new Hash(msg.updateId.toString());
 
     if (!msg.opens) {
       throw new ProtocolError("Undefined 'opens' parameter encountered during 'OpenRollCall'");
@@ -56,8 +56,8 @@ export class ReopenRollCall implements MessageData {
 
     return new ReopenRollCall({
       ...obj,
-      opened_at: new Timestamp(obj.opened_at),
-      update_id: new Hash(obj.update_id),
+      openedAt: new Timestamp(obj.opened_at),
+      updateId: new Hash(obj.update_id),
       opens: new Hash(obj.opens),
     });
   }

--- a/fe1-web/model/network/method/message/data/rollCall/ReopenRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/ReopenRollCall.ts
@@ -14,14 +14,14 @@ export class ReopenRollCall implements MessageData {
 
   public readonly opens: Hash;
 
-  public readonly start: Timestamp;
+  public readonly opened_at: Timestamp;
 
   constructor(msg: Partial<ReopenRollCall>) {
-    if (!msg.start) {
+    if (!msg.opened_at) {
       throw new ProtocolError("Undefined 'start' parameter encountered during 'ReopenRollCall'");
     }
-    checkTimestampStaleness(msg.start);
-    this.start = new Timestamp(msg.start.toString());
+    checkTimestampStaleness(msg.opened_at);
+    this.opened_at = new Timestamp(msg.opened_at.toString());
 
     if (!msg.update_id) {
       throw new ProtocolError("Undefined 'update_id' parameter encountered during 'ReopenRollCall'");
@@ -56,7 +56,7 @@ export class ReopenRollCall implements MessageData {
 
     return new ReopenRollCall({
       ...obj,
-      start: new Timestamp(obj.start),
+      opened_at: new Timestamp(obj.opened_at),
       update_id: new Hash(obj.update_id),
       opens: new Hash(obj.opens),
     });

--- a/fe1-web/model/network/method/message/data/rollCall/ReopenRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/ReopenRollCall.ts
@@ -10,20 +10,20 @@ export class ReopenRollCall implements MessageData {
 
   public readonly action: ActionType = ActionType.REOPEN;
 
-  public readonly updateId: Hash;
+  public readonly update_id: Hash;
 
   public readonly opens: Hash;
 
-  public readonly openedAt: Timestamp;
+  public readonly opened_at: Timestamp;
 
   constructor(msg: Partial<ReopenRollCall>) {
-    if (!msg.openedAt) {
+    if (!msg.opened_at) {
       throw new ProtocolError("Undefined 'openedAt' parameter encountered during 'ReopenRollCall'");
     }
-    checkTimestampStaleness(msg.openedAt);
-    this.openedAt = new Timestamp(msg.openedAt.toString());
+    checkTimestampStaleness(msg.opened_at);
+    this.opened_at = new Timestamp(msg.opened_at.toString());
 
-    if (!msg.updateId) {
+    if (!msg.update_id) {
       throw new ProtocolError("Undefined 'updateId' parameter encountered during 'ReopenRollCall'");
     }
 
@@ -39,7 +39,7 @@ export class ReopenRollCall implements MessageData {
         'Invalid \'id\' parameter encountered during \'CreateLao\': unexpected id value'
       );
     */
-    this.updateId = new Hash(msg.updateId.toString());
+    this.update_id = new Hash(msg.update_id.toString());
 
     if (!msg.opens) {
       throw new ProtocolError("Undefined 'opens' parameter encountered during 'OpenRollCall'");
@@ -56,8 +56,8 @@ export class ReopenRollCall implements MessageData {
 
     return new ReopenRollCall({
       ...obj,
-      openedAt: new Timestamp(obj.opened_at),
-      updateId: new Hash(obj.update_id),
+      opened_at: new Timestamp(obj.opened_at),
+      update_id: new Hash(obj.update_id),
       opens: new Hash(obj.opens),
     });
   }

--- a/fe1-web/model/network/method/message/data/rollCall/ReopenRollCall.ts
+++ b/fe1-web/model/network/method/message/data/rollCall/ReopenRollCall.ts
@@ -18,13 +18,13 @@ export class ReopenRollCall implements MessageData {
 
   constructor(msg: Partial<ReopenRollCall>) {
     if (!msg.opened_at) {
-      throw new ProtocolError("Undefined 'openedAt' parameter encountered during 'ReopenRollCall'");
+      throw new ProtocolError("Undefined 'opened_at' parameter encountered during 'ReopenRollCall'");
     }
     checkTimestampStaleness(msg.opened_at);
     this.opened_at = new Timestamp(msg.opened_at.toString());
 
     if (!msg.update_id) {
-      throw new ProtocolError("Undefined 'updateId' parameter encountered during 'ReopenRollCall'");
+      throw new ProtocolError("Undefined 'update_id' parameter encountered during 'ReopenRollCall'");
     }
 
     // FIXME: implementation not finished, get event from storage,

--- a/fe1-web/model/objects/RollCall.ts
+++ b/fe1-web/model/objects/RollCall.ts
@@ -122,8 +122,8 @@ export class RollCall implements LaoEvent {
     const obj: any = JSON.parse(JSON.stringify(this));
     return {
       ...obj,
-      start: obj.getStart(),
-      end: obj.getEnd(),
+      start: this.start.valueOf(),
+      end: this.end.valueOf(),
       eventType: LaoEventType.ROLL_CALL,
     };
   }

--- a/fe1-web/model/objects/RollCall.ts
+++ b/fe1-web/model/objects/RollCall.ts
@@ -15,7 +15,11 @@ export interface RollCallState extends LaoEventState {
   location: string;
   description?: string;
   creation: number;
-  status: RollCallStatus;
+  proposed_start: number;
+  proposed_end: number;
+  opened_at?: number;
+  closed_at?: number;
+  status: number;
   attendees?: string[];
 }
 
@@ -105,8 +109,10 @@ export class RollCall implements LaoEvent {
       location: rc.location,
       description: rc.description,
       creation: new Timestamp(rc.creation),
-      start: new Timestamp(rc.start),
-      end: new Timestamp(rc.end),
+      proposed_start: new Timestamp(rc.proposed_start),
+      proposed_end: new Timestamp(rc.proposed_end),
+      opened_at: new Timestamp(rc.opened_at),
+      closed_at: new Timestamp(rc.closed_at),
       status: rc.status,
       attendees: rc.attendees?.map((a) => new PublicKey(a)),
     });
@@ -116,6 +122,8 @@ export class RollCall implements LaoEvent {
     const obj: any = JSON.parse(JSON.stringify(this));
     return {
       ...obj,
+      start: obj.getStart(),
+      end: obj.getEnd(),
       eventType: LaoEventType.ROLL_CALL,
     };
   }

--- a/fe1-web/network/MessageApi.ts
+++ b/fe1-web/network/MessageApi.ts
@@ -132,18 +132,11 @@ export function requestWitnessMessage(channel: Channel, messageId: Hash): Promis
  *  given location (String). An optional start time (Timestamp), scheduled time (Timestamp) or
  *  description (String) can be specified */
 export function requestCreateRollCall(
-  name: string, location: string, start?: Timestamp, scheduled?: Timestamp, description?: string,
+  name: string, location: string, proposed_start: Timestamp, proposed_end: Timestamp,
+  description?: string,
 ): Promise<void> {
   const time: Timestamp = Timestamp.EpochNow();
   const currentLao: Lao = OpenedLaoStore.get();
-
-  if (start === undefined && scheduled === undefined) {
-    throw new Error('RollCall creation failed : neither "start" or "scheduled" field was given');
-  }
-
-  if (start !== undefined && scheduled !== undefined) {
-    throw new Error('RollCall creation failed : both "start" and "scheduled" fields were given');
-  }
 
   const message = new CreateRollCall({
     id: Hash.fromStringArray(
@@ -152,8 +145,8 @@ export function requestCreateRollCall(
     name: name,
     creation: time,
     location: location,
-    proposed_start: start,
-    proposed_end: scheduled,
+    proposed_start: proposed_start,
+    proposed_end: proposed_end,
     description: description,
   });
 

--- a/fe1-web/network/MessageApi.ts
+++ b/fe1-web/network/MessageApi.ts
@@ -132,7 +132,7 @@ export function requestWitnessMessage(channel: Channel, messageId: Hash): Promis
  *  given location (String). An optional start time (Timestamp), scheduled time (Timestamp) or
  *  description (String) can be specified */
 export function requestCreateRollCall(
-  name: string, location: string, proposed_start: Timestamp, proposed_end: Timestamp,
+  name: string, location: string, proposedStart: Timestamp, proposedEnd: Timestamp,
   description?: string,
 ): Promise<void> {
   const time: Timestamp = Timestamp.EpochNow();
@@ -145,8 +145,8 @@ export function requestCreateRollCall(
     name: name,
     creation: time,
     location: location,
-    proposed_start: proposed_start,
-    proposed_end: proposed_end,
+    proposedStart: proposedStart,
+    proposedEnd: proposedEnd,
     description: description,
   });
 

--- a/fe1-web/network/MessageApi.ts
+++ b/fe1-web/network/MessageApi.ts
@@ -145,8 +145,8 @@ export function requestCreateRollCall(
     name: name,
     creation: time,
     location: location,
-    proposedStart: proposedStart,
-    proposedEnd: proposedEnd,
+    proposed_start: proposedStart,
+    proposed_end: proposedEnd,
     description: description,
   });
 

--- a/fe1-web/network/MessageApi.ts
+++ b/fe1-web/network/MessageApi.ts
@@ -152,9 +152,9 @@ export function requestCreateRollCall(
     name: name,
     creation: time,
     location: location,
-    start: start,
-    scheduled: scheduled,
-    roll_call_description: description,
+    proposed_start: start,
+    proposed_end: scheduled,
+    description: description,
   });
 
   const laoCh = channelFromId(currentLao.id);

--- a/fe1-web/parts/lao/organizer/eventCreation/events/CreateRollCall.tsx
+++ b/fe1-web/parts/lao/organizer/eventCreation/events/CreateRollCall.tsx
@@ -25,9 +25,13 @@ function dateToTimestamp(date: Date): Timestamp {
 const CreateRollCall = ({ route }: any) => {
   const styles = route.params;
   const navigation = useNavigation();
-  const initialDate = new Date();
+  const initialStartDate = new Date();
+  const initialEndDate = new Date();
+  // Sets initial end date to 1 hour later than start date
+  initialEndDate.setHours(initialEndDate.getHours() + 1);
 
-  const [startDate, setStartDate] = useState(dateToTimestamp(initialDate));
+  const [proposedStartDate, setProposedStartDate] = useState(dateToTimestamp(initialStartDate));
+  const [proposedEndDate, setProposedEndDate] = useState(dateToTimestamp(initialEndDate));
 
   const [rollCallName, setRollCallName] = useState('');
   const [rollCallLocation, setRollCallLocation] = useState('');
@@ -35,14 +39,21 @@ const CreateRollCall = ({ route }: any) => {
 
   const buildDatePickerWeb = () => {
     const startTime = new Date(0);
-    startTime.setUTCSeconds(startDate.valueOf());
+    const endTime = new Date(0);
+    startTime.setUTCSeconds(proposedStartDate.valueOf());
+    endTime.setUTCSeconds(proposedEndDate.valueOf());
 
     return (
       <View style={styles.view}>
-        <ParagraphBlock text={STRINGS.roll_call_create_deadline} />
+        <ParagraphBlock text={STRINGS.roll_call_create_proposed_start} />
         <DatePicker
           selected={startTime}
-          onChange={(date: Date) => setStartDate(dateToTimestamp(date))}
+          onChange={(date: Date) => setProposedStartDate(dateToTimestamp(date))}
+        />
+        <ParagraphBlock text={STRINGS.roll_call_create_proposed_end} />
+        <DatePicker
+          selected={endTime}
+          onChange={(date: Date) => setProposedEndDate(dateToTimestamp(date))}
         />
       </View>
     );
@@ -50,12 +61,10 @@ const CreateRollCall = ({ route }: any) => {
 
   const buttonsVisibility: boolean = (rollCallName !== '' && rollCallLocation !== '');
 
-  const createRollCall = (scheduled: boolean) => {
+  const createRollCall = () => {
     const description = (rollCallDescription === '') ? undefined : rollCallDescription;
     requestCreateRollCall(
-      rollCallName, rollCallLocation,
-      scheduled ? undefined : startDate,
-      scheduled ? startDate : undefined,
+      rollCallName, rollCallLocation, proposedStartDate, proposedEndDate,
       description,
     )
       .then(() => {

--- a/fe1-web/parts/lao/organizer/eventCreation/events/CreateRollCall.tsx
+++ b/fe1-web/parts/lao/organizer/eventCreation/events/CreateRollCall.tsx
@@ -27,6 +27,8 @@ const CreateRollCall = ({ route }: any) => {
   const navigation = useNavigation();
   const initialStartDate = new Date();
   const initialEndDate = new Date();
+  // Sets initial start date 5 minutes in the future to avoid: proposed_start < creation
+  initialStartDate.setMinutes(initialStartDate.getMinutes() + 5);
   // Sets initial end date to 1 hour later than start date
   initialEndDate.setHours(initialEndDate.getHours() + 1);
 
@@ -75,9 +77,7 @@ const CreateRollCall = ({ route }: any) => {
       });
   };
 
-  const onConfirmPress = () => createRollCall(true);
-
-  const onOpenPress = () => createRollCall(false);
+  const onConfirmPress = () => createRollCall();
 
   return (
     <ScrollView>
@@ -103,11 +103,6 @@ const CreateRollCall = ({ route }: any) => {
       <WideButtonView
         title={STRINGS.general_button_confirm}
         onPress={onConfirmPress}
-        disabled={!buttonsVisibility}
-      />
-      <WideButtonView
-        title={STRINGS.general_button_open}
-        onPress={onOpenPress}
         disabled={!buttonsVisibility}
       />
       <WideButtonView

--- a/fe1-web/res/strings.ts
+++ b/fe1-web/res/strings.ts
@@ -95,7 +95,8 @@ const STRINGS = {
   discussion_create_open: 'discussion open',
 
   /* --- Roll-call creation Strings --- */
-  roll_call_create_deadline: 'Deadline:',
+  roll_call_create_proposed_start: 'Proposed Start:',
+  roll_call_create_proposed_end: 'Proposed End:',
   roll_call_create_description: 'Description',
   roll_call_create_location: 'Location*',
   roll_call_create_name: 'Name*',


### PR DESCRIPTION
In this [Pull Request](https://github.com/dedis/student_21_pop/pull/287) the protocol message regarding the roll call was changed a tiny bit. 
The Protocol changes were:
1. In the **create** roll call:
    - Instead of having `start` and `scheduled` field now there is a `proposed_start` and `proposed_end` field
    - `roll_call_description` was changed to `description`
2. In the **open** roll call:
    - `start` was changed to `opened_at`
3. In the **close** roll call
    - `end` was changed to `closed_at`

Therefore the tests had to be adjusted. 
As can be seen in the changes most of it is just updating the names. But some extra checks were also removed since before only one of either `start` or `scheduled` was required in the createRollCall. Whereas now both proposed start and end are required. 

The create Roll Call UI was also updated in order to allow 2 date inputs for the proposed start and date. 