### PR TITLE
Disable swipes to navigate through tabs

### DIFF
--- a/fe1-web/navigation/bars/LaoNavigation.tsx
+++ b/fe1-web/navigation/bars/LaoNavigation.tsx
@@ -113,6 +113,7 @@ function LaoNavigation() {
     <OrganizationTopTabNavigator.Navigator
       style={styles.navigator}
       initialRouteName={tabName}
+      swipeEnabled={false}
     >
 
       <OrganizationTopTabNavigator.Screen

--- a/fe1-web/navigation/bars/MainNavigation.tsx
+++ b/fe1-web/navigation/bars/MainNavigation.tsx
@@ -32,6 +32,7 @@ export default function MainNavigation() {
     <HomeTopTabNavigator.Navigator
       style={styles.navigator}
       initialRouteName={STRINGS.navigation_tab_home}
+      swipeEnabled={false}
     >
       <HomeTopTabNavigator.Screen
         name={STRINGS.navigation_tab_home}


### PR DESCRIPTION
I disabled the ability to swipe to navigate through the tabs at the top.
I think it can be nice to have on mobile devices, but for now it may be better to just disable it as we use it only on PC and it creates weird interactions while selecting text.