### PR TITLE
Add correct websocket path and required jsonrpc field in the request to communicate with the backend

### DIFF
--- a/fe1-web/__tests__/model/network/FromJsonRpcRequest.test.ts
+++ b/fe1-web/__tests__/model/network/FromJsonRpcRequest.test.ts
@@ -13,7 +13,7 @@ import { JsonRpcMethod, JsonRpcRequest } from 'model/network';
 import { CreateLao } from 'model/network/method/message/data';
 import { JsonRpcParamsWithMessage } from 'model/network/method/JsonRpcParamsWithMessage';
 
-const JSON_RPC_FIELDS: string[] = ['method', 'params', 'id']; // jsonrpc version is not stored, thus only 3 fields
+const JSON_RPC_FIELDS: string[] = ['method', 'params', 'id', 'jsonrpc'];
 const QUERY_FIELD_COUNT = JSON_RPC_FIELDS.length;
 
 const METHODS = Object.keys(JsonRpcMethod)

--- a/fe1-web/model/network/JsonRpcRequest.ts
+++ b/fe1-web/model/network/JsonRpcRequest.ts
@@ -10,6 +10,8 @@ import { validateJsonRpcRequest } from './validation';
  * This class represents a JSON-RPC 2.0 Request (or Notification)
  */
 export class JsonRpcRequest {
+  public readonly jsonrpc: string;
+
   public readonly method: JsonRpcMethod;
 
   public readonly id?: number;
@@ -50,6 +52,7 @@ export class JsonRpcRequest {
     this.method = req.method;
     this.id = (req.id === undefined || req.id === null) ? undefined : req.id;
     this.params = req.params;
+    this.jsonrpc = '2.0';
   }
 
   static fromJson(jsonString: string): JsonRpcRequest {

--- a/fe1-web/network/NetworkManager.ts
+++ b/fe1-web/network/NetworkManager.ts
@@ -26,7 +26,11 @@ class NetworkManager {
   }
 
   /** Connects to a server or returns an existing connection to the server
-   * Mockserver port: 8080, Go backend: 9000
+   * Mockserver port: 8080
+   * Go backend default organizer port: 9000
+   * The full path to connect to the backend is:
+   * as organizer ws://host:clientport/organizer/client/
+   * as a witness: ws://host:witnessport/organizer/witness/
    * @param host the server's host
    * @param port the server's port
    * @param path the path at which the websocket can be established

--- a/fe1-web/network/NetworkManager.ts
+++ b/fe1-web/network/NetworkManager.ts
@@ -33,7 +33,7 @@ class NetworkManager {
    *
    * @returns a new connection to the server, or an existing one if it's already established
    */
-  public connect(host: string, port: number = 8080, path: string = ''): NetworkConnection {
+  public connect(host: string, port: number = 9000, path: string = 'organizer/client/'): NetworkConnection {
     const address: string = NetworkManager.buildAddress(host, port, path);
     const existingConnection = this.getConnectionByAddress(address);
 


### PR DESCRIPTION
Tiny PR which fixes 2 issues which stopped the front-end from communicating with the backend.
1. the websocketpath is now 'organizer/client' to cinnect as an organizer ([See Go readme)](https://github.com/dedis/student_21_pop/tree/master/be1-go#student_21_pop)
This was changed in the [Go PR that added wintess funcitonality](https://github.com/dedis/student_21_pop/pull/301)
2. The RPCRequest needs a value `rpcrequest: 2.0`