### PR TITLE
Fix JsonMessageGeneralSerializer message_id issue

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/MessageGeneral.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/model/network/method/message/MessageGeneral.java
@@ -1,6 +1,5 @@
 package com.github.dedis.student20_pop.model.network.method.message;
 
-import java.util.Base64;
 import android.util.Log;
 
 import com.github.dedis.student20_pop.model.network.method.message.data.Data;
@@ -11,8 +10,10 @@ import com.google.crypto.tink.PublicKeyVerify;
 import com.google.crypto.tink.subtle.Ed25519Verify;
 import com.google.gson.Gson;
 
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 /**
@@ -84,12 +85,12 @@ public final class MessageGeneral {
   }
 
   private void generateId() {
-    this.messageId =
-            Hash.hash(Base64.getUrlEncoder().encodeToString(this.dataBuf), Base64.getUrlEncoder().encodeToString(this.signature)).getBytes();
+    this.messageId = Hash.hash(Base64.getUrlEncoder().encodeToString(this.dataBuf), Base64.getUrlEncoder().encodeToString(this.signature)).getBytes(StandardCharsets.UTF_8);
   }
 
   public String getMessageId() {
-    return Base64.getUrlEncoder().encodeToString(messageId);
+    Log.d(TAG, "Message ID: " + new String(this.messageId, StandardCharsets.UTF_8));
+    return new String(this.messageId, StandardCharsets.UTF_8);
   }
 
   public String getSender() {

--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/utility/json/JsonMessageGeneralSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/utility/json/JsonMessageGeneralSerializer.java
@@ -19,6 +19,7 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -34,8 +35,7 @@ public class JsonMessageGeneralSerializer
           throws JsonParseException {
     JsonObject root = json.getAsJsonObject();
 
-
-    byte[] messageId = Base64.getUrlDecoder().decode(root.get("message_id").getAsString());
+    byte[] messageId = root.get("message_id").getAsString().getBytes(StandardCharsets.UTF_8);
     byte[] dataBuf = Base64.getUrlDecoder().decode(root.get("data").getAsString());
     byte[] sender = Base64.getUrlDecoder().decode(root.get("sender").getAsString());
     byte[] signature = Base64.getUrlDecoder().decode(root.get(SIG).getAsString());


### PR DESCRIPTION
The issue from PR #387.

- MessageGeneral: `messageId` is not encoded twice on `getMessageId` 
- JsonMessageGeneralSerializer: `message_id` is not decoded, because the message id is kept Base64URL encoded in MessageGeneral