### PR TITLE
Handle multiple rollcalls

### DIFF
--- a/be1-go/hub/organizer.go
+++ b/be1-go/hub/organizer.go
@@ -347,7 +347,7 @@ func (o *organizerHub) createLao(publish message.Publish) error {
 	laoChannelID := rootPrefix + encodedID
 
 	laoCh := laoChannel{
-		rollCall:    rollCall{},
+		rollCalls:   make(map[string]rollCallState),
 		attendees:   make(map[string]struct{}),
 		baseChannel: createBaseChannel(o, laoChannelID),
 	}
@@ -360,7 +360,11 @@ func (o *organizerHub) createLao(publish message.Publish) error {
 }
 
 type laoChannel struct {
-	rollCall  rollCall
+	// The key corresponds to the current ID of the roll call
+	// and value is the state of that roll call
+	rollCalls map[string]rollCallState
+
+	// The key corresponds to the public key of an attendee
 	attendees map[string]struct{}
 	*baseChannel
 }
@@ -372,11 +376,6 @@ const (
 	Closed  rollCallState = "closed"
 	Created rollCallState = "created"
 )
-
-type rollCall struct {
-	state rollCallState
-	id    string
-}
 
 func (c *laoChannel) Publish(publish message.Publish) error {
 	err := c.baseChannel.VerifyPublishMessage(publish)

--- a/be1-go/hub/organizer_test.go
+++ b/be1-go/hub/organizer_test.go
@@ -363,6 +363,7 @@ func requireSameKeys(t *testing.T, keysList []message.PublicKey, keysMap map[str
 }
 func TestOrganizer_MultipleRollCalls(t *testing.T) {
 	laoID, laoChannel, err := createLao(oHub, organizerKeyPair, "lao 2 rollcalls")
+	require.NoError(t, err)
 
 	// Generate public keys
 	var attendees []message.PublicKey

--- a/be1-go/hub/rollCall.go
+++ b/be1-go/hub/rollCall.go
@@ -98,7 +98,8 @@ func (c *laoChannel) processCloseRollCall(data message.Data) error {
 
 	c.attendees = map[string]struct{}{}
 	for i := 0; i < len(rollCallData.Attendees); i += 1 {
-		c.attendees[string(rollCallData.Attendees[i])] = struct{}{}
+		attendee := base64.URLEncoding.EncodeToString(rollCallData.Attendees[i])
+		c.attendees[attendee] = struct{}{}
 	}
 
 	return nil

--- a/be1-go/hub/rollCall.go
+++ b/be1-go/hub/rollCall.go
@@ -94,7 +94,7 @@ func (c *laoChannel) processCloseRollCall(data message.Data) error {
 		}
 	}
 
-	c.updateRollCall(rollCallData.Closes, rollCallData.Closes, Closed)
+	c.updateRollCall(rollCallData.Closes, rollCallData.UpdateID, Closed)
 
 	c.attendees = map[string]struct{}{}
 	for i := 0; i < len(rollCallData.Attendees); i += 1 {
@@ -125,7 +125,7 @@ func (c *laoChannel) getRollCallState(rollCallID []byte) (*rollCallState, error)
 	if !ok {
 		return nil, &message.Error{
 			Code:        -4,
-			Description: "The ID does not correspond to the id of any current roll call",
+			Description: "The ID does not correspond to the ID of any current roll call",
 		}
 	}
 


### PR DESCRIPTION
Fixes #353

- Added the possibility to create multiple roll calls in parallel.
- Each time a roll call is closed, the previous list of public keys of the attendees is replaced by the list provided in the CloseRollCall message.
- Updated the encoding of the attendees' public keys that are store on the server after a roll call. Now the public keys are store in Base64URL.