### PR TITLE
Cleaning and fix double click for dialog

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/detail/LaoDetailViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/detail/LaoDetailViewModel.java
@@ -838,10 +838,6 @@ public class LaoDetailViewModel extends AndroidViewModel implements CameraPermis
       mOpenAttendeesListEvent.postValue(new Event<>(rollCallId));
     }
 
-    public void logoutWallet(){
-        Wallet.getInstance().logout();
-    }
-
     @Override
     public void onPermissionGranted() {
         openQrCodeScanningRollCall();

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/detail/fragments/RollCallTokenFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/detail/fragments/RollCallTokenFragment.java
@@ -64,7 +64,7 @@ public class RollCallTokenFragment extends Fragment {
         String pk = "";
         Log.d(TAG, "rollcall: "+rollCallId);
         try {
-            Pair<byte[], byte[]> token = Wallet.getInstance().findKeyPair(firstLaoId, rollCallId);
+            Pair<byte[], byte[]> token = Wallet.getInstance().findKeyPair(firstLaoId, rollCall.getPersistentId());
             sk = Base64.getUrlEncoder().encodeToString(token.first);
             pk = Base64.getUrlEncoder().encodeToString(token.second);
         } catch (GeneralSecurityException e) {

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/home/fragments/ContentWalletFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/home/fragments/ContentWalletFragment.java
@@ -65,9 +65,7 @@ public class ContentWalletFragment extends Fragment {
           mHomeViewModel.logoutWallet()
         );
         builder.setNegativeButton(R.string.cancel, (dialog, which) -> dialog.dismiss());
-        AlertDialog alert = builder.create();
-        alert.setCanceledOnTouchOutside(true);
-        alert.show();
+        builder.show();
       });
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/home/fragments/ContentWalletFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/home/fragments/ContentWalletFragment.java
@@ -31,6 +31,7 @@ public class ContentWalletFragment extends Fragment {
   private FragmentContentWalletBinding mContentWalletBinding;
   private HomeViewModel mHomeViewModel;
   private LAOListAdapter mListAdapter;
+  private AlertDialog logoutAlert;
 
   @Nullable
   @Override
@@ -58,6 +59,9 @@ public class ContentWalletFragment extends Fragment {
     if(Wallet.getInstance().isSetUp()){
       mContentWalletBinding.logoutButton.setVisibility(View.VISIBLE);
       mContentWalletBinding.logoutButton.setOnClickListener(clicked -> {
+        if(logoutAlert!=null && logoutAlert.isShowing()) {
+          logoutAlert.dismiss();
+        }
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setTitle(R.string.logout_title);
         builder.setMessage(R.string.logout_message);
@@ -65,7 +69,8 @@ public class ContentWalletFragment extends Fragment {
           mHomeViewModel.logoutWallet()
         );
         builder.setNegativeButton(R.string.cancel, (dialog, which) -> dialog.dismiss());
-        builder.show();
+        logoutAlert = builder.create();
+        logoutAlert.show();
       });
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/home/fragments/SeedWalletFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/home/fragments/SeedWalletFragment.java
@@ -26,6 +26,7 @@ public class SeedWalletFragment extends Fragment {
   public static SeedWalletFragment newInstance() {
     return new SeedWalletFragment();
   }
+  private AlertDialog seedAlert;
 
   @Nullable
   @Override
@@ -81,6 +82,9 @@ public class SeedWalletFragment extends Fragment {
 
   private void setupConfirmSeedButton() {
     mSeedWalletFragBinding.buttonConfirmSeed.setOnClickListener(v -> {
+      if(seedAlert!=null && seedAlert.isShowing()) {
+        seedAlert.dismiss();
+      }
       AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
       builder.setTitle("You are sure you have saved the words somewhere?");
       builder.setPositiveButton("Yes", (dialog, which)-> {
@@ -92,7 +96,8 @@ public class SeedWalletFragment extends Fragment {
         }
       );
       builder.setNegativeButton("Cancel",(dialog, which)-> dialog.cancel());
-      builder.show();
+      seedAlert = builder.create();
+      seedAlert.show();
     });
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/home/fragments/WalletFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/home/fragments/WalletFragment.java
@@ -31,7 +31,7 @@ public class WalletFragment extends Fragment {
   public static WalletFragment newInstance() {
     return new WalletFragment();
   }
-
+  private AlertDialog seedAlert;
 
   @Nullable
   @Override
@@ -72,6 +72,9 @@ public class WalletFragment extends Fragment {
   private void setupOwnSeedButton() {
     String defaultSeed = "elbow six card empty next sight turn quality capital please vocal indoor";
     mWalletFragBinding.buttonOwnSeed.setOnClickListener(v ->{
+      if(seedAlert!=null && seedAlert.isShowing()) {
+        seedAlert.dismiss();
+      }
       AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
       builder.setTitle("Type the 12 word seed:");
 
@@ -99,8 +102,9 @@ public class WalletFragment extends Fragment {
         }
       );
       builder.setNegativeButton("Cancel",  (dialog,which) -> dialog.cancel());
-      builder.show();
-    } );
+      seedAlert = builder.create();
+      seedAlert.show();
+    });
   }
 
   private void setupNewWalletButton() {

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/RollCall.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/RollCall.java
@@ -10,7 +10,7 @@ import java.util.Set;
 public class RollCall extends Event {
 
   private String id;
-  private String persistentId;
+  private final String persistentId;
   private String name;
   private long creation;
   private long start;
@@ -21,7 +21,9 @@ public class RollCall extends Event {
   private String location;
   private String description;
 
-  public RollCall() {
+  public RollCall(String id) {
+    this.id = id;
+    this.persistentId = id;
     this.attendees = new HashSet<>();
   }
 
@@ -35,10 +37,6 @@ public class RollCall extends Event {
 
   public String getPersistentId() {
     return persistentId;
-  }
-
-  public void setPersistentId(String persistentId) {
-    this.persistentId = persistentId;
   }
 
   public String getName() {

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/data/LAORepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/data/LAORepository.java
@@ -379,9 +379,7 @@ public class LAORepository {
     Lao lao = laoById.get(channel).getLao();
     Log.d(TAG, "handleCreateRollCall: " + channel + " name " + createRollCall.getName());
 
-    RollCall rollCall = new RollCall();
-    rollCall.setId(createRollCall.getId());
-    rollCall.setPersistentId(createRollCall.getId());
+    RollCall rollCall = new RollCall(createRollCall.getId());
     rollCall.setCreation(createRollCall.getCreation());
     rollCall.setState(EventState.CREATED);
     rollCall.setStart(createRollCall.getProposedStart());

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/qrcode/QRCodeScanningFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/qrcode/QRCodeScanningFragment.java
@@ -153,9 +153,7 @@ public final class QRCodeScanningFragment extends Fragment {
 
   private void setupCloseRollCallButton() {
     mQrCodeFragBinding.addAttendeeConfirm.setOnClickListener(
-            clicked -> {
-                setupClickCloseListener(R.id.fragment_lao_detail);
-            }
+            clicked -> setupClickCloseListener(R.id.fragment_lao_detail)
     );
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/qrcode/QRCodeScanningFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/qrcode/QRCodeScanningFragment.java
@@ -40,6 +40,7 @@ public final class QRCodeScanningFragment extends Fragment {
   private BarcodeDetector barcodeDetector;
   private Integer nbAttendees = 0;
   private boolean isCloseDialogBusy = false;
+  private AlertDialog closeRollCallAlert;
 
   /** Fragment constructor */
   public QRCodeScanningFragment(CameraSource camera, BarcodeDetector detector) {
@@ -158,24 +159,24 @@ public final class QRCodeScanningFragment extends Fragment {
   }
 
   private void setupClickCloseListener(int nextFragment){
-    if(!isCloseDialogBusy) {
-      AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-      builder.setTitle("Close Roll Call");
-      builder.setMessage("You have scanned " + nbAttendees + " attendees.");
-      builder.setOnDismissListener(dialog -> {
-        isCloseDialogBusy = false;
-        startCamera();
-      });
-      builder.setPositiveButton(R.string.confirm, (dialog, which) ->
-              ((LaoDetailViewModel) mQRCodeScanningViewModel).closeRollCall(nextFragment)
-      );
-      builder.setNegativeButton(R.string.cancel, (dialog, which) ->
-          dialog.dismiss()
-      );
-      mPreview.stop();
-      builder.show();
-      isCloseDialogBusy = true;
+    if(closeRollCallAlert!=null && closeRollCallAlert.isShowing()) {
+      closeRollCallAlert.dismiss();
     }
+    AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+    builder.setTitle("Close Roll Call");
+    builder.setMessage("You have scanned " + nbAttendees + " attendees.");
+    builder.setOnDismissListener(dialog ->
+      startCamera()
+    );
+    builder.setPositiveButton(R.string.confirm, (dialog, which) ->
+            ((LaoDetailViewModel) mQRCodeScanningViewModel).closeRollCall(nextFragment)
+    );
+    builder.setNegativeButton(R.string.cancel, (dialog, which) ->
+            dialog.dismiss()
+    );
+    mPreview.stop();
+    closeRollCallAlert = builder.create();
+    closeRollCallAlert.show();
   }
 
   private void setupSuccessPopup(String msg){

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/qrcode/QRCodeScanningFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/qrcode/QRCodeScanningFragment.java
@@ -39,6 +39,7 @@ public final class QRCodeScanningFragment extends Fragment {
   private CameraPreview mPreview;
   private BarcodeDetector barcodeDetector;
   private Integer nbAttendees = 0;
+  private boolean isCloseDialogBusy = false;
 
   /** Fragment constructor */
   public QRCodeScanningFragment(CameraSource camera, BarcodeDetector detector) {
@@ -152,23 +153,31 @@ public final class QRCodeScanningFragment extends Fragment {
 
   private void setupCloseRollCallButton() {
     mQrCodeFragBinding.addAttendeeConfirm.setOnClickListener(
-            clicked -> setupClickCloseListener(R.id.fragment_lao_detail)
+            clicked -> {
+                setupClickCloseListener(R.id.fragment_lao_detail);
+            }
     );
   }
 
   private void setupClickCloseListener(int nextFragment){
-    AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-    builder.setTitle("Close Roll Call");
-    builder.setMessage("You have scanned "+nbAttendees+" attendees.");
-    builder.setOnDismissListener(dialog -> startCamera());
-    builder.setPositiveButton(R.string.confirm, (dialog, which) ->
-              ((LaoDetailViewModel)mQRCodeScanningViewModel).closeRollCall(nextFragment)
-    );
-    builder.setNegativeButton(R.string.cancel, (dialog, which) -> dialog.dismiss());
-    AlertDialog alert = builder.create();
-    alert.setCanceledOnTouchOutside(true);
-    mPreview.stop();
-    alert.show();
+    if(!isCloseDialogBusy) {
+      AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+      builder.setTitle("Close Roll Call");
+      builder.setMessage("You have scanned " + nbAttendees + " attendees.");
+      builder.setOnDismissListener(dialog -> {
+        isCloseDialogBusy = false;
+        startCamera();
+      });
+      builder.setPositiveButton(R.string.confirm, (dialog, which) ->
+              ((LaoDetailViewModel) mQRCodeScanningViewModel).closeRollCall(nextFragment)
+      );
+      builder.setNegativeButton(R.string.cancel, (dialog, which) ->
+          dialog.dismiss()
+      );
+      mPreview.stop();
+      builder.show();
+      isCloseDialogBusy = true;
+    }
   }
 
   private void setupSuccessPopup(String msg){
@@ -177,7 +186,6 @@ public final class QRCodeScanningFragment extends Fragment {
     builder.setMessage(msg);
     builder.setOnDismissListener(dialog -> startCamera());
     AlertDialog alert = builder.create();
-    alert.setCanceledOnTouchOutside(true);
     mPreview.stop();
     alert.show();
     new Handler().postDelayed(new Runnable() {
@@ -200,9 +208,7 @@ public final class QRCodeScanningFragment extends Fragment {
         dialog.dismiss();
       }
     });
-    AlertDialog alert = builder.create();
-    alert.setCanceledOnTouchOutside(true);
     mPreview.stop();
-    alert.show();
+    builder.show();
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/qrcode/QRCodeScanningFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/qrcode/QRCodeScanningFragment.java
@@ -39,7 +39,6 @@ public final class QRCodeScanningFragment extends Fragment {
   private CameraPreview mPreview;
   private BarcodeDetector barcodeDetector;
   private Integer nbAttendees = 0;
-  private boolean isCloseDialogBusy = false;
   private AlertDialog closeRollCallAlert;
 
   /** Fragment constructor */

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Student 20 PoP</string>
+    <string name="app_name">Student 21 PoP</string>
 
     <!-- Top Tabs -->
     <string name="tab_home">Home</string>


### PR DESCRIPTION
- changed name of app to "Student 21 PoP"
- changed the persistentId in RollCall to final
- use persistentId to display token in RollTokenFragment
- bug: when double clicking on a button that shows a dialog it might show up twice and could crash the app if we click on confirm the first time and click on one of the buttons on the second one. The problem was always appearing for the close roll-call dialog and very rarely to the others. It probably depends on how much time the code for setting the builder takes. Is this a clean solution ? If it is I could do something similar for the others.