### PR TITLE
Add return error to message handlers

### DIFF
--- a/be1-go/hub/organizer/mod.go
+++ b/be1-go/hub/organizer/mod.go
@@ -115,7 +115,12 @@ func (h *Hub) Start() {
 					h.workers.Acquire(context.Background(), 1)
 				}
 
-				go h.handleIncomingMessage(&incomingMessage)
+				go func() {
+					err := h.handleIncomingMessage(&incomingMessage)
+					if err != nil {
+						h.log.Err(err).Msg("problem handling incoming message")
+					}
+				}()
 			case id := <-h.closedSockets:
 				h.RLock()
 				for _, channel := range h.channelByID {
@@ -149,25 +154,28 @@ func (h *Hub) OnSocketClose() chan<- string {
 }
 
 // handleRootChannelMesssage handles an incoming message on the root channel.
-func (h *Hub) handleRootChannelMesssage(socket socket.Socket, publish method.Publish) {
+func (h *Hub) handleRootChannelMesssage(socket socket.Socket, publish method.Publish) error {
 	jsonData, err := base64.URLEncoding.DecodeString(publish.Params.Message.Data)
 	if err != nil {
-		socket.SendError(&publish.ID, xerrors.Errorf("failed to decode message data: %v", err))
-		return
+		err := xerrors.Errorf("failed to decode message data: %v", err)
+		socket.SendError(&publish.ID, err)
+		return err
 	}
 
 	// validate message data against the json schema
 	err = h.schemaValidator.VerifyJSON(jsonData, validation.Data)
 	if err != nil {
+		err := xerrors.Errorf("failed to validate message against json schema: %v", err)
 		socket.SendError(&publish.ID, err)
-		return
+		return err
 	}
 
 	// get object#action
 	object, action, err := messagedata.GetObjectAndAction(jsonData)
 	if err != nil {
+		err := xerrors.Errorf("failed to get object#action: %v", err)
 		socket.SendError(&publish.ID, err)
-		return
+		return err
 	}
 
 	// must be "lao#create"
@@ -176,7 +184,7 @@ func (h *Hub) handleRootChannelMesssage(socket socket.Socket, publish method.Pub
 			"but found %s#%s", object, action)
 		h.log.Err(err)
 		socket.SendError(&publish.ID, err)
-		return
+		return err
 	}
 
 	var laoCreate messagedata.LaoCreate
@@ -185,19 +193,21 @@ func (h *Hub) handleRootChannelMesssage(socket socket.Socket, publish method.Pub
 	if err != nil {
 		h.log.Err(err).Msg("failed to unmarshal lao#create")
 		socket.SendError(&publish.ID, err)
-		return
+		return err
 	}
 
 	err = h.createLao(publish, laoCreate)
 	if err != nil {
 		h.log.Err(err).Msg("failed to create lao")
 		socket.SendError(&publish.ID, err)
-		return
+		return err
 	}
+
+	return nil
 }
 
 // handleMessageFromClient handles an incoming message from an end user.
-func (h *Hub) handleMessageFromClient(incomingMessage *socket.IncomingMessage) {
+func (h *Hub) handleMessageFromClient(incomingMessage *socket.IncomingMessage) error {
 	socket := incomingMessage.Socket
 	byteMessage := incomingMessage.Message
 
@@ -205,22 +215,25 @@ func (h *Hub) handleMessageFromClient(incomingMessage *socket.IncomingMessage) {
 	err := h.schemaValidator.VerifyJSON(byteMessage, validation.GenericMessage)
 	if err != nil {
 		h.log.Err(err).Msg("message is not valid against json schema")
-		socket.SendError(nil, xerrors.Errorf("message is not valid against json schema: %v", err))
-		return
+		schemaErr := xerrors.Errorf("message is not valid against json schema: %v", err)
+		socket.SendError(nil, schemaErr)
+		return schemaErr
 	}
 
 	rpctype, err := jsonrpc.GetType(byteMessage)
 	if err != nil {
 		h.log.Err(err).Msg("failed to get rpc type")
-		socket.SendError(nil, err)
-		return
+		rpcErr := xerrors.Errorf("failed to get rpc type: %v", err)
+		socket.SendError(nil, rpcErr)
+		return rpcErr
 	}
 
 	// check type (answer or query), we expect a query
 	if rpctype != jsonrpc.RPCTypeQuery {
-		h.log.Error().Msgf("jsonRPC message is not of type query")
-		socket.SendError(nil, xerrors.New("jsonRPC message is not of type query"))
-		return
+		h.log.Error().Msg("jsonRPC message is not of type query")
+		rpcErr := xerrors.New("jsonRPC message is not of type query")
+		socket.SendError(nil, rpcErr)
+		return rpcErr
 	}
 
 	var queryBase query.Base
@@ -230,7 +243,7 @@ func (h *Hub) handleMessageFromClient(incomingMessage *socket.IncomingMessage) {
 		err := answer.NewErrorf(-4, "failed to unmarshal incoming message: %v", err)
 		h.log.Err(err)
 		socket.SendError(nil, err)
-		return
+		return err
 	}
 
 	var id int
@@ -250,22 +263,23 @@ func (h *Hub) handleMessageFromClient(incomingMessage *socket.IncomingMessage) {
 		err = answer.NewErrorf(-2, "unexpected method: '%s'", queryBase.Method)
 		h.log.Err(err)
 		socket.SendError(nil, err)
-		return
+		return err
 	}
 
 	if handlerErr != nil {
 		err := answer.NewErrorf(-4, "failed to handle method: %v", handlerErr)
 		h.log.Err(err)
 		socket.SendError(nil, err)
-		return
+		return err
 	}
 
 	if queryBase.Method == query.MethodCatchUp {
 		socket.SendResult(id, msgs)
-		return
+		return nil
 	}
 
 	socket.SendResult(id, nil)
+	return nil
 }
 
 func (h *Hub) handlePublish(socket socket.Socket, byteMessage []byte) (int, error) {
@@ -277,7 +291,10 @@ func (h *Hub) handlePublish(socket socket.Socket, byteMessage []byte) (int, erro
 	}
 
 	if publish.Params.Channel == "/root" {
-		h.handleRootChannelMesssage(socket, publish)
+		err := h.handleRootChannelMesssage(socket, publish)
+		if err != nil {
+			return -1, xerrors.Errorf("failed to handle root channel message: %v", err)
+		}
 		return publish.ID, nil
 	}
 
@@ -374,24 +391,26 @@ func (h *Hub) getChan(channelPath string) (channel.Channel, error) {
 }
 
 // handleMessageFromWitness handles an incoming message from a witness server.
-func (h *Hub) handleMessageFromWitness(incomingMessage *socket.IncomingMessage) {
+func (h *Hub) handleMessageFromWitness(incomingMessage *socket.IncomingMessage) error {
 	//TODO
+	return nil
 }
 
 // handleIncomingMessage handles an incoming message based on the socket it
 // originates from.
-func (h *Hub) handleIncomingMessage(incomingMessage *socket.IncomingMessage) {
+func (h *Hub) handleIncomingMessage(incomingMessage *socket.IncomingMessage) error {
 	defer h.workers.Release(1)
 
 	h.log.Info().Str("msg", string(incomingMessage.Message)).Msg("handle incoming message")
 
 	switch incomingMessage.Socket.Type() {
 	case socket.ClientSocketType:
-		h.handleMessageFromClient(incomingMessage)
+		return h.handleMessageFromClient(incomingMessage)
 	case socket.WitnessSocketType:
-		h.handleMessageFromWitness(incomingMessage)
+		return h.handleMessageFromWitness(incomingMessage)
 	default:
-		h.log.Error().Msg("error: invalid socket type")
+		h.log.Error().Msg("invalid socket type")
+		return xerrors.Errorf("invalid socket type")
 	}
 
 }

--- a/be1-go/hub/witness/mod.go
+++ b/be1-go/hub/witness/mod.go
@@ -65,19 +65,19 @@ func NewHub(public kyber.Point, log zerolog.Logger) (*Hub, error) {
 	return &witnessHub, nil
 }
 
-func (h *Hub) handleMessageFromOrganizer(incMsg *socket.IncomingMessage) {
+func (h *Hub) handleMessageFromOrganizer(incMsg *socket.IncomingMessage) error {
 	panic("handleMessageFromOrganizer not implemented")
 }
 
-func (h *Hub) handleMessageFromClient(incMsg *socket.IncomingMessage) {
+func (h *Hub) handleMessageFromClient(incMsg *socket.IncomingMessage) error {
 	panic("handleMessageFromClient not implemented")
 }
 
-func (h *Hub) handleMessageFromWitness(incMsg *socket.IncomingMessage) {
+func (h *Hub) handleMessageFromWitness(incMsg *socket.IncomingMessage) error {
 	panic("handleMessageFromWitness not implemented")
 }
 
-func (h *Hub) handleIncomingMessage(incMsg *socket.IncomingMessage) {
+func (h *Hub) handleIncomingMessage(incMsg *socket.IncomingMessage) error{
 	defer h.workers.Release(1)
 
 	h.log.Info().Str("msg", fmt.Sprintf("%v", incMsg.Message)).
@@ -86,14 +86,14 @@ func (h *Hub) handleIncomingMessage(incMsg *socket.IncomingMessage) {
 
 	switch incMsg.Socket.Type() {
 	case socket.OrganizerSocketType:
-		h.handleMessageFromOrganizer(incMsg)
-		return
+		return h.handleMessageFromOrganizer(incMsg)
 	case socket.ClientSocketType:
-		h.handleMessageFromClient(incMsg)
-		return
+		return h.handleMessageFromClient(incMsg)
 	case socket.WitnessSocketType:
-		h.handleMessageFromWitness(incMsg)
-		return
+		return h.handleMessageFromWitness(incMsg)
+	default:
+		h.log.Error().Msg("invalid socket type")
+		return xerrors.Errorf("invalid socket type")
 	}
 }
 
@@ -111,7 +111,10 @@ func (h *Hub) Start() {
 					h.workers.Acquire(context.Background(), 1)
 				}
 
-				h.handleIncomingMessage(&incMsg)
+				err := h.handleIncomingMessage(&incMsg)
+				if err != nil {
+					h.log.Err(err).Msg("problem handling incoming message")
+				}
 			case id := <-h.closedSockets:
 				h.RLock()
 				for _, channel := range h.channelByID {


### PR DESCRIPTION
The message handlers of the organizer and witness hub now return an error, making it easier to debug when an error occurs during this process.