### PR TITLE
Add value to json-rpc and id field of error 

### DIFF
--- a/be1-go/hub/organizer/mod.go
+++ b/be1-go/hub/organizer/mod.go
@@ -302,19 +302,19 @@ func (h *Hub) handlePublish(socket socket.Socket, byteMessage []byte) (int, erro
 	if publish.Params.Channel == "/root" {
 		err := h.handleRootChannelMesssage(socket, publish)
 		if err != nil {
-			return -1, xerrors.Errorf("failed to handle root channel message: %v", err)
+			return publish.ID, xerrors.Errorf("failed to handle root channel message: %v", err)
 		}
 		return publish.ID, nil
 	}
 
 	channel, err := h.getChan(publish.Params.Channel)
 	if err != nil {
-		return -1, xerrors.Errorf("failed to get channel: %v", err)
+		return publish.ID, xerrors.Errorf("failed to get channel: %v", err)
 	}
 
 	err = channel.Publish(publish)
 	if err != nil {
-		return -1, xerrors.Errorf("failed to publish: %v", err)
+		return publish.ID, xerrors.Errorf("failed to publish: %v", err)
 	}
 
 	return publish.ID, nil
@@ -330,12 +330,12 @@ func (h *Hub) handleSubscribe(socket socket.Socket, byteMessage []byte) (int, er
 
 	channel, err := h.getChan(subscribe.Params.Channel)
 	if err != nil {
-		return -1, xerrors.Errorf("failed to get subscribe channel: %v", err)
+		return subscribe.ID, xerrors.Errorf("failed to get subscribe channel: %v", err)
 	}
 
 	err = channel.Subscribe(socket, subscribe)
 	if err != nil {
-		return -1, xerrors.Errorf("failed to publish: %v", err)
+		return subscribe.ID, xerrors.Errorf("failed to publish: %v", err)
 	}
 
 	return subscribe.ID, nil
@@ -351,12 +351,12 @@ func (h *Hub) handleUnsubscribe(socket socket.Socket, byteMessage []byte) (int, 
 
 	channel, err := h.getChan(unsubscribe.Params.Channel)
 	if err != nil {
-		return -1, xerrors.Errorf("failed to get unsubscribe channel: %v", err)
+		return unsubscribe.ID, xerrors.Errorf("failed to get unsubscribe channel: %v", err)
 	}
 
 	err = channel.Unsubscribe(socket.ID(), unsubscribe)
 	if err != nil {
-		return -1, xerrors.Errorf("failed to unsubscribe: %v", err)
+		return unsubscribe.ID, xerrors.Errorf("failed to unsubscribe: %v", err)
 	}
 
 	return unsubscribe.ID, nil
@@ -372,12 +372,12 @@ func (h *Hub) handleCatchup(byteMessage []byte) ([]message.Message, int, error) 
 
 	channel, err := h.getChan(catchup.Params.Channel)
 	if err != nil {
-		return nil, -1, xerrors.Errorf("failed to get catchup channel: %v", err)
+		return nil, catchup.ID, xerrors.Errorf("failed to get catchup channel: %v", err)
 	}
 
 	msg := channel.Catchup(catchup)
 	if err != nil {
-		return nil, -1, xerrors.Errorf("failed to catchup: %v", err)
+		return nil, catchup.ID, xerrors.Errorf("failed to catchup: %v", err)
 	}
 
 	return msg, catchup.ID, nil

--- a/be1-go/hub/organizer/mod.go
+++ b/be1-go/hub/organizer/mod.go
@@ -278,7 +278,7 @@ func (h *Hub) handleMessageFromClient(incomingMessage *socket.IncomingMessage) e
 	if handlerErr != nil {
 		err := answer.NewErrorf(-4, "failed to handle method: %v", handlerErr)
 		h.log.Err(err)
-		socket.SendError(nil, err)
+		socket.SendError(&id, err)
 		return err
 	}
 

--- a/be1-go/hub/organizer/mod_test.go
+++ b/be1-go/hub/organizer/mod_test.go
@@ -390,9 +390,9 @@ func TestOrganizer_Handle_Catchup(t *testing.T) {
 	require.Equal(t, fakeMessages, c.msgs)
 }
 
-// Check that if the organizer receives a wrong message, it will send an error with
-// id = null if impossible to recover request id
-// The fakeSocket abstraction replaces null by -1 for testing
+// Check that if the organizer receives a wrong message, it will send an error
+// with id = null if impossible to recover request id. The fakeSocket
+// abstraction replaces null by -1 for testing.
 func TestOrganizer_HandleWrongMessage(t *testing.T) {
 	keypair := generateKeyPair(t)
 

--- a/be1-go/hub/organizer/mod_test.go
+++ b/be1-go/hub/organizer/mod_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"popstellar/channel"
 	"popstellar/crypto"
 	jsonrpc "popstellar/message"
@@ -388,6 +390,66 @@ func TestOrganizer_Handle_Catchup(t *testing.T) {
 	require.Equal(t, fakeMessages, c.msgs)
 }
 
+// Check that if the organizer receives a wrong message, it will send an error with
+// id = null if impossible to recover request id
+// The fakeSocket abstraction replaces null by -1 for testing
+func TestOrganizer_HandleWrongMessage(t *testing.T) {
+	keypair := generateKeyPair(t)
+
+	fakeMessages := []message.Message{
+		{
+			MessageID: "XXX",
+		},
+	}
+
+	// set fake messages on the channel
+	c := &fakeChannel{
+		msgs: fakeMessages,
+	}
+
+	hub, err := NewHub(keypair.public, nolog, nil)
+	require.NoError(t, err)
+
+	laoID := "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM="
+
+	hub.channelByID[rootPrefix+laoID] = c
+
+	// get the wrong message example
+	relativeExamplePath := filepath.Join("..", "..", "..", "protocol",
+		"examples")
+	file := filepath.Join(relativeExamplePath, "wrong_missing_jsonrpc.json")
+
+	buf, err := os.ReadFile(file)
+	require.NoError(t, err)
+
+	publishBuf, err := json.Marshal(&buf)
+	require.NoError(t, err)
+
+	sock := &fakeSocket{id: "fakeID"}
+
+	err = hub.handleMessageFromClient(&socket.IncomingMessage{
+		Socket:  sock,
+		Message: publishBuf,
+	})
+	require.Error(t, err)
+	require.Error(t, sock.err)
+
+	// > check the id
+	require.Equal(t, -1, sock.resultID)
+
+	// > check that there is no errors with messages from witness too
+	err = hub.handleMessageFromWitness(&socket.IncomingMessage{
+		Socket:  sock,
+		Message: publishBuf,
+	})
+
+	require.Error(t, err)
+	require.Error(t, sock.err)
+
+	// > check the id
+	require.Equal(t, -1, sock.resultID)
+}
+
 // -----------------------------------------------------------------------------
 // Utility functions
 
@@ -510,6 +572,11 @@ func (f *fakeSocket) SendResult(id int, res []message.Message) {
 
 // SendError implements socket.Socket
 func (f *fakeSocket) SendError(id *int, err error) {
+	if id != nil {
+		f.resultID = *id
+	} else {
+		f.resultID = -1
+	}
 	f.err = err
 }
 

--- a/be1-go/hub/witness/mod.go
+++ b/be1-go/hub/witness/mod.go
@@ -337,12 +337,12 @@ func (h *Hub) handlePublish(socket socket.Socket, byteMessage []byte) (int, erro
 
 	channel, err := h.getChan(publish.Params.Channel)
 	if err != nil {
-		return -1, xerrors.Errorf("failed to get channel: %v", err)
+		return publish.ID, xerrors.Errorf("failed to get channel: %v", err)
 	}
 
 	err = channel.Publish(publish)
 	if err != nil {
-		return -1, xerrors.Errorf("failed to publish: %v", err)
+		return publish.ID, xerrors.Errorf("failed to publish: %v", err)
 	}
 
 	return publish.ID, nil
@@ -359,12 +359,12 @@ func (h *Hub) handleSubscribe(socket socket.Socket, byteMessage []byte) (int, er
 
 	channel, err := h.getChan(subscribe.Params.Channel)
 	if err != nil {
-		return -1, xerrors.Errorf("failed to get subscribe channel: %v", err)
+		return subscribe.ID, xerrors.Errorf("failed to get subscribe channel: %v", err)
 	}
 
 	err = channel.Subscribe(socket, subscribe)
 	if err != nil {
-		return -1, xerrors.Errorf("failed to publish: %v", err)
+		return subscribe.ID, xerrors.Errorf("failed to publish: %v", err)
 	}
 
 	return subscribe.ID, nil
@@ -381,12 +381,12 @@ func (h *Hub) handleUnsubscribe(socket socket.Socket, byteMessage []byte) (int, 
 
 	channel, err := h.getChan(unsubscribe.Params.Channel)
 	if err != nil {
-		return -1, xerrors.Errorf("failed to get unsubscribe channel: %v", err)
+		return unsubscribe.ID, xerrors.Errorf("failed to get unsubscribe channel: %v", err)
 	}
 
 	err = channel.Unsubscribe(socket.ID(), unsubscribe)
 	if err != nil {
-		return -1, xerrors.Errorf("failed to unsubscribe: %v", err)
+		return unsubscribe.ID, xerrors.Errorf("failed to unsubscribe: %v", err)
 	}
 
 	return unsubscribe.ID, nil
@@ -403,12 +403,12 @@ func (h *Hub) handleCatchup(byteMessage []byte) ([]message.Message, int, error) 
 
 	channel, err := h.getChan(catchup.Params.Channel)
 	if err != nil {
-		return nil, -1, xerrors.Errorf("failed to get catchup channel: %v", err)
+		return nil, catchup.ID, xerrors.Errorf("failed to get catchup channel: %v", err)
 	}
 
 	msg := channel.Catchup(catchup)
 	if err != nil {
-		return nil, -1, xerrors.Errorf("failed to catchup: %v", err)
+		return nil, catchup.ID, xerrors.Errorf("failed to catchup: %v", err)
 	}
 
 	return msg, catchup.ID, nil

--- a/be1-go/hub/witness/mod.go
+++ b/be1-go/hub/witness/mod.go
@@ -133,7 +133,7 @@ func (h *Hub) tempHandleMessage(incMsg *socket.IncomingMessage) error {
 	if handlerErr != nil {
 		err := answer.NewErrorf(-4, failedMethodHandling, handlerErr)
 		h.log.Err(err)
-		socket.SendError(nil, err)
+		socket.SendError(&id, err)
 		return err
 	}
 

--- a/be1-go/network/socket/socket.go
+++ b/be1-go/network/socket/socket.go
@@ -2,6 +2,7 @@ package socket
 
 import (
 	"encoding/json"
+	jsonrpc "popstellar/message"
 	"sync"
 	"time"
 
@@ -177,6 +178,7 @@ func (s *baseSocket) SendError(id *int, err error) {
 	}
 
 	answer := answer.Answer{
+		JSONRPCBase: jsonrpc.JSONRPCBase{JSONRPC: "2.0"},
 		ID:    id,
 		Error: msgError,
 	}


### PR DESCRIPTION
The json-rpc field is now 2.0 for every error answer sent.
The id field is not null when possible. The errors from invalid schema, invalid RPC type, invalid method and unmarshal issues will have a null value. 

Will test in another PR when PR #526 will be merged.