### PR TITLE
PipelineErrors generate the correct reply rpc id

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/AnswerGenerator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/AnswerGenerator.scala
@@ -26,8 +26,8 @@ object AnswerGenerator {
           case DbActor.DbActorCatchupAck(list: List[Message]) =>
             val resultObject: ResultObject = new ResultObject(list)
             Left(JsonRpcResponse(RpcValidator.JSON_RPC_VERSION, Some(resultObject), None, rpcRequest.id))
-          case DbActor.DbActorNAck(code, description) => Right(PipelineError(code, description))
-          case _ => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "Database actor returned an unknown answer"))
+          case DbActor.DbActorNAck(code, description) => Right(PipelineError(code, description, rpcRequest.id))
+          case _ => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "Database actor returned an unknown answer", rpcRequest.id))
         }
 
         Await.result(f, DbActor.getDuration)
@@ -41,18 +41,19 @@ object AnswerGenerator {
       ))
     }
 
-    // TODO null id
+    // Convert PipelineErrors into negative JsonRpcResponses
     case Right(pipelineError: PipelineError) => Left(JsonRpcResponse(
       RpcValidator.JSON_RPC_VERSION,
       None,
       Some(ErrorObject(pipelineError.code, pipelineError.description)),
-      None
+      pipelineError.rpcId
     ))
 
     // /!\ If something is outputted as Right(...), then there's a mistake somewhere in the graph!
     case _ => Right(PipelineError(
       ErrorCodes.SERVER_ERROR.id,
-      s"Internal server error: unknown reason. The MessageEncoder could not decide what to do with input $graphMessage"
+      s"Internal server error: unknown reason. The MessageEncoder could not decide what to do with input $graphMessage",
+      None
     ))
   }
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/MessageDecoder.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/MessageDecoder.scala
@@ -34,7 +34,8 @@ object MessageDecoder {
         }
       case _ => Right(PipelineError(
         ErrorCodes.INVALID_DATA.id,
-        "MessageDecoder parsing failed : input json is not correctly formatted"
+        "MessageDecoder parsing failed : input json is not correctly formatted (and thus unknown rpcId).",
+        None // no rpcId since we couldn't decrypt the message
       ))
     }
 
@@ -115,16 +116,18 @@ object MessageDecoder {
               typedRequest = typeCastRequest(jsonRpcRequest)
             } match {
               case Success(_) => Left(typedRequest) // everything worked at expected, 'decodedData' field was populated
-              case Failure(exception) => Right(PipelineError(ErrorCodes.INVALID_DATA.id, s"Invalid data: $exception"))
+              case Failure(exception) => Right(PipelineError(ErrorCodes.INVALID_DATA.id, s"Invalid data: $exception", jsonRpcRequest.id))
             }
 
           case Success(_) => Right(PipelineError(
             ErrorCodes.INVALID_DATA.id,
-            "Invalid data: Unable to parse 'data' field: 'object' or 'action' field is missing/wrongly formatted"
+            "Invalid data: Unable to parse 'data' field: 'object' or 'action' field is missing/wrongly formatted",
+            jsonRpcRequest.id
           ))
           case _ => Right(PipelineError(
             ErrorCodes.INVALID_DATA.id,
-            "Invalid data: Unable to parse 'data' field: 'data' is not a valid json string"
+            "Invalid data: Unable to parse 'data' field: 'data' is not a valid json string",
+            jsonRpcRequest.id
           ))
         }
     }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/PipelineError.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/PipelineError.scala
@@ -1,6 +1,15 @@
 package ch.epfl.pop.pubsub.graph
 
-final case class PipelineError(code: Int, description: String)
+/**
+ * All errors encountered during the graph traversal is embedded inside a [[PipelineError]]
+ *
+ * @param code error code of the error
+ * @param description description of the error
+ * @param rpcId rpc-id of the client request (if available)
+ *
+ * Note: the rpcId is used later in the graph at the 'Answerer' stage
+ */
+final case class PipelineError(code: Int, description: String, rpcId: Option[Int])
 
 object ErrorCodes extends Enumeration {
   type ErrorCodes = Value

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/MessageHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/MessageHandler.scala
@@ -28,10 +28,10 @@ trait MessageHandler {
           case true =>
             // FIXME propagate
             Left(rpcMessage)
-          case _ => Right(PipelineError(-10, "")) // FIXME add DbActor "answers" with error description if failed
+          case _ => Right(PipelineError(-10, "", rpcMessage.id)) // FIXME add DbActor "answers" with error description if failed
         }
         Await.result(ask, DbActor.getDuration)
-      case _ => Right(PipelineError(ErrorCodes.INVALID_DATA.id, s"RPC-params does not contain any message"))
+      case _ => Right(PipelineError(ErrorCodes.INVALID_DATA.id, s"RPC-params does not contain any message", rpcMessage.id))
     }
   }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsHandler.scala
@@ -54,14 +54,14 @@ object ParamsHandler {
     case Left(jsonRpcMessage: Subscribe) =>
       // ActorFlow.ask(clientActorRef)(makeMessage = (el, replyTo: ActorRef) => SubscribeTo(channel))
       clientActorRef ! ClientActor.SubscribeTo(jsonRpcMessage.channel)
-      Right(PipelineError(-100, "FIXME: should use akka ask pattern to create an ActorFlow"))
+      Right(PipelineError(-100, "", Some(-111))) // FIXME: should use akka ask pattern to create an ActorFlow
     case graphMessage@_ => graphMessage
   }
 
   def unsubscribeHandler(clientActorRef: ActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map {
     case Left(jsonRpcMessage: Unsubscribe) =>
       clientActorRef ! ClientActor.UnsubscribeFrom(jsonRpcMessage.channel)
-      Right(PipelineError(-100, "FIXME: should use akka ask pattern to create an ActorFlow"))
+      Right(PipelineError(-100, "", Some(-111))) // FIXME: should use akka ask pattern to create an ActorFlow
     case graphMessage@_ => graphMessage
   }
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/ContentValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/ContentValidator.scala
@@ -12,6 +12,6 @@ trait ContentValidator {
    * @param errorCode error code related to the error
    * @return a description of the error and where it occurred
    */
-  def validationError(reason: String, validator: String, errorCode: ErrorCodes.ErrorCodes = ErrorCodes.INVALID_DATA): PipelineError =
-    PipelineError(errorCode.id, s"$validator content validation failed: $reason")
+  def validationError(reason: String, validator: String, rpcId: Option[Int], errorCode: ErrorCodes.ErrorCodes = ErrorCodes.INVALID_DATA): PipelineError =
+    PipelineError(errorCode.id, s"$validator content validation failed: $reason", rpcId)
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidator.scala
@@ -13,7 +13,7 @@ import scala.concurrent.{Await, Future}
 
 case object LaoValidator extends MessageDataContentValidator {
   def validateCreateLao(rpcMessage: JsonRpcRequest): GraphMessage = {
-    def validationError(reason: String): PipelineError = super.validationError(reason, "CreateLao")
+    def validationError(reason: String): PipelineError = super.validationError(reason, "CreateLao", rpcMessage.id)
 
     rpcMessage.getParamsMessage match {
       case Some(message: Message) =>
@@ -31,12 +31,12 @@ case object LaoValidator extends MessageDataContentValidator {
         } else {
           Left(rpcMessage)
         }
-      case _ => Right(validationErrorNoMessage)
+      case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }
 
   def validateStateLao(rpcMessage: JsonRpcRequest): GraphMessage = {
-    def validationError(reason: String): PipelineError = super.validationError(reason, "StateLao")
+    def validationError(reason: String): PipelineError = super.validationError(reason, "StateLao", rpcMessage.id)
 
     rpcMessage.getParamsMessage match {
       case Some(message: Message) =>
@@ -66,21 +66,21 @@ case object LaoValidator extends MessageDataContentValidator {
             }
 
           case DbActor.DbActorReadAck(None) =>
-            Right(PipelineError(ErrorCodes.INVALID_RESOURCE.id, "No CreateLao message associated found"))
+            Right(PipelineError(ErrorCodes.INVALID_RESOURCE.id, "No CreateLao message associated found", rpcMessage.id))
           case DbActor.DbActorNAck(code, description) =>
-            Right(PipelineError(code, description))
+            Right(PipelineError(code, description, rpcMessage.id))
           case _ =>
-            Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "Database actor returned an unknown answer"))
+            Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "Database actor returned an unknown answer", rpcMessage.id))
         }
 
         Await.result(f, duration)
 
-      case _ => Right(validationErrorNoMessage)
+      case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }
 
   def validateUpdateLao(rpcMessage: JsonRpcRequest): GraphMessage = {
-    def validationError(reason: String): PipelineError = super.validationError(reason, "UpdateLao")
+    def validationError(reason: String): PipelineError = super.validationError(reason, "UpdateLao", rpcMessage.id)
 
     rpcMessage.getParamsMessage match {
       case Some(message: Message) =>
@@ -106,16 +106,16 @@ case object LaoValidator extends MessageDataContentValidator {
             }
 
           case DbActor.DbActorReadAck(None) =>
-            Right(PipelineError(ErrorCodes.INVALID_RESOURCE.id, "No CreateLao message associated found"))
+            Right(PipelineError(ErrorCodes.INVALID_RESOURCE.id, "No CreateLao message associated found", rpcMessage.id))
           case DbActor.DbActorNAck(code, description) =>
-            Right(PipelineError(code, description))
+            Right(PipelineError(code, description, rpcMessage.id))
           case _ =>
-            Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "Database actor returned an unknown answer"))
+            Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "Database actor returned an unknown answer", rpcMessage.id))
         }
 
         Await.result(f, duration)
 
-      case _ => Right(validationErrorNoMessage)
+      case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MeetingValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MeetingValidator.scala
@@ -9,7 +9,7 @@ import ch.epfl.pop.pubsub.graph.{GraphMessage, PipelineError}
 
 case object MeetingValidator extends MessageDataContentValidator {
   def validateCreateMeeting(rpcMessage: JsonRpcRequest): GraphMessage = {
-    def validationError(reason: String): PipelineError = super.validationError(reason, "CreateMeeting")
+    def validationError(reason: String): PipelineError = super.validationError(reason, "CreateMeeting", rpcMessage.id)
 
     rpcMessage.getParamsMessage match {
       case Some(message: Message) =>
@@ -27,12 +27,12 @@ case object MeetingValidator extends MessageDataContentValidator {
         } else {
           Left(rpcMessage)
         }
-      case _ => Right(validationErrorNoMessage)
+      case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }
 
   def validateStateMeeting(rpcMessage: JsonRpcRequest): GraphMessage = {
-    def validationError(reason: String): PipelineError = super.validationError(reason, "StateMeeting")
+    def validationError(reason: String): PipelineError = super.validationError(reason, "StateMeeting", rpcMessage.id)
 
     rpcMessage.getParamsMessage match {
       case Some(message: Message) =>
@@ -56,7 +56,7 @@ case object MeetingValidator extends MessageDataContentValidator {
         } else {
           Left(rpcMessage)
         }
-      case _ => Right(validationErrorNoMessage)
+      case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageDataContentValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageDataContentValidator.scala
@@ -21,10 +21,10 @@ trait MessageDataContentValidator extends ContentValidator {
    * @param errorCode error code related to the error
    * @return a description of the error and where it occurred
    */
-  override def validationError(reason: String, validator: String, errorCode: ErrorCodes.ErrorCodes = ErrorCodes.INVALID_DATA): PipelineError =
-    super.validationError(reason, validator, errorCode)
+  override def validationError(reason: String, validator: String, rpcId: Option[Int], errorCode: ErrorCodes.ErrorCodes = ErrorCodes.INVALID_DATA): PipelineError =
+    super.validationError(reason, validator, rpcId, errorCode)
 
-  final val validationErrorNoMessage: PipelineError = PipelineError(ErrorCodes.INVALID_DATA.id, s"RPC-params does not contain any message")
+  def validationErrorNoMessage(rpcId: Option[Int]): PipelineError = PipelineError(ErrorCodes.INVALID_DATA.id, s"RPC-params does not contain any message", rpcId)
 
   // Lower bound for a timestamp to not be stale
   final val TIMESTAMP_BASE_TIME: Timestamp = Timestamp(1577833200L) // 1st january 2020

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidator.scala
@@ -13,8 +13,8 @@ object MessageValidator extends ContentValidator {
    * @param errorCode error code related to the error
    * @return a description of the error and where it occurred
    */
-  override def validationError(reason: String, validator: String, errorCode: ErrorCodes.ErrorCodes = ErrorCodes.INVALID_DATA): PipelineError =
-    super.validationError(reason, validator, errorCode)
+  override def validationError(reason: String, validator: String, rpcId: Option[Int], errorCode: ErrorCodes.ErrorCodes = ErrorCodes.INVALID_DATA): PipelineError =
+    super.validationError(reason, validator, rpcId, errorCode)
 
   def validateMessage(rpcMessage: JsonRpcMessage): GraphMessage = Left(rpcMessage)
   /** TODO: Verifications on the message

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MethodContentValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MethodContentValidator.scala
@@ -16,8 +16,8 @@ trait MethodContentValidator extends ContentValidator {
    * @param errorCode error code related to the error
    * @return a description of the error and where it occurred
    */
-  override def validationError(reason: String, validator: String, errorCode: ErrorCodes.ErrorCodes = ErrorCodes.INVALID_DATA): PipelineError =
-    super.validationError(reason, validator, errorCode)
+  override def validationError(reason: String, validator: String, rpcId: Option[Int], errorCode: ErrorCodes.ErrorCodes = ErrorCodes.INVALID_DATA): PipelineError =
+    super.validationError(reason, validator, rpcId, errorCode)
 
   def validateChannel(channel: Channel): Boolean = channel match {
     case _ if channel.isRootChannel => true

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/ParamsValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/ParamsValidator.scala
@@ -5,11 +5,11 @@ import ch.epfl.pop.pubsub.graph.{GraphMessage, PipelineError}
 
 object ParamsValidator extends MethodContentValidator {
 
-  final def validationError(reason: String): PipelineError = super.validationError(reason, "MethodValidator")
+  final def validationError(reason: String, rpcId: Option[Int]): PipelineError = super.validationError(reason, "MethodValidator", rpcId)
 
   private def validateGeneralParams(rpcMessage: JsonRpcRequest): GraphMessage = {
     if (!validateChannel(rpcMessage.getParamsChannel)) {
-      Right(ParamsValidator.validationError("Channel validation failed"))
+      Right(ParamsValidator.validationError("Channel validation failed", rpcMessage.id))
     } else {
       Left(rpcMessage)
     }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
@@ -10,7 +10,7 @@ import ch.epfl.pop.pubsub.graph.{GraphMessage, PipelineError}
 case object RollCallValidator extends MessageDataContentValidator {
   // TODO the roll call validator checks with the old roll call specs!
   def validateCreateRollCall(rpcMessage: JsonRpcRequest): GraphMessage = {
-    def validationError(reason: String): PipelineError = super.validationError(reason, "CreateRollCall")
+    def validationError(reason: String): PipelineError = super.validationError(reason, "CreateRollCall", rpcMessage.id)
 
     rpcMessage.getParamsMessage match {
       case Some(message: Message) =>
@@ -30,13 +30,13 @@ case object RollCallValidator extends MessageDataContentValidator {
         } else {
           Left(rpcMessage)
         }
-      case _ => Right(validationErrorNoMessage)
+      case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }
 
   // TODO check that this is correct (correct validations)
   def validateOpenRollCall(rpcMessage: JsonRpcRequest): GraphMessage = {
-    def validationError(reason: String): PipelineError = super.validationError(reason, "OpenRollCall")
+    def validationError(reason: String): PipelineError = super.validationError(reason, "OpenRollCall", rpcMessage.id)
 
     rpcMessage.getParamsMessage match {
       case Some(message: Message) =>
@@ -47,13 +47,13 @@ case object RollCallValidator extends MessageDataContentValidator {
         } else {
           Left(rpcMessage)
         }
-      case _ => Right(validationErrorNoMessage)
+      case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }
 
   // TODO check that this is correct (correct validations)
   def validateReopenRollCall(rpcMessage: JsonRpcRequest): GraphMessage = {
-    def validationError(reason: String): PipelineError = super.validationError(reason, "ReopenRollCall")
+    def validationError(reason: String): PipelineError = super.validationError(reason, "ReopenRollCall", rpcMessage.id)
 
     rpcMessage.getParamsMessage match {
       case Some(message: Message) =>
@@ -64,13 +64,13 @@ case object RollCallValidator extends MessageDataContentValidator {
         } else {
           Left(rpcMessage)
         }
-      case _ => Right(validationErrorNoMessage)
+      case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }
 
   // TODO check that this is correct (correct validations)
   def validateCloseRollCall(rpcMessage: JsonRpcRequest): GraphMessage = {
-    def validationError(reason: String): PipelineError = super.validationError(reason, "CloseRollCall")
+    def validationError(reason: String): PipelineError = super.validationError(reason, "CloseRollCall", rpcMessage.id)
 
     rpcMessage.getParamsMessage match {
       case Some(message: Message) =>
@@ -83,7 +83,7 @@ case object RollCallValidator extends MessageDataContentValidator {
         } else {
           Left(rpcMessage)
         }
-      case _ => Right(validationErrorNoMessage)
+      case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RpcValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RpcValidator.scala
@@ -15,13 +15,13 @@ object RpcValidator extends ContentValidator {
   }
 
   def validateRpcRequest(rpcMessage: JsonRpcRequest): GraphMessage = {
-    def validationError(reason: String): PipelineError = super.validationError(reason, "RpcRequest")
+    def validationError(reason: String): PipelineError = super.validationError(reason, "RpcRequest", rpcMessage.id)
 
     validateGeneralRpc(rpcMessage, validationError)
   }
 
   def validateRpcResponse(rpcMessage: JsonRpcResponse): GraphMessage = {
-    def validationError(reason: String): PipelineError = super.validationError(reason, "RpcResponse")
+    def validationError(reason: String): PipelineError = super.validationError(reason, "RpcResponse", rpcMessage.id)
 
     validateGeneralRpc(rpcMessage, validationError)
   }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidator.scala
@@ -6,11 +6,11 @@ import ch.epfl.pop.pubsub.graph.{GraphMessage, PipelineError}
 
 case object WitnessValidator extends MessageDataContentValidator {
   def validateWitnessMessage(rpcMessage: JsonRpcRequest): GraphMessage = {
-    def validationError(reason: String): PipelineError = super.validationError(reason, "WitnessMessage")
+    def validationError(reason: String): PipelineError = super.validationError(reason, "WitnessMessage", rpcMessage.id)
 
     rpcMessage.getParamsMessage match {
       case Some(_) => Left(rpcMessage)
-      case _ => Right(validationErrorNoMessage)
+      case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }
 }


### PR DESCRIPTION
Up until now, if something went wrong in the graph, a PipelineError
was issued and the server would respond to the client with a 'null'
id (json-rpc id)