### PR TITLE
Fixes the bug of open roll call

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/config/application.conf
+++ b/be2-scala/src/main/scala/ch/epfl/pop/config/application.conf
@@ -1,10 +1,7 @@
 ## Akka configs 
-akka.http.server.idle-timeout = infinite   #  
-akka.http.server.idle-timeout = infinite   # for testing purposes only
 
-#akka.http.client.idle-timeout =  30 s 
-#akka.http.server.idle-timeout =  30 s  
-
+akka.http.client.idle-timeout =  600 s 
+akka.http.server.idle-timeout =  600 s  
 akka.http.server.request-timeout = 600 s
 
 #POP Server config default

--- a/be2-scala/src/main/scala/ch/epfl/pop/config/application.conf
+++ b/be2-scala/src/main/scala/ch/epfl/pop/config/application.conf
@@ -1,7 +1,9 @@
 ## Akka configs 
-akka.http.server.idle-timeout =  5 s  
-#akka.http.server.idle-timeout = infinite   # for testing purposes only
-akka.http.client.idle-timeout =  5 s 
+akka.http.server.idle-timeout = infinite   #  
+akka.http.server.idle-timeout = infinite   # for testing purposes only
+
+#akka.http.client.idle-timeout =  30 s 
+#akka.http.server.idle-timeout =  30 s  
 
 akka.http.server.request-timeout = 600 s
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/json/HighLevelProtocol.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/json/HighLevelProtocol.scala
@@ -163,17 +163,20 @@ object HighLevelProtocol extends DefaultJsonProtocol {
     }
 
     override def write(obj: JsonRpcRequest): JsValue = {
-      val optId: JsValue = obj.id match {
-        case Some(idx) => idx.toJson
-        case _ => JsNull
-      }
-
-      JsObject(
-        PARAM_JSON_RPC -> obj.jsonrpc.toJson,
-        PARAM_METHOD -> obj.method.toJson,
-        PARAM_PARAMS -> obj.params.toJson,
-        PARAM_ID -> optId
-      )
+      
+      var jsObjectContent: ListMap[String, JsValue] = ListMap.empty[String, JsValue]
+      
+      jsObjectContent += (PARAM_JSON_RPC -> obj.jsonrpc.toJson)
+      jsObjectContent += (PARAM_METHOD -> obj.method.toJson)
+      jsObjectContent += (PARAM_PARAMS -> obj.params.toJson)
+          
+      /*Add the id key iif it's non null*/
+      if(obj.isIdDefined){
+        jsObjectContent += (PARAM_ID -> obj.id.get.toJson)
+      } 
+        
+      JsObject(jsObjectContent)
+      
     }
   }
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/json/HighLevelProtocol.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/json/HighLevelProtocol.scala
@@ -170,7 +170,7 @@ object HighLevelProtocol extends DefaultJsonProtocol {
       jsObjectContent += (PARAM_METHOD -> obj.method.toJson)
       jsObjectContent += (PARAM_PARAMS -> obj.params.toJson)
 
-      /*Add the id key iif it's non null*/
+      /*Add the id key iff it's non null*/
       if(obj.id.isDefined){
         jsObjectContent += (PARAM_ID -> obj.id.get.toJson)
       }

--- a/be2-scala/src/main/scala/ch/epfl/pop/json/HighLevelProtocol.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/json/HighLevelProtocol.scala
@@ -163,20 +163,20 @@ object HighLevelProtocol extends DefaultJsonProtocol {
     }
 
     override def write(obj: JsonRpcRequest): JsValue = {
-      
+
       var jsObjectContent: ListMap[String, JsValue] = ListMap.empty[String, JsValue]
-      
+
       jsObjectContent += (PARAM_JSON_RPC -> obj.jsonrpc.toJson)
       jsObjectContent += (PARAM_METHOD -> obj.method.toJson)
       jsObjectContent += (PARAM_PARAMS -> obj.params.toJson)
-          
+
       /*Add the id key iif it's non null*/
-      if(obj.isIdDefined){
+      if(obj.id.isDefined){
         jsObjectContent += (PARAM_ID -> obj.id.get.toJson)
-      } 
-        
+      }
+
       JsObject(jsObjectContent)
-      
+
     }
   }
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/JsonRpcRequest.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/JsonRpcRequest.scala
@@ -17,6 +17,8 @@ class JsonRpcRequest(
                       val params: Params,
                       val id: Option[Int]
                     ) extends JsonRpcMessage {
+                      
+  def isIdDefined = id.isDefined
 
   // defensive methods in case protocol structure changes
   def getParams: Params = params
@@ -77,5 +79,10 @@ object JsonRpcRequest extends Parsable {
     new JsonRpcRequest(jsonrpc, method, params, id)
   }
 
-  override def buildFromJson(payload: String): JsonRpcRequest = payload.parseJson.asJsObject.convertTo[JsonRpcRequest]
+  override def buildFromJson(payload: String): JsonRpcRequest = {
+  
+    val withId: JsonRpcRequest = payload.parseJson.asJsObject.convertTo[JsonRpcRequest]
+    withId
+
+  }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/JsonRpcRequest.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/JsonRpcRequest.scala
@@ -17,8 +17,6 @@ class JsonRpcRequest(
                       val params: Params,
                       val id: Option[Int]
                     ) extends JsonRpcMessage {
-                      
-  def isIdDefined = id.isDefined
 
   // defensive methods in case protocol structure changes
   def getParams: Params = params
@@ -78,11 +76,5 @@ object JsonRpcRequest extends Parsable {
            ): JsonRpcRequest = {
     new JsonRpcRequest(jsonrpc, method, params, id)
   }
-
-  override def buildFromJson(payload: String): JsonRpcRequest = {
-  
-    val withId: JsonRpcRequest = payload.parseJson.asJsObject.convertTo[JsonRpcRequest]
-    withId
-
-  }
+  override def buildFromJson(payload: String): JsonRpcRequest = payload.parseJson.asJsObject.convertTo[JsonRpcRequest]
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/MethodType.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/MethodType.scala
@@ -6,7 +6,7 @@ object MethodType extends Enumeration {
   // uninitialized placeholder
   val INVALID: Value = MatchingValue("__INVALID_METHOD__")
 
-  val BROADCAST: Value = MatchingValue("message")
+  val BROADCAST: Value = MatchingValue("broadcast")
   val PUBLISH: Value = MatchingValue("publish")
   val SUBSCRIBE: Value = MatchingValue("subscribe")
   val UNSUBSCRIBE: Value = MatchingValue("unsubscribe")


### PR DESCRIPTION
 Double bugs:
A null ID gets included in the RPC message, causing the front-end-1 to reject it, the method was incorrect (`message `instead of `broadcast`, it has now been fixed according to the protocol specifications. 
This patch corrects this issue, I'll be providing more tests soon to cover the format specifications 😃  