### PR TITLE
Fix LAO connection problems in fe2 reported by fe1

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/detail/fragments/LaoDetailFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/detail/fragments/LaoDetailFragment.java
@@ -112,7 +112,7 @@ public class LaoDetailFragment extends Fragment {
           .observe(
               getActivity(),
               lao -> {
-                Bitmap myBitmap = QRCode.from(lao.getChannel()).bitmap();
+                Bitmap myBitmap = QRCode.from(lao.getChannel().substring(6)).bitmap();
                 mLaoDetailFragBinding.channelQrCode.setImageBitmap(myBitmap);
               });
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/home/HomeViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/home/HomeViewModel.java
@@ -3,7 +3,6 @@ package com.github.dedis.student20_pop.home;
 import android.Manifest;
 import android.app.Application;
 import android.content.pm.PackageManager;
-import java.util.Base64;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -33,6 +32,7 @@ import com.google.gson.Gson;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -114,7 +114,7 @@ public class HomeViewModel extends AndroidViewModel
   @Override
   public void onQRCodeDetected(Barcode barcode) {
     Log.d(TAG, "Detected barcode with value: " + barcode.rawValue);
-    String channel = barcode.rawValue;
+    String channel = "/root/"+barcode.rawValue;
     mLAORepository
           .sendSubscribe(channel)
           .observeOn(AndroidSchedulers.mainThread())

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/MessageGeneral.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/MessageGeneral.java
@@ -1,5 +1,6 @@
 package com.github.dedis.student20_pop.model.network.method.message;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import android.util.Log;
 
@@ -88,7 +89,7 @@ public final class MessageGeneral {
   }
 
   public String getMessageId() {
-    return Base64.getUrlEncoder().encodeToString(this.messageId);
+    return new String(this.messageId, StandardCharsets.UTF_8);
   }
 
   public String getSender() {

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/data/lao/CreateLao.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/data/lao/CreateLao.java
@@ -39,7 +39,7 @@ public class CreateLao extends Data {
   public CreateLao(String name, String organizer) {
     this.name = name;
     this.organizer = organizer;
-    this.creation = Instant.now().toEpochMilli();
+    this.creation = Instant.now().getEpochSecond();
     this.id = Hash.hash("L", organizer, Long.toString(creation), name);
     this.witnesses = new ArrayList<>();
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/data/lao/CreateLao.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/data/lao/CreateLao.java
@@ -40,7 +40,7 @@ public class CreateLao extends Data {
     this.name = name;
     this.organizer = organizer;
     this.creation = Instant.now().getEpochSecond();
-    this.id = Hash.hash("L", organizer, Long.toString(creation), name);
+    this.id = Hash.hash(organizer, Long.toString(creation), name);
     this.witnesses = new ArrayList<>();
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/data/rollcall/CreateRollCall.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/data/rollcall/CreateRollCall.java
@@ -42,8 +42,12 @@ public class CreateRollCall extends Data {
       @Nullable String description,
       String laoId) {
     this.name = name;
-    this.creation = Instant.now().toEpochMilli();
-    this.proposedStart= proposedStart;
+    this.creation = Instant.now().getEpochSecond();
+    if(proposedStart <= this.creation){
+      this.proposedStart = this.creation;
+    }else{
+      this.proposedStart = proposedStart;
+    }
     this.proposedEnd = proposedEnd;
     this.location = location;
     this.description = description;


### PR DESCRIPTION
- remove /root/ prefix in LAO QR code
- if proposed_start<creation_time then proposed_start is automatically set to creation_time
- the message_id of MessageGeneral was applying base64url encoding on the hash output twice
- remove the 'L' in the hash for the createLao (this is fixed by PR #366 but is not yet on master)

Adi and I tested that on fe1 we can connect to a LAO created by fe2 and create rollcalls. This PR contains only changes regarding the fe2 side.