### PR TITLE
Fix missing messages in catchup

### DIFF
--- a/be1-go/hub/organizer.go
+++ b/be1-go/hub/organizer.go
@@ -280,9 +280,6 @@ func (c *laoChannel) processLaoObject(msg message.Message) error {
 
 	switch action {
 	case message.UpdateLaoAction:
-		c.inboxMu.Lock()
-		c.inbox[msgIDEncoded] = msg
-		c.inboxMu.Unlock()
 	case message.StateLaoAction:
 		err := c.processLaoState(msg.Data.(*message.StateLAOData))
 		if err != nil {
@@ -295,6 +292,10 @@ func (c *laoChannel) processLaoObject(msg message.Message) error {
 			Description: fmt.Sprintf("invalid action: %s", action),
 		}
 	}
+
+	c.inboxMu.Lock()
+	c.inbox[msgIDEncoded] = msg
+	c.inboxMu.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
Fixes #313.
The `lao/state` message was not added to the lao inbox. This is why it was not sent in catchup messages.