### PR TITLE
Disabled html escaping, converted election setup's creation time to seconds

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/data/election/ElectionSetup.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/data/election/ElectionSetup.java
@@ -41,7 +41,7 @@ public class ElectionSetup extends Data {
             String question,
             String laoId) {
         this.name = name;
-        this.createdAt = Instant.now().toEpochMilli();
+        this.createdAt = Instant.now().getEpochSecond();
         this.startTime = start;
         this.endTime = end;
         this.lao = laoId;

--- a/fe2-android/app/src/prod/java/com/github/dedis/student20_pop/Injection.java
+++ b/fe2-android/app/src/prod/java/com/github/dedis/student20_pop/Injection.java
@@ -106,6 +106,7 @@ public class Injection {
         .registerTypeAdapter(Result.class, new JsonResultSerializer())
         .registerTypeAdapter(Answer.class, new JsonAnswerSerializer())
         .registerTypeAdapter(MessageGeneral.class, new JsonMessageGeneralSerializer())
+            .disableHtmlEscaping()
         .create();
   }
 


### PR DESCRIPTION
- Disabling html escaping prevents the "=" character from being encoded into "\u003d", which causes a parsing failure 
- the variable for the date of creation in ElectionSetup was in milliseconds, which was inconsistent with the rest of the timestamps that are in seconds