### PR TITLE
Fix election selection bug

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/student20_pop/detail/adapters/EventExpandableListViewAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/student20_pop/detail/adapters/EventExpandableListViewAdapter.java
@@ -327,15 +327,23 @@ public class EventExpandableListViewAdapter extends BaseExpandableListAdapter {
         viewModel.setCurrentElection(election);
         if (category == PRESENT) {
             electionBinding.electionActionButton.setOnClickListener(
-                    clicked -> viewModel.openCastVotes());
+                    clicked -> {
+                        viewModel.setCurrentElection(election);
+                        viewModel.openCastVotes();
+                    });
         } else if (category == PAST) {
             electionBinding.electionActionButton.setOnClickListener(
-                    clicked -> viewModel.openElectionResults(true));
+                    clicked -> {
+                        viewModel.setCurrentElection(election);
+                        viewModel.openElectionResults(true);
+                    });
 
         }
 
-        electionBinding.electionEditButton.setOnClickListener(clicked ->
-            viewModel.openManageElection(true)
+        electionBinding.electionEditButton.setOnClickListener(clicked -> {
+            viewModel.setCurrentElection(election);
+            viewModel.openManageElection(true);
+                }
         );
         electionBinding.setEventCategory(category);
         electionBinding.setViewModel(viewModel);


### PR DESCRIPTION
- Before the current election in the view model was not set in the button listener but outside. It means that when a button was pressed the current election was always the last one created because it is the last one getChildView in EventExpandableListViewAdapter calls.
- fixes  #390 