### PR TITLE
Add exclusion to the test files for the sonar analysis

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -208,7 +208,18 @@ jobs:
         emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
         disable-animations: true
         working-directory: ./fe2-android
-        script: ./gradlew connectedMockDebugAndroidTest jacocoTestReport
+        script: ./gradlew connectedMockDebugAndroidTest
+    
+    - name: Generate Test Coverage
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 29
+        arch: x86_64
+        profile: pixel_2
+        emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
+        disable-animations: true
+        working-directory: ./fe2-android
+        script: ./gradlew jacocoTestReport --continue
     
     - name: SonarCloud Analysis
       env:

--- a/be1-go/sonar-project.properties
+++ b/be1-go/sonar-project.properties
@@ -1,4 +1,14 @@
 sonar.organization=dedis
 sonar.projectKey=dedis_student_21_pop_be1
+
+# Path of the test and coverage reports
 sonar.go.tests.reportPaths=./report.json
 sonar.go.coverage.reportPaths=./coverage.out
+
+# Path patterns of the source files
+sonar.sources=.
+sonar.exclusions=**/*_test.go,**/test/**
+
+# Path patterns of the test files
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go,**/test/**

--- a/be2-scala/build.sbt
+++ b/be2-scala/build.sbt
@@ -28,9 +28,13 @@ scalacOptions in Scapegoat += "-P:scapegoat:overrideLevels:all=Warning"
 sonarProperties := Map(
   "sonar.organization" -> "dedis",
   "sonar.projectKey" -> "dedis_student_21_pop_be2",
+  
   "sonar.sources" -> "src/main/scala",
+  "sonar.tests" -> "src/test/scala",
+  
   "sonar.sourceEncoding" -> "UTF-8",
   "sonar.scala.version" -> "2.13.5",
+  // Paths to the test and coverage reports
   "sonar.scala.coverage.reportPaths" -> "./target/scala-2.13/scoverage-report/scoverage.xml",
   "sonar.scala.scapegoat.reportPaths" -> "./target/scala-2.13/scapegoat-report/scapegoat.xml"
 )

--- a/fe1-web/sonar-project.properties
+++ b/fe1-web/sonar-project.properties
@@ -2,7 +2,19 @@ sonar.organization=dedis
 sonar.projectKey=dedis_student_21_pop_fe1
 sonar.host.url=https://sonarcloud.io
 
+# Path to test and coverage reports
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.testExecutionReportPaths=./test-report.xml
+
+# Path patterns of the source files
+sonar.sources=.
+sonar.exclusions=**/__tests__/**/*.ts
+
+# Path patterns of the test files
+sonar.tests=.
+sonar.test.inclusions=**/__tests__/**/*.ts
+
+# Exclude mocks and tests from coverage
+sonar.coverage.exclusions=**/__tests__/**/*.ts,**/__mocks__/**/*.ts
 
 sonar.sourceEncoding=UTF-8

--- a/fe2-android/app/build.gradle
+++ b/fe2-android/app/build.gradle
@@ -13,12 +13,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        // The following argument makes the Android Test Orchestrator run its
-        // "pm clear" command after each test invocation. This command ensures
-        // that the app's state is completely cleared between tests.
-        testInstrumentationRunnerArguments clearPackageData: 'true'
 
         compileOptions {
             sourceCompatibility JavaVersion.VERSION_1_8
@@ -26,9 +21,6 @@ android {
         }
 
         testOptions {
-            // This makes the coverage fail. For more information :
-            // https://developer.android.com/training/testing/junit-runner#using-android-test-orchestrator
-            // execution 'ANDROIDX_TEST_ORCHESTRATOR'
             unitTests.returnDefaultValues = true
             // Improve tests performances by disabling fancy animations
             animationsDisabled = true
@@ -44,8 +36,9 @@ android {
     buildTypes {
         debug {
             getIsDefault().set(true)  // sets this build type as default
-            testCoverageEnabled true
+            testCoverageEnabled true // Enables test coverage
         }
+
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
@@ -63,10 +56,34 @@ android {
     productFlavors {
         mock {
             dimension "default"
+
+            testOptions {
+                execution 'ANDROIDX_TEST_ORCHESTRATOR'
+            }
+
+            // The following argument makes the Android Test Orchestrator run its
+            // "pm clear" command after each test invocation. This command ensures
+            // that the app's state is completely cleared between tests.
+            testInstrumentationRunnerArguments clearPackageData: 'true'
         }
+
+        // Flavor used only to compute the coverage of teh tests as it cannot be done with
+        // the android orchestrator enabled. More informations :
+        // https://developer.android.com/training/testing/junit-runner#using-android-test-orchestrator
+        cov {
+            dimension "default"
+        }
+
         prod {
             getIsDefault().set(true)  // sets this flavor as default
             dimension "default"
+        }
+    }
+
+    // Make sure the coverage flavor uses the same source set as the mock
+    sourceSets{
+        cov {
+            java.srcDirs += [ 'src/mock/java' ]
         }
     }
 }
@@ -149,7 +166,7 @@ dependencies {
     androidTestUtil 'androidx.test:orchestrator:1.4.0'
 }
 
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testMockDebugUnitTest', 'createMockDebugCoverageReport']) {
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testCovDebugUnitTest', 'createCovDebugCoverageReport']) {
     reports {
         xml.enabled = true
         html.enabled = true
@@ -163,13 +180,13 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testMockDebugUnitTest', '
         '**/*Test*.*',
         'android/**/*.*'
     ]
-    def debugTree = fileTree(dir: "$project.buildDir/intermediates/javac/mockDebug/classes", excludes: fileFilter)
+    def debugTree = fileTree(dir: "$project.buildDir/intermediates/javac/covDebug/classes", excludes: fileFilter)
     def mainSrc = "$project.projectDir/src/main/java"
 
     sourceDirectories.setFrom(files([mainSrc]))
     classDirectories.setFrom(files([debugTree]))
     executionData.setFrom(fileTree(dir: project.buildDir, includes: [
-        'outputs/unit_test_code_coverage/mockDebugUnitTest/testMockDebugUnitTest.exec',
-        'outputs/code_coverage/mockDebugAndroidTest/connected/*coverage.ec'
+        'outputs/unit_test_code_coverage/covDebugUnitTest/testCovDebugUnitTest.exec',
+        'outputs/code_coverage/covDebugAndroidTest/connected/**/*.ec'
     ]))
 }

--- a/fe2-android/app/build.gradle
+++ b/fe2-android/app/build.gradle
@@ -89,13 +89,21 @@ android {
 }
 
 sonarqube {
+
+    // The flavor and build type to analyse with SonarCloud
+    var analysedProject = "mockDebug"
+
     properties {
         property "sonar.projectKey", "dedis_student_21_pop_fe2"
         property "sonar.projectName", "PoP - Fe2-Android"
         property "sonar.organization", "dedis"
         property "sonar.host.url", "https://sonarcloud.io"
+        // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
+        property "sonar.junit.reportPaths", "./build/test-results/test${analysedProject.capitalize()}UnitTest/TEST-*.xml"
+        // Paths (absolute or relative) to xml files with Android Lint issues.
+        property "sonar.androidLint.reportPaths", "./build/reports/lint-results-${analysedProject}.xml"
+        // Paths to JaCoCo XML coverage report files.
         property "sonar.coverage.jacoco.xmlReportPaths", "./build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
-        property "sonar.junit.reportsPath", "./build/test-results/*/TEST-*.xml"
     }
 }
 

--- a/fe2-android/app/build.gradle
+++ b/fe2-android/app/build.gradle
@@ -81,27 +81,23 @@ android {
     }
 
     // Make sure the coverage flavor uses the same source set as the mock
-    sourceSets{
+    sourceSets {
         cov {
-            java.srcDirs += [ 'src/mock/java' ]
+            java.srcDirs += ['src/mock/java']
         }
     }
 }
 
 sonarqube {
-
-    // The flavor and build type to analyse with SonarCloud
-    var analysedProject = "mockDebug"
-
     properties {
         property "sonar.projectKey", "dedis_student_21_pop_fe2"
         property "sonar.projectName", "PoP - Fe2-Android"
         property "sonar.organization", "dedis"
         property "sonar.host.url", "https://sonarcloud.io"
         // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
-        property "sonar.junit.reportPaths", "./build/test-results/test${analysedProject.capitalize()}UnitTest/TEST-*.xml"
+        property "sonar.junit.reportPaths", "./build/test-results/*/TEST-*.xml"
         // Paths (absolute or relative) to xml files with Android Lint issues.
-        property "sonar.androidLint.reportPaths", "./build/reports/lint-results-${analysedProject}.xml"
+        property "sonar.androidLint.reportPaths", "./build/reports/lint-results-*.xml"
         // Paths to JaCoCo XML coverage report files.
         property "sonar.coverage.jacoco.xmlReportPaths", "./build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
     }


### PR DESCRIPTION
The PR aims to analyze the coverage of the actual sources of the project and not the tests.

It also adds a specific build setup for the android project that allows both coverage and the reliability brought by the android orchestrator.