### PR TITLE
Use zerolog for logging 

### DIFF
--- a/be1-go/channel/election/mod.go
+++ b/be1-go/channel/election/mod.go
@@ -3,7 +3,8 @@ package election
 import (
 	"encoding/base64"
 	"encoding/json"
-	"log"
+	"github.com/rs/zerolog"
+	"os"
 	"popstellar/channel"
 	"popstellar/channel/inbox"
 	"popstellar/crypto"
@@ -15,10 +16,19 @@ import (
 	"popstellar/message/query/method/message"
 	"popstellar/network/socket"
 	"popstellar/validation"
+	"strconv"
 	"sync"
+	"time"
 
 	"golang.org/x/xerrors"
 )
+
+const defaultLevel = zerolog.InfoLevel
+
+var logout = zerolog.ConsoleWriter{
+	Out:        os.Stdout,
+	TimeFormat: time.RFC3339,
+}
 
 // attendees represents the attendees in an election.
 type attendees struct {
@@ -70,6 +80,11 @@ func NewChannel(channelPath string, start, end int64, terminated bool,
 	questions []messagedata.ElectionSetupQuestion, attendeesMap map[string]struct{},
 	msg message.Message, hub channel.HubFunctionalities) Channel {
 
+	log := zerolog.New(logout).Level(defaultLevel).
+		With().Timestamp().Logger().
+		With().Caller().Logger().
+		With().Str("role", "election channel").Logger()
+
 	// Saving on election channel too so it self-contains the entire election history
 	// electionCh.inbox.storeMessage(msg)
 	return Channel{
@@ -87,6 +102,8 @@ func NewChannel(channelPath string, start, end int64, terminated bool,
 		},
 
 		hub: hub,
+
+		log: log,
 	}
 }
 
@@ -115,6 +132,8 @@ type Channel struct {
 	attendees *attendees
 
 	hub channel.HubFunctionalities
+
+	log zerolog.Logger
 }
 
 // question represents a question in an election.
@@ -198,7 +217,9 @@ func (c *Channel) Publish(publish method.Publish) error {
 
 // Subscribe is used to handle a subscribe message from the client.
 func (c *Channel) Subscribe(socket socket.Socket, msg method.Subscribe) error {
-	log.Printf("received a subscribe with id: %d", msg.ID)
+	c.log.Info().
+		Str("msg id", strconv.Itoa(msg.ID)).
+		Msg("received a subscribe")
 	c.sockets.Upsert(socket)
 
 	return nil
@@ -206,7 +227,9 @@ func (c *Channel) Subscribe(socket socket.Socket, msg method.Subscribe) error {
 
 // Unsubscribe is used to handle an unsubscribe message.
 func (c *Channel) Unsubscribe(socketID string, msg method.Unsubscribe) error {
-	log.Printf("received an unsubscribe with id: %d", msg.ID)
+	c.log.Info().
+		Str("msg id", strconv.Itoa(msg.ID)).
+		Msg("received an unsubscribe")
 
 	ok := c.sockets.Delete(socketID)
 
@@ -219,7 +242,9 @@ func (c *Channel) Unsubscribe(socketID string, msg method.Unsubscribe) error {
 
 // Catchup is used to handle a catchup message.
 func (c *Channel) Catchup(catchup method.Catchup) []message.Message {
-	log.Printf("received a catchup with id: %d", catchup.ID)
+	c.log.Info().
+		Str("msg id", strconv.Itoa(catchup.ID)).
+		Msg("received a catchup")
 
 	return c.inbox.GetSortedMessages()
 }
@@ -227,6 +252,10 @@ func (c *Channel) Catchup(catchup method.Catchup) []message.Message {
 // broadcastToAllClients is a helper message to broadcast a message to all
 // subscribers.
 func (c *Channel) broadcastToAllClients(msg message.Message) {
+	c.log.Info().
+		Str("msg id", msg.MessageID).
+		Msg("broadcasting message to all clients")
+
 	rpcMessage := method.Broadcast{
 		Base: query.Base{
 			JSONRPCBase: jsonrpc.JSONRPCBase{
@@ -245,7 +274,7 @@ func (c *Channel) broadcastToAllClients(msg message.Message) {
 
 	buf, err := json.Marshal(&rpcMessage)
 	if err != nil {
-		log.Printf("failed to marshal broadcast query: %v", err)
+		c.log.Err(err).Msg("failed to marshal broadcast query")
 	}
 
 	c.sockets.SendToAll(buf)
@@ -253,7 +282,9 @@ func (c *Channel) broadcastToAllClients(msg message.Message) {
 
 // VerifyPublishMessage checks if a Publish message is valid
 func (c *Channel) VerifyPublishMessage(publish method.Publish) error {
-	log.Printf("received a publish with id: %d", publish.ID)
+	c.log.Info().
+		Str("msg id", strconv.Itoa(publish.ID)).
+		Msg("received a publish")
 
 	// Check if the structure of the message is correct
 	msg := publish.Params.Message
@@ -432,7 +463,9 @@ func (c *Channel) publishResultElection(msg message.Message) error {
 
 			resultElection.Questions = append(resultElection.Questions, electResult)
 
-			log.Printf("Appending a question id:%s with the count and result", id)
+			c.log.Info().
+				Str("question id", id).
+				Msg("appending a question with the count and result")
 		}
 	}
 

--- a/be1-go/cli/witness/witness.go
+++ b/be1-go/cli/witness/witness.go
@@ -128,7 +128,7 @@ func connectToWitnessSocket(otherHubType hub.HubType, address string, h hub.Hub,
 		return xerrors.Errorf("failed to dial to %s: %v", u.String(), err)
 	}
 
-	log.Printf("connected to %s at %s", otherHubType, urlString)
+	log.Info().Msgf("connected to %s at %s", otherHubType, urlString)
 
 	switch otherHubType {
 	case hub.OrganizerHubType:

--- a/be1-go/db/sqlite/cli/mod.go
+++ b/be1-go/db/sqlite/cli/mod.go
@@ -4,16 +4,29 @@ package main
 import (
 	"database/sql"
 	"flag"
-	"log"
+	"github.com/rs/zerolog"
 	"os"
+	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 )
+
+const defaultLevel = zerolog.InfoLevel
+
+var logout = zerolog.ConsoleWriter{
+	Out:        os.Stdout,
+	TimeFormat: time.RFC3339,
+}
 
 func main() {
 	var dbPath string
 	var schemaPath string
 	var force bool
+
+	log := zerolog.New(logout).Level(defaultLevel).
+		With().Timestamp().Logger().
+		With().Caller().Logger().
+		With().Str("role", "db").Logger()
 
 	flag.StringVar(&dbPath, "db", "pop_go_hub.db", "location of the database file")
 	flag.StringVar(&schemaPath, "schema", "schema.sql", "location of the SQL schema")
@@ -23,34 +36,34 @@ func main() {
 
 	_, err := os.Stat(dbPath)
 	if err == nil && !force {
-		log.Printf("db already exists, use -f if you want to overwrite it")
+		log.Err(err).Msg("db already exists, use -f if you want to overwrite it")
 		return
 	}
 
 	os.Remove(dbPath)
 
-	log.Println("opening db")
+	log.Info().Msg("opening db")
 
 	db, err := sql.Open("sqlite3", dbPath)
 	if err != nil {
-		log.Fatalf("failed to open db: %v", err)
+		log.Err(err).Msg("failed to open db")
 	}
 
 	defer db.Close()
 
-	log.Println("reading schema")
+	log.Info().Msg("reading schema")
 
 	schema, err := os.ReadFile(schemaPath)
 	if err != nil {
-		log.Fatalf("failed to read schema: %v", err)
+		log.Err(err).Msg("failed to read schema")
 	}
 
-	log.Println("setting up db")
+	log.Info().Msg("setting up db")
 
 	_, err = db.Exec(string(schema))
 	if err != nil {
-		log.Fatalf("failed to exec schema: %v", err)
+		log.Err(err).Msg("failed to exec schema")
 	}
 
-	log.Printf("done, db saved in %s", dbPath)
+	log.Info().Msgf("db successfully saved in %s", dbPath)
 }

--- a/be1-go/hub/witness/mod.go
+++ b/be1-go/hub/witness/mod.go
@@ -3,7 +3,6 @@ package witness
 import (
 	"context"
 	"fmt"
-	"log"
 	"popstellar/channel"
 	"popstellar/hub"
 	"popstellar/message/query/method"
@@ -99,7 +98,7 @@ func (h *Hub) handleIncomingMessage(incMsg *socket.IncomingMessage) {
 
 // Start implements hub.Hub
 func (h *Hub) Start() {
-	log.Printf("started witness...")
+	h.log.Info().Msg("started witness...")
 
 	go func() {
 		for {
@@ -107,7 +106,7 @@ func (h *Hub) Start() {
 			case incMsg := <-h.messageChan:
 				ok := h.workers.TryAcquire(1)
 				if !ok {
-					log.Print("warn: worker pool full, waiting...")
+					h.log.Warn().Msg("worker pool full, waiting...")
 					h.workers.Acquire(context.Background(), 1)
 				}
 
@@ -120,7 +119,7 @@ func (h *Hub) Start() {
 				}
 				h.RUnlock()
 			case <-h.stop:
-				log.Println("closing the hub...")
+				h.log.Info().Msg("closing the hub...")
 				return
 			}
 		}
@@ -130,7 +129,7 @@ func (h *Hub) Start() {
 // Stop implements hub.Hub
 func (h *Hub) Stop() {
 	close(h.stop)
-	log.Println("Waiting for existing workers to finish...")
+	h.log.Info().Msg("waiting for existing workers to finish...")
 	h.workers.Acquire(context.Background(), numWorkers)
 }
 

--- a/be1-go/network/socket/mod.go
+++ b/be1-go/network/socket/mod.go
@@ -1,4 +1,4 @@
-// The socket package contains an implementation of the Socket interface which
+// Package socket contains an implementation of the Socket interface which
 // is responsible for low level communication over websockets, i.e. sending
 // and receiving marshaled messages over the wire.
 //

--- a/be1-go/validation/schema_validator.go
+++ b/be1-go/validation/schema_validator.go
@@ -61,6 +61,7 @@ func init() {
 // VerifyJSON verifies that the `msg` follow the schema protocol of name
 // 'schemaName', it returns an error otherwise.
 func (s SchemaValidator) VerifyJSON(msg []byte, st SchemaType) error {
+	//TODO: take log in argument
 	log := zerolog.New(logout).Level(defaultLevel).
 		With().Timestamp().Logger().
 		With().Caller().Logger()


### PR DESCRIPTION
All uses of `fmt.Println` and `log.Printf` have been modified to use `zerolog.Logger`. 

The only file that still needs to be modified is `channel/inbox/mod.go`, I hesitate between adding a log to the `Inbox` type or having a log in every function.