### PR TITLE
Fix id of CreateLao

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/data/lao/CreateLao.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/data/lao/CreateLao.java
@@ -40,7 +40,7 @@ public class CreateLao extends Data {
     this.name = name;
     this.organizer = organizer;
     this.creation = Instant.now().toEpochMilli();
-    this.id = Hash.hash("L", organizer, Long.toString(creation), name);
+    this.id = Hash.hash(organizer, Long.toString(creation), name);
     this.witnesses = new ArrayList<>();
   }
 


### PR DESCRIPTION
The id of [dataCreateLao](https://github.com/dedis/student_21_pop/blob/master/protocol/query/method/message/data/dataCreateLao.json) was computed as  `Hash('L'||organizer||creation||name)` instead of `Hash(organizer||creation||name)`