### PR TITLE
Avoid network redirections with default fe1/fe2 paths

### DIFF
--- a/be1-go/cli/witness/witness.go
+++ b/be1-go/cli/witness/witness.go
@@ -117,7 +117,7 @@ func Serve(cliCtx *cli.Context) error {
 func connectToWitnessSocket(otherHubType hub.HubType, address string, h hub.Hub,
 	wg *sync.WaitGroup, done chan struct{}, log zerolog.Logger) error {
 
-	urlString := fmt.Sprintf("ws://%s/%s/witness/", address, otherHubType)
+	urlString := fmt.Sprintf("ws://%s/%s/witness", address, otherHubType)
 	u, err := url.Parse(urlString)
 	if err != nil {
 		return xerrors.Errorf("failed to parse connection url %s %v", urlString, err)

--- a/be1-go/network/server.go
+++ b/be1-go/network/server.go
@@ -58,7 +58,7 @@ func NewServer(h hub.Hub, port int, st socket.SocketType, log zerolog.Logger) *S
 		log:     log,
 	}
 
-	path := fmt.Sprintf("/%s/%s/", h.Type(), st)
+	path := fmt.Sprintf("/%s/%s", h.Type(), st)
 	mux := http.NewServeMux()
 	mux.HandleFunc(path, server.ServeHTTP)
 


### PR DESCRIPTION
This was introduced during the refactoring and created some problems for both front-ends. 

Essentially, in this scenario, the `mux.HandleFunc()` call was redirecting `/a/b` to `/a/b/ `, but not all WebSocket clients support redirection. It was hidden away by the fact that we were often running the server behind a Nginx proxy.

It's easier to do the modification here than on both front-ends, especially as it's a temporary fix and bound to be configurable later on.