### PR TITLE
be1-go: Fix deadlock on missing channel

### DIFF
--- a/be1-go/hub/organizer.go
+++ b/be1-go/hub/organizer.go
@@ -213,6 +213,7 @@ func (o *organizerHub) handleMessageFromClient(incomingMessage *IncomingMessage)
 			Code:        -2,
 			Description: fmt.Sprintf("channel with id %s does not exist", channelID),
 		})
+		o.RUnlock()
 		return
 	}
 	o.RUnlock()


### PR DESCRIPTION
Fixes a deadlock because of a missing unlock on an `RWMutex` on error