### PR TITLE
Fix Message Id

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/MessageGeneral.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/MessageGeneral.java
@@ -1,6 +1,5 @@
 package com.github.dedis.student20_pop.model.network.method.message;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import android.util.Log;
 

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/MessageGeneral.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/MessageGeneral.java
@@ -85,14 +85,13 @@ public final class MessageGeneral {
   }
 
   private void generateId() {
-    this.messageId = Base64.getUrlEncoder().encode(
-            Hash.hash(Base64.getUrlEncoder().encodeToString(this.dataBuf), Base64.getUrlEncoder().encodeToString(this.signature)).getBytes()
-    )
-    ;
+    this.messageId =
+            Hash.hash(Base64.getUrlEncoder().encodeToString(this.dataBuf), Base64.getUrlEncoder().encodeToString(this.signature)).getBytes();
+
   }
 
   public String getMessageId() {
-    return new String(this.messageId, StandardCharsets.UTF_8);
+    return Base64.getUrlEncoder().encodeToString(messageId);
   }
 
   public String getSender() {

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/MessageGeneral.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/MessageGeneral.java
@@ -86,7 +86,6 @@ public final class MessageGeneral {
   private void generateId() {
     this.messageId =
             Hash.hash(Base64.getUrlEncoder().encodeToString(this.dataBuf), Base64.getUrlEncoder().encodeToString(this.signature)).getBytes();
-
   }
 
   public String getMessageId() {

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/MessageGeneral.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/MessageGeneral.java
@@ -85,7 +85,10 @@ public final class MessageGeneral {
   }
 
   private void generateId() {
-    this.messageId = Hash.hash(Base64.getUrlEncoder().encodeToString(this.dataBuf), Base64.getUrlEncoder().encodeToString(this.signature)).getBytes();
+    this.messageId = Base64.getUrlEncoder().encode(
+            Hash.hash(Base64.getUrlEncoder().encodeToString(this.dataBuf), Base64.getUrlEncoder().encodeToString(this.signature)).getBytes()
+    )
+    ;
   }
 
   public String getMessageId() {


### PR DESCRIPTION
Issue : the message Id was never Base 64 encoded so when we transformed it into a string it gave some weird UFT8 character. 
![AF30E74C-1F29-45A6-9E18-87E07883D1FD](https://user-images.githubusercontent.com/48682328/122011229-2b5d1b80-cdbc-11eb-91b7-7405db34ecc3.JPG)
