### PR TITLE
Added some models and UI for Consensus

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/Action.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/Action.java
@@ -18,7 +18,10 @@ public enum Action {
   OPEN("open"),
   REOPEN("reopen"),
   CLOSE("close"),
-  CAST_VOTE("cast_vote");
+  CAST_VOTE("cast_vote"),
+  PHASE_1_ELECT("phase_1_elect"),
+  PHASE_1_ELECT_ACCEPT("phase_1_elect_accept"),
+  PHASE_1_LEARN("phase_1_learn");
 
   private static final List<Action> ALL = Collections.unmodifiableList(Arrays.asList(values()));
   private final String action;

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/Data.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/Data.java
@@ -5,12 +5,16 @@ import static com.github.dedis.popstellar.model.network.method.message.data.Acti
 import static com.github.dedis.popstellar.model.network.method.message.data.Action.CREATE;
 import static com.github.dedis.popstellar.model.network.method.message.data.Action.END;
 import static com.github.dedis.popstellar.model.network.method.message.data.Action.OPEN;
+import static com.github.dedis.popstellar.model.network.method.message.data.Action.PHASE_1_ELECT;
+import static com.github.dedis.popstellar.model.network.method.message.data.Action.PHASE_1_ELECT_ACCEPT;
+import static com.github.dedis.popstellar.model.network.method.message.data.Action.PHASE_1_LEARN;
 import static com.github.dedis.popstellar.model.network.method.message.data.Action.REOPEN;
 import static com.github.dedis.popstellar.model.network.method.message.data.Action.RESULT;
 import static com.github.dedis.popstellar.model.network.method.message.data.Action.SETUP;
 import static com.github.dedis.popstellar.model.network.method.message.data.Action.STATE;
 import static com.github.dedis.popstellar.model.network.method.message.data.Action.UPDATE;
 import static com.github.dedis.popstellar.model.network.method.message.data.Action.WITNESS;
+import static com.github.dedis.popstellar.model.network.method.message.data.Objects.CONSENSUS;
 import static com.github.dedis.popstellar.model.network.method.message.data.Objects.ELECTION;
 import static com.github.dedis.popstellar.model.network.method.message.data.Objects.LAO;
 import static com.github.dedis.popstellar.model.network.method.message.data.Objects.MEETING;
@@ -18,6 +22,9 @@ import static com.github.dedis.popstellar.model.network.method.message.data.Obje
 import static com.github.dedis.popstellar.model.network.method.message.data.Objects.ROLL_CALL;
 
 import android.util.Log;
+import com.github.dedis.popstellar.model.network.method.message.data.consensus.ConsensusVote;
+import com.github.dedis.popstellar.model.network.method.message.data.consensus.CreateConsensus;
+import com.github.dedis.popstellar.model.network.method.message.data.consensus.LearnConsensus;
 import com.github.dedis.popstellar.model.network.method.message.data.election.CastVote;
 import com.github.dedis.popstellar.model.network.method.message.data.election.ElectionEnd;
 import com.github.dedis.popstellar.model.network.method.message.data.election.ElectionResult;
@@ -88,6 +95,11 @@ public abstract class Data {
     messagesMap.put(pair(ELECTION, CAST_VOTE), CastVote.class);
     messagesMap.put(pair(ELECTION, END), ElectionEnd.class);
     messagesMap.put(pair(ELECTION, RESULT), ElectionResult.class);
+
+    // Consensus
+    messagesMap.put(pair(CONSENSUS, PHASE_1_ELECT), CreateConsensus.class);
+    messagesMap.put(pair(CONSENSUS, PHASE_1_ELECT_ACCEPT), ConsensusVote.class);
+    //messagesMap.put(pair(CONSENSUS, PHASE_1_LEARN), LearnConsensus.class);
 
     return Collections.unmodifiableMap(messagesMap);
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/Objects.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/Objects.java
@@ -12,7 +12,8 @@ public enum Objects {
   MEETING("meeting"),
   MESSAGE("message"),
   ROLL_CALL("roll_call"),
-  ELECTION("election");
+  ELECTION("election"),
+  CONSENSUS("consensus");
 
   private static final List<Objects> ALL = Collections.unmodifiableList(Arrays.asList(values()));
   private final String object;

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusVote.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusVote.java
@@ -1,0 +1,57 @@
+package com.github.dedis.popstellar.model.network.method.message.data.consensus;
+
+import com.github.dedis.popstellar.model.network.method.message.data.Action;
+import com.github.dedis.popstellar.model.network.method.message.data.Data;
+import com.github.dedis.popstellar.model.network.method.message.data.Objects;
+import com.google.gson.annotations.SerializedName;
+
+public class ConsensusVote extends Data {
+
+  @SerializedName("message_id")
+  private final String messageId;
+  private final boolean accept;
+
+  public ConsensusVote(String messageId, boolean accept) {
+    this.messageId = messageId;
+    this.accept = accept;
+  }
+
+
+  public String getMessageId() {
+    return messageId;
+  }
+
+  public boolean isAccept() {
+    return accept;
+  }
+
+
+  @Override
+  public String getObject() {
+    return Objects.CONSENSUS.getObject();
+  }
+
+  @Override
+  public String getAction() {
+    return Action.PHASE_1_ELECT_ACCEPT.getAction();
+  }
+
+
+  @Override
+  public int hashCode() {
+    return java.util.Objects.hash(messageId, accept);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ConsensusVote that = (ConsensusVote) o;
+
+    return messageId.equals(that.messageId) && accept == that.accept;
+  }
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/CreateConsensus.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/CreateConsensus.java
@@ -1,0 +1,90 @@
+package com.github.dedis.popstellar.model.network.method.message.data.consensus;
+
+import com.github.dedis.popstellar.model.network.method.message.data.Action;
+import com.github.dedis.popstellar.model.network.method.message.data.Data;
+import com.github.dedis.popstellar.model.network.method.message.data.Objects;
+import com.github.dedis.popstellar.model.objects.Consensus;
+import com.google.gson.annotations.SerializedName;
+
+public class CreateConsensus extends Data {
+
+  @SerializedName("instance_id")
+  private final String instanceId;
+
+  @SerializedName("created_at")
+  private final long creation;
+
+  private final String objId;
+  private final String type;
+  private final String property;
+
+  private final Object value;
+
+  public CreateConsensus(long creation, String objId, String type, String property, Object value) {
+    this.instanceId =
+        Consensus.generateConsensusId(creation, type, objId, property, String.valueOf(value));
+    this.creation = creation;
+
+    this.objId = objId;
+    this.type = type;
+    this.property = property;
+    this.value = value;
+  }
+
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  public long getCreation() {
+    return creation;
+  }
+
+  public String getObjId() {
+    return objId;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public String getProperty() {
+    return property;
+  }
+
+  public Object getValue() {
+    return value;
+  }
+
+  @Override
+  public String getObject() {
+    return Objects.CONSENSUS.getObject();
+  }
+
+  @Override
+  public String getAction() {
+    return Action.PHASE_1_ELECT.getAction();
+  }
+
+  @Override
+  public int hashCode() {
+    return java.util.Objects.hash(instanceId, creation, objId, type, property, value);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CreateConsensus that = (CreateConsensus) o;
+
+    return instanceId.equals(that.instanceId)
+        && creation == that.creation
+        && objId.equals(that.objId)
+        && type.equals(that.type)
+        && property.equals(that.property)
+        && java.util.Objects.equals(value, that.value);
+  }
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/Consensus.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/Consensus.java
@@ -1,0 +1,214 @@
+package com.github.dedis.popstellar.model.objects;
+
+import com.github.dedis.popstellar.model.objects.event.Event;
+import com.github.dedis.popstellar.model.objects.event.EventState;
+import com.github.dedis.popstellar.model.objects.event.EventType;
+import com.github.dedis.popstellar.utility.security.Hash;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class Consensus extends Event {
+
+  private String channel;
+  private String id;
+
+  private String type;
+  private String objId;
+  private String property;
+  private Object value;
+
+  private long creation;
+  private long end;
+
+  private EventState state;
+  private Boolean isAccepted;
+
+  private String proposer;
+  private Set<String> acceptors;
+  private Map<String, Boolean> acceptorsResponses;
+
+
+
+  public Consensus(String type, String objId, long creation, String property, Object value) {
+    this.id = generateConsensusId(creation, type, objId, property, value);
+    this.type = type;
+    this.objId = objId;
+    this.property = property;
+    this.value = value;
+
+    this.acceptorsResponses = new HashMap<>();
+  }
+
+
+  public String getChannel() {
+    return channel;
+  }
+
+  public void setChannel(String channel) {
+    if (id == null) {
+      throw new IllegalArgumentException("consensus channel shouldn't be null");
+    }
+    this.channel = channel;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    if (id == null) {
+      throw new IllegalArgumentException("consensus id shouldn't be null");
+    }
+    this.id = id;
+  }
+
+  public String getConsensusType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    if (type == null) {
+      throw new IllegalArgumentException("consensus type shouldn't be null");
+    }
+    this.type = type;
+  }
+
+  public String getObjId() {
+    return objId;
+  }
+
+  public void setObjId(String objId) {
+    if (objId == null) {
+      throw new IllegalArgumentException("consensus object id shouldn't be null");
+    }
+    this.objId = objId;
+  }
+
+  public String getProperty() {
+    return property;
+  }
+
+  public void setProperty(String property) {
+    if (property == null) {
+      throw new IllegalArgumentException("consensus property shouldn't be null");
+    }
+    this.property = property;
+  }
+
+  public Object getValue() {
+    return value;
+  }
+
+  public void setValue(Object value) {
+    this.value = value;
+  }
+
+  public long getCreation() {
+    return creation;
+  }
+
+  public void setCreation(long creation) {
+    if (creation < 0) {
+      throw new IllegalArgumentException();
+    }
+    this.creation = creation;
+  }
+
+  public long getEnd() {
+    return end;
+  }
+
+  public void setEnd(long end) {
+    if (end < creation) {
+      throw new IllegalArgumentException();
+    }
+    this.end = end;
+  }
+
+
+  public EventState getState() {
+    return state;
+  }
+
+  public void setEventState(EventState state) {
+    if (state == null) {
+      throw new IllegalArgumentException("consensus state shouldn't be null");
+    }
+    this.state = state;
+  }
+
+  public String getProposer() {
+    return proposer;
+  }
+
+  public void setProposer(String proposer) {
+    if (proposer == null) {
+      throw new IllegalArgumentException("consensus proposer shouldn't be null");
+    }
+    this.proposer = proposer;
+  }
+
+  public Set<String> getAcceptors() {
+    return acceptors;
+  }
+
+  public void setAcceptors(Set<String> acceptors) {
+    if (acceptors == null) {
+      throw new IllegalArgumentException("consensus acceptors shouldn't be null");
+    }
+    this.acceptors = acceptors;
+  }
+
+  public Map<String, Boolean> getAcceptorsResponses() {
+    return acceptorsResponses;
+  }
+
+  public void setAcceptorsResponses(Map<String, Boolean> acceptorsResponses) {
+    this.acceptorsResponses = acceptorsResponses;
+  }
+
+  public void putAcceptorResponse(String acceptor, boolean accept) {
+    if (acceptor == null) {
+      throw new IllegalArgumentException("Acceptor public key cannot be null.");
+    }
+    acceptorsResponses.put(acceptor, accept);
+  }
+
+  public Boolean isAccepted() {
+    // Part 1 : all acceptors need to accept the consensus to be accepted
+    //long acceptedCount = acceptorsResponses.values().stream().filter(b -> b).count();
+    //return acceptedCount == acceptors.size();
+
+    return isAccepted;
+  }
+
+  public void setAccepted(boolean accepted) {
+    isAccepted = accepted;
+  }
+
+
+  @Override
+  public long getStartTimestamp() {
+    return creation;
+  }
+
+  @Override
+  public EventType getType() {
+    return EventType.CONSENSUS;
+  }
+
+  @Override
+  public long getEndTimestamp() {
+    return end;
+  }
+
+
+
+  public static String generateConsensusId(
+      long created_at, String type, String id, String property, Object value) {
+    return Hash.hash(
+        "consensus", Long.toString(created_at), type, id, property, String.valueOf(value));
+  }
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/Lao.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/Lao.java
@@ -30,6 +30,7 @@ public final class Lao {
 
   private Map<String, RollCall> rollCalls;
   private Map<String, Election> elections;
+  private Map<String, Consensus> consensuses;
 
   public Lao(String id) {
     if (id == null) {
@@ -41,6 +42,7 @@ public final class Lao {
     this.id = id;
     this.rollCalls = new HashMap<>();
     this.elections = new HashMap<>();
+    this.consensuses = new HashMap<>();
     this.witnessMessages = new HashMap<>();
     this.witnesses = new HashSet<>();
     this.pendingUpdates = new HashSet<>();
@@ -83,6 +85,15 @@ public final class Lao {
     elections.put(newId, election);
   }
 
+  public void updateConsensus(String prevId, Consensus consensus) {
+    if (consensus == null) {
+      throw new IllegalArgumentException("The consensus is null");
+    }
+
+    consensuses.remove(prevId);
+    String newId = consensus.getId();
+    consensuses.put(newId, consensus);
+  }
 
   /**
    * Update the list of messages that have to be signed by witnesses. If the list of messages
@@ -106,6 +117,10 @@ public final class Lao {
 
   public Optional<Election> getElection(String id) {
     return Optional.ofNullable(elections.get(id));
+  }
+
+  public Optional<Consensus> getConsensus(String id) {
+    return Optional.ofNullable(consensuses.get(id));
   }
 
   public Optional<WitnessMessage> getWitnessMessage(String id) {
@@ -133,6 +148,10 @@ public final class Lao {
   public boolean removeRollCall(String id) {
     return (rollCalls.remove(id) != null);
 
+  }
+
+  public boolean removeConsensus(String id) {
+    return (consensuses.remove(id) != null);
   }
 
   public Long getLastModified() {
@@ -235,6 +254,10 @@ public final class Lao {
 
   public Map<String, RollCall> getRollCalls() {
     return rollCalls;
+  }
+
+  public Map<String, Consensus> getConsensuses() {
+    return consensuses;
   }
 
   public Map<String, WitnessMessage> getWitnessMessages() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/event/EventType.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/event/EventType.java
@@ -6,6 +6,7 @@ package com.github.dedis.popstellar.model.objects.event;
 public enum EventType {
   ROLL_CALL("R"),
   ELECTION("Election"),
+  CONSENSUS("Consensus"),
   MEETING("M"),
   POLL("P"),
   DISCUSSION("D");

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailActivity.java
@@ -13,6 +13,7 @@ import androidx.lifecycle.ViewModelProvider;
 import com.github.dedis.popstellar.Injection;
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.ViewModelFactory;
+import com.github.dedis.popstellar.ui.detail.event.consensus.ElectionStartAcceptorsFragment;
 import com.github.dedis.popstellar.ui.detail.event.rollcall.AttendeesListFragment;
 import com.github.dedis.popstellar.ui.detail.event.election.fragments.CastVoteFragment;
 import com.github.dedis.popstellar.ui.detail.event.election.fragments.ElectionResultFragment;
@@ -128,6 +129,9 @@ public class LaoDetailActivity extends AppCompatActivity {
 
     //Subscribe to "open manage election" event
     setupManageElectionFragment();
+
+    //Subscribe to "open consensus vote" event
+    setupConsensusVoteFragment();
   }
 
   private void subscribeWalletEvents() {
@@ -493,6 +497,34 @@ public class LaoDetailActivity extends AppCompatActivity {
                       getSupportFragmentManager(), electionResultFragment,
                       R.id.fragment_container_lao_detail);
                 }
+              }
+            }
+        );
+  }
+
+  private void setupElectionStartAcceptorsFragment() {
+    ElectionStartAcceptorsFragment electionStartAcceptorsFragment =
+        (ElectionStartAcceptorsFragment)
+            getSupportFragmentManager().findFragmentById(R.id.fragment_election_start_acceptors);
+    if (electionStartAcceptorsFragment == null) {
+      electionStartAcceptorsFragment = ElectionStartAcceptorsFragment.newInstance();
+      ActivityUtils.replaceFragmentInActivity(
+          getSupportFragmentManager(),
+          electionStartAcceptorsFragment,
+          R.id.fragment_container_lao_detail
+      );
+    }
+  }
+
+  private void setupConsensusVoteFragment() {
+    mViewModel
+        .getOpenConsensusVoteEvent()
+        .observe(
+            this,
+            booleanSingleEvent -> {
+              Boolean event = booleanSingleEvent.getContentIfNotHandled();
+              if (event != null) {
+                setupElectionStartAcceptorsFragment();
               }
             }
         );

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/consensus/ElectionStartAcceptorsFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/consensus/ElectionStartAcceptorsFragment.java
@@ -1,0 +1,87 @@
+package com.github.dedis.popstellar.ui.detail.event.consensus;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import com.github.dedis.popstellar.R;
+import com.github.dedis.popstellar.databinding.ElectionStartAcceptorsFragmentBinding;
+import com.github.dedis.popstellar.model.objects.Consensus;
+import com.github.dedis.popstellar.model.objects.Election;
+import com.github.dedis.popstellar.model.objects.Lao;
+import com.github.dedis.popstellar.ui.detail.LaoDetailActivity;
+import com.github.dedis.popstellar.ui.detail.LaoDetailViewModel;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+/**
+ * A simple {@link Fragment} subclass. Use the {@link ElectionStartAcceptorsFragment#newInstance}
+ * factory method to create an instance of this fragment.
+ */
+public class ElectionStartAcceptorsFragment extends Fragment {
+
+  private final SimpleDateFormat DATE_FORMAT =
+      new SimpleDateFormat("yyyy/MM/dd HH:mm z", Locale.ENGLISH);
+
+  private Button acceptButton;
+  private Button rejectButton;
+
+  private LaoDetailViewModel laoDetailViewModel;
+
+  public ElectionStartAcceptorsFragment() {
+    // Required empty public constructor
+  }
+
+  public static ElectionStartAcceptorsFragment newInstance() {
+    return new ElectionStartAcceptorsFragment();
+  }
+
+  private void sendConsensusResponse(boolean accepted) {
+    acceptButton.setEnabled(false);
+    rejectButton.setEnabled(false);
+
+    laoDetailViewModel.sendConsensusVote(accepted);
+  }
+
+  @Override
+  public View onCreateView(
+      @NonNull LayoutInflater inflater,
+      @Nullable ViewGroup container,
+      @Nullable Bundle savedInstanceState) {
+
+    ElectionStartAcceptorsFragmentBinding electionStartAcceptorsFragmentBinding =
+        ElectionStartAcceptorsFragmentBinding.inflate(inflater, container, false);
+
+    laoDetailViewModel = LaoDetailActivity.obtainViewModel(getActivity());
+
+    Lao lao = laoDetailViewModel.getCurrentLao().getValue();
+    Consensus consensus = laoDetailViewModel.getCurrentConsensus();
+    String proposer = consensus.getProposer();
+    Election election = lao.getElection(consensus.getObjId()).get();
+
+    Date currentDate = new Date();
+    Date plannedDate = new Date(election.getStartTimestamp() * 1000L);
+
+    electionStartAcceptorsFragmentBinding.currentTime.setText(DATE_FORMAT.format(currentDate));
+    electionStartAcceptorsFragmentBinding.plannedStart.setText(DATE_FORMAT.format(plannedDate));
+    electionStartAcceptorsFragmentBinding.proposer.setText(proposer);
+
+    acceptButton = electionStartAcceptorsFragmentBinding.acceptButton;
+    rejectButton = electionStartAcceptorsFragmentBinding.rejectButton;
+
+    acceptButton.setOnClickListener(v -> sendConsensusResponse(true));
+    rejectButton.setOnClickListener(v -> sendConsensusResponse(false));
+
+    Button back = electionStartAcceptorsFragmentBinding.backLayout.findViewById(R.id.tab_back);
+    back.setOnClickListener(v -> laoDetailViewModel.openLaoDetail());
+
+    electionStartAcceptorsFragmentBinding.setLifecycleOwner(getActivity());
+
+    return electionStartAcceptorsFragmentBinding.getRoot();
+  }
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/election/fragments/ManageElectionFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/election/fragments/ManageElectionFragment.java
@@ -18,6 +18,7 @@ import androidx.fragment.app.Fragment;
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.ElectionManageFragmentBinding;
 import com.github.dedis.popstellar.model.network.method.message.data.election.ElectionQuestion;
+import com.github.dedis.popstellar.model.objects.Election;
 import com.github.dedis.popstellar.ui.detail.LaoDetailActivity;
 import com.github.dedis.popstellar.ui.detail.LaoDetailViewModel;
 import java.text.SimpleDateFormat;
@@ -38,6 +39,7 @@ public class ManageElectionFragment extends Fragment {
   private static final int START_DATE_CODE = 5;
   private static final int END_DATE_CODE = 6;
   private static final int CANCEL_CODE = 7;
+  private static final int START_CODE = 8;
   private final Calendar calendar = Calendar.getInstance();
   int newHour;
   int newMinute;
@@ -49,6 +51,7 @@ public class ManageElectionFragment extends Fragment {
   private int requestCode;
   private String newName;
   private String newQuestion;
+  private Button startButton;
   private Button terminate;
   private Button editName;
   private Button editQuestion;
@@ -73,6 +76,7 @@ public class ManageElectionFragment extends Fragment {
         ElectionManageFragmentBinding.inflate(inflater, container, false);
 
     laoDetailViewModel = LaoDetailActivity.obtainViewModel(getActivity());
+    startButton = mManageElectionFragBinding.startElection;
     terminate = mManageElectionFragBinding.terminateElection;
     editStartTimeButton = mManageElectionFragBinding.editStartTime;
     editEndTimeButton = mManageElectionFragBinding.editEndTime;
@@ -122,6 +126,12 @@ public class ManageElectionFragment extends Fragment {
       //Yes button clicked
       if (which == DialogInterface.BUTTON_POSITIVE) {
         switch (requestCode) {
+          case START_CODE: {
+            Election election = laoDetailViewModel.getCurrentElection();
+            long creation = System.currentTimeMillis() / 1000L;
+            laoDetailViewModel.createNewConsensus(creation, election.getId(), "election", "state", "started");
+            break;
+          }
           case CANCEL_CODE: {
             // TODO : In the future send a UpdateElection message with a modified end time as the current time
             laoDetailViewModel.openLaoDetail();
@@ -323,6 +333,12 @@ public class ManageElectionFragment extends Fragment {
 
         });
 
+    startButton.setOnClickListener(
+        v -> {
+          setupRequestCode(START_CODE);
+          builder.show();
+        }
+    );
 
   }
 

--- a/fe2-android/app/src/main/res/layout/consensus_event_layout.xml
+++ b/fe2-android/app/src/main/res/layout/consensus_event_layout.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android" >
+
+  <LinearLayout
+    android:id="@+id/consensus_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <LinearLayout
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginHorizontal="@dimen/margin_text"
+      android:orientation="vertical">
+
+      <TextView
+        android:id="@+id/consensus_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/size_body"
+        android:textStyle="bold" />
+
+      <TextView
+        android:id="@+id/consensus_type"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/size_body" />
+
+      <TextView
+        android:id="@+id/consensus_object_id"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/size_small" />
+
+    </LinearLayout>
+
+    <LinearLayout
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:orientation="vertical">
+
+      <Button
+        android:id="@+id/consensus_vote_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/vote" />
+
+      <Button
+        android:id="@+id/consensus_status_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/status" />
+    </LinearLayout>
+  </LinearLayout>
+</layout>

--- a/fe2-android/app/src/main/res/layout/election_manage_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/election_manage_fragment.xml
@@ -233,6 +233,11 @@
           android:layout_height="wrap_content"
           android:text="@string/cancel_election" />
 
+        <Button
+          android:id="@+id/start_election"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="@string/start_election" />
 
       </LinearLayout>
 

--- a/fe2-android/app/src/main/res/layout/election_start_acceptors_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/election_start_acceptors_fragment.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:id="@+id/fragment_election_start_acceptors"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include
+      android:id="@+id/back_layout"
+      layout="@layout/tab_back"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent" />
+
+    <androidx.constraintlayout.widget.Guideline
+      android:id="@+id/election_start_guideline_horizontal"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:orientation="horizontal"
+      app:layout_constraintGuide_percent="@dimen/guideline_horizontal_tab" />
+
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      app:layout_constraintTop_toBottomOf="@+id/election_start_guideline_horizontal">
+
+      <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_text"
+        android:gravity="center"
+        android:textStyle="bold"
+        android:textSize="@dimen/size_title"
+        android:text="@string/election_start" />
+
+      <GridLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/margin_text"
+        android:columnCount="2"
+        android:useDefaultMargins="true">
+
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/proposed_by" />
+        <TextView
+          android:id="@+id/proposer"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:breakStrategy="balanced" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/planned_start_time"/>
+        <TextView
+          android:id="@+id/planned_start"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/current_time" />
+        <TextView
+          android:id="@+id/current_time"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content" />
+      </GridLayout>
+
+      <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center">
+
+        <Button
+          android:id="@+id/accept_button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginHorizontal="@dimen/margin_button"
+          android:text="@string/accept" />
+
+        <Button
+          android:id="@+id/reject_button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginHorizontal="@dimen/margin_button"
+          android:text="@string/reject" />
+
+      </LinearLayout>
+    </LinearLayout>
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/fe2-android/app/src/main/res/layout/event_layout.xml
+++ b/fe2-android/app/src/main/res/layout/event_layout.xml
@@ -30,6 +30,13 @@
       android:layout_height="match_parent"
       android:visibility="@{event.getType() == EventType.ELECTION ? View.VISIBLE : View.GONE}" />
 
+    <!-- Display for a Consensus -->
+    <include
+      android:id="@+id/include_layout_consensus"
+      layout="@layout/consensus_event_layout"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:visibility="@{event.getType() == EventType.CONSENSUS ? View.VISIBLE : View.GONE}" />
 
   </LinearLayout>
 </layout>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -166,6 +166,20 @@
   <string name="cast_vote">Cast votes</string>
   <string name="show_results">Show results</string>
 
+  <!-- Consensus -->
+  <string name="start_election">Start Election</string>
+  <string name="election_start">Election Start</string>
+  <string name="proposed_by">Proposed by :</string>
+  <string name="planned_start_time">Planned start :</string>
+  <string name="yes">Yes</string>
+  <string name="no">No</string>
+  <string name="accept">Accept</string>
+  <string name="reject">Reject</string>
+  <string name="accepted">Accepted</string>
+  <string name="rejected">Rejected</string>
+  <string name="vote">Vote</string>
+  <string name="status">Status</string>
+
   <!-- Wallet -->
   <string name="button_own_seed">I own a seed</string>
   <string name="button_new_wallet">New wallet</string>
@@ -189,4 +203,6 @@
   <string name="message_signed">MESSAGE SIGNED</string>
   <string name="witness_messages">WITNESS MESSAGES</string>
   <string name="delete_a_witness">delete a witness</string>
+  <!-- TODO: Remove or change this placeholder text -->
+  <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>


### PR DESCRIPTION
## Added
- ConsensusCreate, ConsensusVote as Data classes for message
- Consensus as an Event, that contains all information
- createNewConsensus** and sendConsensusVote methods in LaoDetailViewModel
- a Start button in the manage Election (img 1)
- consensus event in the events list (img 2) (buttons only displayed for acceptors)
- a view to vote for the election start (img3)

** because backend is not supported yet, a piece of code was adding locally the new event => TODO remove

## TODO
- Message handler & subscribe
- View with the consensus status
- View to confirm the consensus when all acceptors have accepted
- Documentation & comment & tests
- Check elects & Learn Result parts
- Verify if it is compatible with backend when done

## Bug
- The consensus event only show when we go to the home then lao, not when just back after start. Maybe it will be fixed when created from message handler instead.


![qemu-system-x86_64_2021-10-04_14-29-11](https://user-images.githubusercontent.com/19479532/135853208-8a4fbe5d-9698-4fe5-b464-59d2ae05ce5a.png)
![qemu-system-x86_64_2021-10-04_14-28-56](https://user-images.githubusercontent.com/19479532/135853300-66d4b03d-d05c-464a-b19f-c8b1087eff7a.png)
![qemu-system-x86_64_2021-10-04_14-25-40](https://user-images.githubusercontent.com/19479532/135853313-9b3342c9-93c4-4644-9882-d57d15253653.png)
