### PR TITLE
Update the consensus stage 1

### DIFF
--- a/be1-go/channel/consensus/mod.go
+++ b/be1-go/channel/consensus/mod.go
@@ -214,7 +214,7 @@ func (c *Channel) processConsensusObject(action string, msg message.Message) err
 		if err != nil {
 			return xerrors.Errorf("failed to process elect accept action: %w", err)
 		}
-	case messagedata.ConsensuisActionLearn:
+	case messagedata.ConsensusActionLearn:
 		var consensusLearn messagedata.ConsensusLearn
 
 		err := msg.UnmarshalData(&consensusLearn)

--- a/be1-go/message/messagedata/consensus_elect.go
+++ b/be1-go/message/messagedata/consensus_elect.go
@@ -1,8 +1,6 @@
 package messagedata
 
 import (
-	"fmt"
-
 	"golang.org/x/xerrors"
 )
 
@@ -28,11 +26,9 @@ type Key struct {
 func (message ConsensusElect) Verify() error {
 	expectedID := Hash(
 		message.Object,
-		fmt.Sprintf("%d", message.CreatedAt),
 		message.Key.Type,
 		message.Key.ID,
 		message.Key.Property,
-		message.Value,
 	)
 
 	if message.InstanceID != expectedID {

--- a/be1-go/message/messagedata/consensus_elect_accept.go
+++ b/be1-go/message/messagedata/consensus_elect_accept.go
@@ -2,8 +2,9 @@ package messagedata
 
 // ConsensusElectAccept defines a message data
 type ConsensusElectAccept struct {
-	Object    string `json:"object"`
-	Action    string `json:"action"`
-	MessageID string `json:"message_id"`
-	Accept    bool   `json:"accept"`
+	Object     string `json:"object"`
+	Action     string `json:"action"`
+	InstanceID string `json:"instance_id"`
+	MessageID  string `json:"message_id"`
+	Accept     bool   `json:"accept"`
 }

--- a/be1-go/message/messagedata/consensus_learn.go
+++ b/be1-go/message/messagedata/consensus_learn.go
@@ -2,8 +2,9 @@ package messagedata
 
 // ConsensusLearn defines a message data
 type ConsensusLearn struct {
-	Object    string   `json:"object"`
-	Action    string   `json:"action"`
-	MessageID string   `json:"message_id"`
-	Acceptors []string `json:"acceptors"`
+	Object     string   `json:"object"`
+	Action     string   `json:"action"`
+	InstanceID string   `json:"instance_id"`
+	MessageID  string   `json:"message_id"`
+	Acceptors  []string `json:"acceptors"`
 }

--- a/be1-go/message/messagedata/mod.go
+++ b/be1-go/message/messagedata/mod.go
@@ -13,7 +13,7 @@ const (
 	ConsensusObject            = "consensus"
 	ConsensusActionElect       = "elect"
 	ConsensusActionElectAccept = "elect-accept"
-	ConsensuisActionLearn      = "learn"
+	ConsensusActionLearn       = "learn"
 
 	ElectionObject       = "election"
 	ElectionActionEnd    = "end"

--- a/be1-go/message/test/messagedata/consensus_elect_accept_test.go
+++ b/be1-go/message/test/messagedata/consensus_elect_accept_test.go
@@ -29,6 +29,7 @@ func Test_Consensus_Elect_Accept(t *testing.T) {
 
 	require.Equal(t, "consensus", msg.Object)
 	require.Equal(t, "elect-accept", msg.Action)
-	require.Equal(t, "6z1k9Eqet9-YAOdEE9NaIQMvw8_W_Fj-u2vRL4siIb0=", msg.MessageID)
+	require.Equal(t, "6wCJZmUn0UwsdZGyJVy7iiAIiPEHwsBRmIsL_TxM4Cs=", msg.InstanceID)
+	require.Equal(t, "7J0d6d8Bw28AJwB4ttOUiMgm_DUTHSYFXM30_8kmd1Q=", msg.MessageID)
 	require.True(t, msg.Accept)
 }

--- a/be1-go/message/test/messagedata/consensus_elect_test.go
+++ b/be1-go/message/test/messagedata/consensus_elect_test.go
@@ -29,11 +29,11 @@ func Test_Consensus_Elect(t *testing.T) {
 
 	require.Equal(t, "consensus", msg.Object)
 	require.Equal(t, "elect", msg.Action)
-	require.Equal(t, "0bknjMZT1rVyyHJbRQBGl0CjCIxUnSmZcnI1XNIdCpM=", msg.InstanceID)
+	require.Equal(t, "6wCJZmUn0UwsdZGyJVy7iiAIiPEHwsBRmIsL_TxM4Cs=", msg.InstanceID)
 	require.Equal(t, int64(1634553005), msg.CreatedAt)
 
 	require.Equal(t, "election", msg.Key.Type)
-	require.Equal(t, "-t0xoQZa-ryiW18JnTjJHCsCNehFxuXOFOsfgKHHkj0=", msg.Key.ID)
+	require.Equal(t, "GXVFZVHlVNpOJsdRsJkUmJW2hnrd9n_vKtEc7P6FMF4=", msg.Key.ID)
 	require.Equal(t, "state", msg.Key.Property)
 
 	require.Equal(t, "started", msg.Value)

--- a/be1-go/message/test/messagedata/consensus_learn_test.go
+++ b/be1-go/message/test/messagedata/consensus_learn_test.go
@@ -29,7 +29,9 @@ func Test_Consensus_Learn(t *testing.T) {
 
 	require.Equal(t, "consensus", msg.Object)
 	require.Equal(t, "learn", msg.Action)
-	require.Equal(t, "6z1k9Eqet9-YAOdEE9NaIQMvw8_W_Fj-u2vRL4siIb0=", msg.MessageID)
+
+	require.Equal(t, "6wCJZmUn0UwsdZGyJVy7iiAIiPEHwsBRmIsL_TxM4Cs=", msg.InstanceID)
+	require.Equal(t, "7J0d6d8Bw28AJwB4ttOUiMgm_DUTHSYFXM30_8kmd1Q=", msg.MessageID)
 
 	require.Len(t, msg.Acceptors, 3)
 	require.Equal(t, "pFFLRiOVyFX2UwFw8kd8PnVg6rshT-ofWYVAc_QuRz4=", msg.Acceptors[0])

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusElect.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusElect.java
@@ -19,8 +19,7 @@ public final class ConsensusElect extends Data {
   private final Object value;
 
   public ConsensusElect(long creation, String objId, String type, String property, Object value) {
-    this.instanceId =
-        Consensus.generateConsensusId(creation, type, objId, property, String.valueOf(value));
+    this.instanceId = Consensus.generateConsensusId(type, objId, property);
     this.creation = creation;
     this.key = new ConsensusKey(type, objId, property);
     this.value = value;
@@ -67,10 +66,10 @@ public final class ConsensusElect extends Data {
     }
     ConsensusElect that = (ConsensusElect) o;
 
-    return java.util.Objects.equals(instanceId, that.instanceId)
-        && creation == that.creation
+    return creation == that.creation
         && java.util.Objects.equals(key, that.key)
-        && java.util.Objects.equals(value, that.value);
+        && java.util.Objects.equals(value, that.value)
+        && java.util.Objects.equals(instanceId, that.instanceId);
   }
 
   @Override

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusElect.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusElect.java
@@ -67,9 +67,9 @@ public final class ConsensusElect extends Data {
     ConsensusElect that = (ConsensusElect) o;
 
     return creation == that.creation
+        && java.util.Objects.equals(instanceId, that.instanceId)
         && java.util.Objects.equals(key, that.key)
-        && java.util.Objects.equals(value, that.value)
-        && java.util.Objects.equals(instanceId, that.instanceId);
+        && java.util.Objects.equals(value, that.value);
   }
 
   @Override

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusElectAccept.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusElectAccept.java
@@ -58,9 +58,9 @@ public final class ConsensusElectAccept extends Data {
     }
     ConsensusElectAccept that = (ConsensusElectAccept) o;
 
-    return java.util.Objects.equals(instanceId, that.instanceId)
-        && java.util.Objects.equals(messageId, that.messageId)
-        && accept == that.accept;
+    return accept == that.accept
+        && java.util.Objects.equals(instanceId, that.instanceId)
+        && java.util.Objects.equals(messageId, that.messageId);
   }
 
   @Override

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusElectAccept.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusElectAccept.java
@@ -7,14 +7,22 @@ import com.google.gson.annotations.SerializedName;
 
 public final class ConsensusElectAccept extends Data {
 
+  @SerializedName("instance_id")
+  private final String instanceId;
+
   @SerializedName("message_id")
   private final String messageId;
 
   private final boolean accept;
 
-  public ConsensusElectAccept(String messageId, boolean accept) {
+  public ConsensusElectAccept(String instanceId, String messageId, boolean accept) {
+    this.instanceId = instanceId;
     this.messageId = messageId;
     this.accept = accept;
+  }
+
+  public String getInstanceId() {
+    return instanceId;
   }
 
   public String getMessageId() {
@@ -37,7 +45,7 @@ public final class ConsensusElectAccept extends Data {
 
   @Override
   public int hashCode() {
-    return java.util.Objects.hash(messageId, accept);
+    return java.util.Objects.hash(instanceId, messageId, accept);
   }
 
   @Override
@@ -50,11 +58,15 @@ public final class ConsensusElectAccept extends Data {
     }
     ConsensusElectAccept that = (ConsensusElectAccept) o;
 
-    return java.util.Objects.equals(messageId, that.messageId) && accept == that.accept;
+    return java.util.Objects.equals(instanceId, that.instanceId)
+        && java.util.Objects.equals(messageId, that.messageId)
+        && accept == that.accept;
   }
 
   @Override
   public String toString() {
-    return String.format("ConsensusElectAccept{message_id='%s', accept=%b}", messageId, accept);
+    return String.format(
+        "ConsensusElectAccept{instance_id='%s', message_id='%s', accept=%b}",
+        instanceId, messageId, accept);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusKey.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusKey.java
@@ -40,9 +40,10 @@ public final class ConsensusKey {
       return false;
     }
     ConsensusKey that = (ConsensusKey) o;
-    return java.util.Objects.equals(getType(), that.getType())
-        && java.util.Objects.equals(getId(), that.getId())
-        && java.util.Objects.equals(getProperty(), that.getProperty());
+
+    return Objects.equals(type, that.type)
+        && Objects.equals(id, that.id)
+        && Objects.equals(property, that.property);
   }
 
   @Override

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusLearn.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusLearn.java
@@ -10,14 +10,22 @@ import java.util.List;
 
 public final class ConsensusLearn extends Data {
 
+  @SerializedName("instance_id")
+  private final String instanceId;
+
   @SerializedName("message_id")
   private final String messageId;
 
   private final List<String> acceptors;
 
-  public ConsensusLearn(String messageId, List<String> acceptors) {
+  public ConsensusLearn(String instanceId, String messageId, List<String> acceptors) {
+    this.instanceId = instanceId;
     this.messageId = messageId;
     this.acceptors = Collections.unmodifiableList(acceptors);
+  }
+
+  public String getInstanceId() {
+    return instanceId;
   }
 
   public String getMessageId() {
@@ -40,7 +48,7 @@ public final class ConsensusLearn extends Data {
 
   @Override
   public int hashCode() {
-    return java.util.Objects.hash(messageId, acceptors);
+    return java.util.Objects.hash(instanceId, messageId, acceptors);
   }
 
   @Override
@@ -53,12 +61,15 @@ public final class ConsensusLearn extends Data {
     }
     ConsensusLearn that = (ConsensusLearn) o;
 
-    return java.util.Objects.equals(messageId, that.messageId)
+    return java.util.Objects.equals(instanceId, that.instanceId)
+        && java.util.Objects.equals(messageId, that.messageId)
         && java.util.Objects.equals(acceptors, that.acceptors);
   }
 
   @Override
   public String toString() {
-    return String.format("ConsensusLearn{message_id='%s', acceptors=%s}", messageId, acceptors);
+    return String.format(
+        "ConsensusLearn{instance_id='%s', message_id='%s', acceptors=%s}",
+        instanceId, messageId, acceptors);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/Consensus.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/Consensus.java
@@ -30,7 +30,7 @@ public final class Consensus {
   private final Map<String, String> acceptorToMessageId;
 
   public Consensus(long creation, ConsensusKey key, Object value) {
-    this.id = generateConsensusId(creation, key.getType(), key.getId(), key.getProperty(), value);
+    this.id = generateConsensusId(key.getType(), key.getId(), key.getProperty());
     this.key = key;
     this.value = value;
     this.creation = creation;
@@ -143,9 +143,7 @@ public final class Consensus {
         id, channel, messageId, key, value, creation, isAccepted, isFailed, proposer);
   }
 
-  public static String generateConsensusId(
-      long createdAt, String type, String id, String property, Object value) {
-    return Hash.hash(
-        "consensus", Long.toString(createdAt), type, id, property, String.valueOf(value));
+  public static String generateConsensusId(String type, String id, String property) {
+    return Hash.hash("consensus", type, id, property);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/ConsensusNode.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/ConsensusNode.java
@@ -36,15 +36,15 @@ public final class ConsensusNode {
     return Collections.unmodifiableSet(acceptedMessageIds);
   }
 
-  public Optional<Consensus> getLastConsensus(String keyId) {
-    // get the consensus for the given key id, with the largest creation time
+  public Optional<Consensus> getLastConsensus(String instanceId) {
+    // get the consensus for the given instanceId, with the largest creation time
     return consensuses.stream()
-        .filter(consensus -> consensus.getKey().getId().equals(keyId))
+        .filter(consensus -> consensus.getId().equals(instanceId))
         .max((c1, c2) -> (int) (c1.getCreation() - c2.getCreation()));
   }
 
-  public State getState(String keyId) {
-    Optional<Consensus> lastConsensus = getLastConsensus(keyId);
+  public State getState(String instanceId) {
+    Optional<Consensus> lastConsensus = getLastConsensus(instanceId);
     if (lastConsensus.isPresent()) {
       Consensus consensus = lastConsensus.get();
       if (consensus.isFailed()) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/ConsensusNode.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/ConsensusNode.java
@@ -2,6 +2,7 @@ package com.github.dedis.popstellar.model.objects;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -40,7 +41,7 @@ public final class ConsensusNode {
     // get the consensus for the given instanceId, with the largest creation time
     return consensuses.stream()
         .filter(consensus -> consensus.getId().equals(instanceId))
-        .max((c1, c2) -> (int) (c1.getCreation() - c2.getCreation()));
+        .max(Comparator.comparingLong(Consensus::getCreation));
   }
 
   public State getState(String instanceId) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
@@ -599,7 +599,7 @@ public class LaoDetailViewModel extends AndroidViewModel
     }
 
     ConsensusElectAccept consensusElectAccept =
-        new ConsensusElectAccept(consensus.getMessageId(), accept);
+        new ConsensusElectAccept(consensus.getId(), consensus.getMessageId(), accept);
 
     try {
       KeysetHandle publicKeysetHandle = mKeysetManager.getKeysetHandle().getPublicKeysetHandle();
@@ -654,7 +654,7 @@ public class LaoDetailViewModel extends AndroidViewModel
     List<String> acceptorsMessageIds =
         new ArrayList<>(consensus.getAcceptorsToMessageId().values());
     ConsensusLearn consensusLearn =
-        new ConsensusLearn(consensus.getMessageId(), acceptorsMessageIds);
+        new ConsensusLearn(consensus.getId(), consensus.getMessageId(), acceptorsMessageIds);
 
     try {
       KeysetHandle publicKeysetHandle = mKeysetManager.getKeysetHandle().getPublicKeysetHandle();

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/consensus/NodesAcceptorAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/consensus/NodesAcceptorAdapter.java
@@ -21,19 +21,19 @@ public class NodesAcceptorAdapter extends BaseAdapter {
 
   private List<ConsensusNode> nodes;
   private final ConsensusNode ownNode;
-  private final String electionId;
+  private final String instanceId;
   private final LaoDetailViewModel laoDetailViewModel;
   private final LifecycleOwner lifecycleOwner;
 
   public NodesAcceptorAdapter(
       List<ConsensusNode> nodes,
       ConsensusNode ownNode,
-      String electionId,
+      String instanceId,
       LifecycleOwner lifecycleOwner,
       LaoDetailViewModel laoDetailViewModel) {
     this.nodes = nodes;
     this.ownNode = ownNode;
-    this.electionId = electionId;
+    this.instanceId = instanceId;
     this.laoDetailViewModel = laoDetailViewModel;
     this.lifecycleOwner = lifecycleOwner;
   }
@@ -73,8 +73,8 @@ public class NodesAcceptorAdapter extends BaseAdapter {
     }
 
     ConsensusNode node = getItem(position);
-    Optional<Consensus> lastConsensus = node.getLastConsensus(electionId);
-    State state = node.getState(electionId);
+    Optional<Consensus> lastConsensus = node.getLastConsensus(instanceId);
+    State state = node.getState(instanceId);
     boolean alreadyAccepted =
         lastConsensus
             .map(consensus -> ownNode.getAcceptedMessageIds().contains(consensus.getMessageId()))

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusElectAcceptTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusElectAcceptTest.java
@@ -13,10 +13,16 @@ import org.junit.Test;
 public class ConsensusElectAcceptTest {
 
   private static final String messageId = "aaa";
+  private static final String instanceId = "bbb";
   private static final ConsensusElectAccept consensusElectAcceptAccept =
-      new ConsensusElectAccept(messageId, true);
+      new ConsensusElectAccept(instanceId, messageId, true);
   private static final ConsensusElectAccept consensusElectAcceptReject =
-      new ConsensusElectAccept(messageId, false);
+      new ConsensusElectAccept(instanceId, messageId, false);
+
+  @Test
+  public void getInstanceId() {
+    assertEquals(instanceId, consensusElectAcceptAccept.getInstanceId());
+  }
 
   @Test
   public void getMessageIdTest() {
@@ -41,11 +47,12 @@ public class ConsensusElectAcceptTest {
 
   @Test
   public void equalsTest() {
-    assertEquals(consensusElectAcceptAccept, new ConsensusElectAccept(messageId, true));
-    assertEquals(consensusElectAcceptReject, new ConsensusElectAccept(messageId, false));
+    assertEquals(consensusElectAcceptAccept, new ConsensusElectAccept(instanceId, messageId, true));
+    assertEquals(consensusElectAcceptReject, new ConsensusElectAccept(instanceId, messageId, false));
 
-    assertNotEquals(consensusElectAcceptAccept, new ConsensusElectAccept("random", true));
-    assertNotEquals(consensusElectAcceptAccept, new ConsensusElectAccept(messageId, false));
-    assertNotEquals(consensusElectAcceptReject, new ConsensusElectAccept(messageId, true));
+    assertNotEquals(consensusElectAcceptAccept, new ConsensusElectAccept("random", messageId, true));
+    assertNotEquals(consensusElectAcceptAccept, new ConsensusElectAccept(instanceId, "random", true));
+    assertNotEquals(consensusElectAcceptAccept, new ConsensusElectAccept(instanceId, messageId, false));
+    assertNotEquals(consensusElectAcceptReject, new ConsensusElectAccept(instanceId, messageId, true));
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusElectTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusElectTest.java
@@ -25,15 +25,8 @@ public class ConsensusElectTest {
 
   @Test
   public void getInstanceIdTest() {
-    // Hash("consensus"||created_at||key:type||key:id||key:property||value)
-    String expectedId =
-        Hash.hash(
-            "consensus",
-            Long.toString(timeInSeconds),
-            type,
-            objId,
-            property,
-            String.valueOf(value));
+    // Hash("consensus"||key:type||key:id||key:property)
+    String expectedId = Hash.hash("consensus", type, objId, property);
     assertEquals(expectedId, consensusElect.getInstanceId());
   }
 

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusLearnTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusLearnTest.java
@@ -18,7 +18,14 @@ public class ConsensusLearnTest {
 
   private static final String messageId = Hash.hash("aaa");
   private static final List<String> acceptors = Arrays.asList("aaa", "bbb");
-  private static final ConsensusLearn consensusLearn = new ConsensusLearn(messageId, acceptors);
+  private static final String instanceId = Hash.hash("ccc");
+  private static final ConsensusLearn consensusLearn =
+      new ConsensusLearn(instanceId, messageId, acceptors);
+
+  @Test
+  public void getInstanceIdTest() {
+    assertEquals(instanceId, consensusLearn.getInstanceId());
+  }
 
   @Test
   public void getMessageIdTest() {
@@ -42,9 +49,11 @@ public class ConsensusLearnTest {
 
   @Test
   public void equalsTest() {
-    assertEquals(consensusLearn, new ConsensusLearn(messageId, new ArrayList<>(acceptors)));
+    assertEquals(
+        consensusLearn, new ConsensusLearn(instanceId, messageId, new ArrayList<>(acceptors)));
 
-    assertNotEquals(consensusLearn, new ConsensusLearn("random", acceptors));
-    assertNotEquals(consensusLearn, new ConsensusLearn(messageId, Collections.emptyList()));
+    assertNotEquals(consensusLearn, new ConsensusLearn(instanceId, "random", acceptors));
+    assertNotEquals(
+        consensusLearn, new ConsensusLearn(instanceId, messageId, Collections.emptyList()));
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/objects/ConsensusTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/objects/ConsensusTest.java
@@ -41,15 +41,8 @@ public class ConsensusTest {
 
   @Test
   public void setAndGetIdTest() {
-    // Hash("consensus"||created_at||key:type||key:id||key:property||value)
-    String expectedId =
-        Hash.hash(
-            "consensus",
-            Long.toString(creationInSeconds),
-            type,
-            objId,
-            property,
-            String.valueOf(value));
+    // Hash("consensus"||key:type||key:id||key:property)
+    String expectedId = Hash.hash("consensus", type, objId, property);
     assertEquals(expectedId, consensus.getId());
 
     String newId = Hash.hash("newId");
@@ -123,16 +116,8 @@ public class ConsensusTest {
 
   @Test
   public void generateConsensusIdTest() {
-    // Hash("consensus"||created_at||key:type||key:id||key:property||value)
-    String expectedId =
-        Hash.hash(
-            "consensus",
-            Long.toString(creationInSeconds),
-            type,
-            objId,
-            property,
-            String.valueOf(value));
-    assertEquals(
-        expectedId, Consensus.generateConsensusId(creationInSeconds, type, objId, property, value));
+    // Hash(“consensus”||key:type||key:id||key:property)
+    String expectedId = Hash.hash("consensus", type, objId, property);
+    assertEquals(expectedId, Consensus.generateConsensusId(type, objId, property));
   }
 }

--- a/protocol/examples/messageData/elect.json
+++ b/protocol/examples/messageData/elect.json
@@ -1,11 +1,11 @@
 {
     "object": "consensus",
     "action": "elect",
-    "instance_id": "0bknjMZT1rVyyHJbRQBGl0CjCIxUnSmZcnI1XNIdCpM=",
+    "instance_id": "6wCJZmUn0UwsdZGyJVy7iiAIiPEHwsBRmIsL_TxM4Cs=",
     "created_at": 1634553005,
     "key": {
         "type": "election",
-        "id": "-t0xoQZa-ryiW18JnTjJHCsCNehFxuXOFOsfgKHHkj0=",
+        "id": "GXVFZVHlVNpOJsdRsJkUmJW2hnrd9n_vKtEc7P6FMF4=",
         "property": "state"
     },
     "value": "started"

--- a/protocol/examples/messageData/elect_accept.json
+++ b/protocol/examples/messageData/elect_accept.json
@@ -1,6 +1,7 @@
 {
     "object": "consensus",
     "action": "elect-accept",
-    "message_id": "6z1k9Eqet9-YAOdEE9NaIQMvw8_W_Fj-u2vRL4siIb0=",
+    "instance_id": "6wCJZmUn0UwsdZGyJVy7iiAIiPEHwsBRmIsL_TxM4Cs=",
+    "message_id": "7J0d6d8Bw28AJwB4ttOUiMgm_DUTHSYFXM30_8kmd1Q=",
     "accept": true
 }

--- a/protocol/examples/messageData/learn.json
+++ b/protocol/examples/messageData/learn.json
@@ -2,7 +2,7 @@
     "object": "consensus",
     "action": "learn",
     "instance_id": "6wCJZmUn0UwsdZGyJVy7iiAIiPEHwsBRmIsL_TxM4Cs=",
-    "message_id": "7J0d6d8Bw28AJwB4ttOUiMgm_DUTHSYFXM30_8kmd1Q",
+    "message_id": "7J0d6d8Bw28AJwB4ttOUiMgm_DUTHSYFXM30_8kmd1Q=",
     "acceptors": [
         "pFFLRiOVyFX2UwFw8kd8PnVg6rshT-ofWYVAc_QuRz4=",
         "cSaSHaZzvVR_sfcD5xngSxafK1eCDxmrd0d1C7-VHXJ=",

--- a/protocol/examples/messageData/learn.json
+++ b/protocol/examples/messageData/learn.json
@@ -1,7 +1,8 @@
 {
     "object": "consensus",
     "action": "learn",
-    "message_id": "6z1k9Eqet9-YAOdEE9NaIQMvw8_W_Fj-u2vRL4siIb0=",
+    "instance_id": "6wCJZmUn0UwsdZGyJVy7iiAIiPEHwsBRmIsL_TxM4Cs=",
+    "message_id": "7J0d6d8Bw28AJwB4ttOUiMgm_DUTHSYFXM30_8kmd1Q",
     "acceptors": [
         "pFFLRiOVyFX2UwFw8kd8PnVg6rshT-ofWYVAc_QuRz4=",
         "cSaSHaZzvVR_sfcD5xngSxafK1eCDxmrd0d1C7-VHXJ=",

--- a/protocol/query/method/message/data/dataElect.json
+++ b/protocol/query/method/message/data/dataElect.json
@@ -13,7 +13,7 @@
         "instance_id": {
             "type": "string",
             "contentEncoding": "base64",
-            "$comment": "Hash : SHA256('consensus'||created_at||key:type||key:id||key:property||value)"
+            "$comment": "Hash : SHA256('consensus'||key:type||key:id||key:property)"
         },
         "created_at": {
             "description": "[Timestamp] creation time",

--- a/protocol/query/method/message/data/dataElect.json
+++ b/protocol/query/method/message/data/dataElect.json
@@ -13,7 +13,7 @@
         "instance_id": {
             "type": "string",
             "contentEncoding": "base64",
-            "$comment": "Hash : SHA256('consensus'||key:type||key:id||key:property)"
+            "$comment": "Hash : HashLen('consensus', key:type, key:id, key:property)"
         },
         "created_at": {
             "description": "[Timestamp] creation time",

--- a/protocol/query/method/message/data/dataElectAccept.json
+++ b/protocol/query/method/message/data/dataElectAccept.json
@@ -10,6 +10,10 @@
         "action": {
             "const": "elect-accept"
         },
+        "instance_id": {
+            "description": "Unique id of the consensus instance taken from the elect message",
+            "type": "string"
+        },
         "message_id": {
             "description": "message_id of the elect message",
             "type": "string"
@@ -23,6 +27,7 @@
     "required": [
         "object",
         "action",
+        "instance_id",
         "message_id",
         "accept"
     ]

--- a/protocol/query/method/message/data/dataLearn.json
+++ b/protocol/query/method/message/data/dataLearn.json
@@ -10,6 +10,10 @@
         "action": {
             "const": "learn"
         },
+        "instance_id": {
+            "description": "Unique id of the consensus instance taken from the elect accept",
+            "type": "string"
+        },
         "message_id": {
             "description": "message_id of the elect message",
             "type": "string"
@@ -26,6 +30,7 @@
     "required": [
         "object",
         "action",
+        "instance_id",
         "message_id",
         "acceptors"
     ]


### PR DESCRIPTION
- Changed how the instance_id is computed : `HashLen(“consensus”, key:type, key:id, key:property)`
- Added the instance_id to elect-accept and learn message
- Updated json schemas/examples
- Use instanceId instead of the key:id for finding consensus instance