### PR TITLE
Add chirp object

### DIFF
--- a/fe1-web/model/objects/Chirp.ts
+++ b/fe1-web/model/objects/Chirp.ts
@@ -1,5 +1,6 @@
 import { Timestamp } from './Timestamp';
 import { Hash } from './Hash';
+import { PublicKey } from './PublicKey';
 
 /**
  * Object to represent a Chirp.
@@ -18,7 +19,7 @@ export class Chirp {
   public readonly id: Hash;
 
   // The sender's public key
-  public readonly sender: string;
+  public readonly sender: PublicKey;
 
   // The text of the chirp
   public readonly text: string;
@@ -51,14 +52,15 @@ export class Chirp {
       throw new Error("Undefined 'id' when creating 'Chirp'");
     }
     if (obj.likes === undefined) {
-      throw new Error("Undefined 'likes' when creating 'Chirp'");
+      this.likes = 0;
+    } else {
+      this.likes = obj.likes;
     }
 
     this.id = obj.id;
     this.sender = obj.sender;
     this.text = obj.text;
     this.time = obj.time;
-    this.likes = obj.likes;
     this.parentId = obj.parentId;
   }
 
@@ -70,7 +72,7 @@ export class Chirp {
   public static fromState(chirpState: ChirpState): Chirp {
     return new Chirp({
       id: new Hash(chirpState.id),
-      sender: chirpState.sender,
+      sender: new PublicKey(chirpState.sender),
       text: chirpState.text,
       time: new Timestamp(chirpState.time),
       likes: chirpState.likes,

--- a/fe1-web/model/objects/Chirp.ts
+++ b/fe1-web/model/objects/Chirp.ts
@@ -1,0 +1,82 @@
+import { Timestamp } from './Timestamp';
+import { Hash } from './Hash';
+
+/**
+ * Object to represent a Chirp.
+ */
+
+export interface ChirpState {
+  id: string;
+  sender: string;
+  text: string;
+  time: number;
+  likes: number;
+  parentId: string;
+}
+
+export class Chirp {
+  public readonly id: Hash;
+
+  public readonly sender: string;
+
+  public readonly text: string;
+
+  public readonly time: Timestamp;
+
+  public readonly likes: number;
+
+  public readonly parentId?: Hash;
+
+  constructor(obj: Partial<Chirp>) {
+    if (obj === undefined || obj === null) {
+      throw new Error('Error encountered while creating a Chirp object: '
+        + 'undefined/null parameters');
+    }
+
+    if (obj.id === undefined) {
+      throw new Error("Undefined 'id' when creating 'Chirp'");
+    }
+    if (obj.sender === undefined) {
+      throw new Error("Undefined 'sender' when creating 'Chirp'");
+    }
+    if (obj.text === undefined) {
+      throw new Error("Undefined 'text' when creating 'Chirp'");
+    }
+    if (obj.time === undefined) {
+      throw new Error("Undefined 'id' when creating 'Chirp'");
+    }
+    if (obj.likes === undefined) {
+      throw new Error("Undefined 'likes' when creating 'Chirp'");
+    }
+
+    this.id = obj.id;
+    this.sender = obj.sender;
+    this.text = obj.text;
+    this.time = obj.time;
+    this.likes = obj.likes;
+    this.parentId = obj.parentId;
+  }
+
+  /**
+   * Creates a Chirp object from a ChirpState object.
+   *
+   * @param chirpState
+   */
+  public static fromState(chirpState: ChirpState): Chirp {
+    return new Chirp({
+      id: new Hash(chirpState.id),
+      sender: chirpState.sender,
+      text: chirpState.text,
+      time: new Timestamp(chirpState.time),
+      likes: chirpState.likes,
+      parentId: new Hash(chirpState.parentId),
+    });
+  }
+
+  /**
+   * Creates a ChirpState object from the current Chirp object.
+   */
+  public toState(): ChirpState {
+    return JSON.parse(JSON.stringify(this));
+  }
+}

--- a/fe1-web/model/objects/Chirp.ts
+++ b/fe1-web/model/objects/Chirp.ts
@@ -17,14 +17,19 @@ export interface ChirpState {
 export class Chirp {
   public readonly id: Hash;
 
+  // The sender's public key
   public readonly sender: string;
 
+  // The text of the chirp
   public readonly text: string;
 
+  // The time where the chirp was posted
   public readonly time: Timestamp;
 
+  // The number of likes
   public readonly likes: number;
 
+  // The id of the parent chirp (if it is a reply)
   public readonly parentId?: Hash;
 
   constructor(obj: Partial<Chirp>) {

--- a/fe1-web/model/objects/__tests__/Chirp.test.ts
+++ b/fe1-web/model/objects/__tests__/Chirp.test.ts
@@ -1,0 +1,111 @@
+import 'jest-extended';
+import '__tests__/utils/matchers';
+import {
+  Chirp, ChirpState,
+} from '../Chirp';
+import { ProtocolError } from '../../network';
+
+describe('Chirp object', () => {
+  it('can do a state round trip', () => {
+    const chirpState: ChirpState = {
+      id: '1234',
+      sender: 'me',
+      text: 'text',
+      time: 1234,
+      likes: 0,
+      parentId: '5678',
+    };
+    const chirp = Chirp.fromState(chirpState);
+    expect(chirp.toState()).toStrictEqual(chirpState);
+  });
+
+  it('throws an error when object is undefined', () => {
+    const createWrongChirp = () => {
+      const wrongChirpState: ChirpState = {};
+      Chirp.fromState(wrongChirpState);
+    };
+    expect(createWrongChirp).toThrow(Error);
+  });
+
+  it('throws an error when id is undefined', () => {
+    const createWrongChirp = () => {
+      const wrongChirpState: ChirpState = {
+        id: undefined,
+        sender: 'me',
+        text: 'text',
+        time: 1234,
+        likes: 0,
+        parentId: '5678',
+      };
+      Chirp.fromState(wrongChirpState);
+    };
+    expect(createWrongChirp).toThrow(Error);
+  });
+
+  it('throws an error when sender is undefined', () => {
+    const createWrongChirp = () => {
+      const wrongChirpState: ChirpState = {
+        id: '1234',
+        sender: undefined,
+        text: 'text',
+        time: 1234,
+        likes: 0,
+        parentId: '5678',
+      };
+      Chirp.fromState(wrongChirpState);
+    };
+    expect(createWrongChirp).toThrow(Error);
+  });
+
+  it('throws an error when text is undefined', () => {
+    const createWrongChirp = () => {
+      const wrongChirpState: ChirpState = {
+        id: '1234',
+        sender: 'me',
+        text: undefined,
+        time: 1234,
+        likes: 0,
+        parentId: '5678',
+      };
+      Chirp.fromState(wrongChirpState);
+    };
+    expect(createWrongChirp).toThrow(Error);
+  });
+
+  it('throws an error when time is undefined', () => {
+    const createWrongChirp = () => {
+      const wrongChirpState: ChirpState = {
+        id: '1234',
+        sender: 'me',
+        text: 'text',
+        time: undefined,
+        likes: 0,
+        parentId: '5678',
+      };
+      Chirp.fromState(wrongChirpState);
+    };
+    expect(createWrongChirp).toThrow(Error);
+  });
+
+  it('throws an error when likes is undefined', () => {
+    const createWrongChirp = () => {
+      const wrongChirpState: ChirpState = {
+        id: '1234',
+        sender: 'me',
+        text: 'text',
+        time: 1234,
+        likes: undefined,
+        parentId: '5678',
+      };
+      Chirp.fromState(wrongChirpState);
+    };
+    expect(createWrongChirp).toThrow(Error);
+  });
+
+  it('throws an error', () => {
+    const throwError = () => {
+      throw new ProtocolError('Error');
+    };
+    expect(throwError).toThrow('Error');
+  });
+});

--- a/fe1-web/model/objects/__tests__/Chirp.test.ts
+++ b/fe1-web/model/objects/__tests__/Chirp.test.ts
@@ -5,92 +5,94 @@ import {
 } from '../Chirp';
 import { Timestamp } from '../Timestamp';
 import { Hash } from '../Hash';
+import { PublicKey } from '../PublicKey';
 
 const TIMESTAMP = new Timestamp(12345);
 const HASH_ID = new Hash('id');
 const HASH_PARENT = new Hash('parent');
+const PK = new PublicKey('publicKey');
+const TEXT = 'text';
 
 describe('Chirp object', () => {
-  it('can do a state round trip', () => {
+  it('does a state round trip correctly', () => {
     const chirpState: ChirpState = {
       id: '1234',
       sender: 'me',
-      text: 'text',
+      text: TEXT,
       time: 1234,
-      likes: 0,
+      likes: 6,
       parentId: '5678',
     };
     const chirp = Chirp.fromState(chirpState);
     expect(chirp.toState()).toStrictEqual(chirpState);
   });
 
-  it('throws an error when id is undefined', () => {
-    const createWrongChirp = () => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const wrongChirp = new Chirp({
-        sender: 'me',
-        text: 'text',
+  describe('constructor', () => {
+    it('throws an error when object is undefined', () => {
+      const partial = undefined as unknown as Partial<Chirp>;
+      const createWrongChirp = () => new Chirp(partial);
+      expect(createWrongChirp).toThrow(Error);
+    });
+
+    it('throws an error when object is null', () => {
+      const partial = null as unknown as Partial<Chirp>;
+      const createWrongChirp = () => new Chirp(partial);
+      expect(createWrongChirp).toThrow(Error);
+    });
+
+    it('throws an error when id is undefined', () => {
+      const createWrongChirp = () => new Chirp({
+        sender: PK,
+        text: TEXT,
         time: TIMESTAMP,
         likes: 0,
         parentId: HASH_PARENT,
       });
-    };
-    expect(createWrongChirp).toThrow(Error);
-  });
+      expect(createWrongChirp).toThrow(Error);
+    });
 
-  it('throws an error when sender is undefined', () => {
-    const createWrongChirp = () => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const wrongChirp = new Chirp({
+    it('throws an error when sender is undefined', () => {
+      const createWrongChirp = () => new Chirp({
         id: HASH_ID,
-        text: 'text',
+        text: TEXT,
         time: TIMESTAMP,
         likes: 0,
         parentId: HASH_PARENT,
       });
-    };
-    expect(createWrongChirp).toThrow(Error);
-  });
+      expect(createWrongChirp).toThrow(Error);
+    });
 
-  it('throws an error when text is undefined', () => {
-    const createWrongChirp = () => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const wrongChirp = new Chirp({
+    it('throws an error when text is undefined', () => {
+      const createWrongChirp = () => new Chirp({
         id: HASH_ID,
-        sender: 'me',
+        sender: PK,
         time: TIMESTAMP,
         likes: 0,
         parentId: HASH_PARENT,
       });
-    };
-    expect(createWrongChirp).toThrow(Error);
-  });
+      expect(createWrongChirp).toThrow(Error);
+    });
 
-  it('throws an error when time is undefined', () => {
-    const createWrongChirp = () => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const wrongChirp = new Chirp({
+    it('throws an error when time is undefined', () => {
+      const createWrongChirp = () => new Chirp({
         id: HASH_ID,
-        sender: 'me',
-        text: 'text',
+        sender: PK,
+        text: TEXT,
         likes: 0,
         parentId: HASH_PARENT,
       });
-    };
-    expect(createWrongChirp).toThrow(Error);
-  });
+      expect(createWrongChirp).toThrow(Error);
+    });
 
-  it('throws an error when likes is undefined', () => {
-    const createWrongChirp = () => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const wrongChirp = new Chirp({
+    it('initializes likes to zero if it is undefined', () => {
+      const newChirp = new Chirp({
         id: HASH_ID,
-        sender: 'me',
-        text: 'text',
+        sender: PK,
+        text: TEXT,
         time: TIMESTAMP,
         parentId: HASH_PARENT,
       });
-    };
-    expect(createWrongChirp).toThrow(Error);
+      expect(newChirp.likes).toStrictEqual(0);
+    });
   });
 });

--- a/fe1-web/model/objects/__tests__/Chirp.test.ts
+++ b/fe1-web/model/objects/__tests__/Chirp.test.ts
@@ -26,7 +26,8 @@ describe('Chirp object', () => {
 
   it('throws an error when id is undefined', () => {
     const createWrongChirp = () => {
-      Chirp.constructor({
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const wrongChirp = new Chirp({
         sender: 'me',
         text: 'text',
         time: TIMESTAMP,
@@ -39,7 +40,8 @@ describe('Chirp object', () => {
 
   it('throws an error when sender is undefined', () => {
     const createWrongChirp = () => {
-      Chirp.constructor({
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const wrongChirp = new Chirp({
         id: HASH_ID,
         text: 'text',
         time: TIMESTAMP,
@@ -52,7 +54,8 @@ describe('Chirp object', () => {
 
   it('throws an error when text is undefined', () => {
     const createWrongChirp = () => {
-      Chirp.constructor({
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const wrongChirp = new Chirp({
         id: HASH_ID,
         sender: 'me',
         time: TIMESTAMP,
@@ -65,7 +68,8 @@ describe('Chirp object', () => {
 
   it('throws an error when time is undefined', () => {
     const createWrongChirp = () => {
-      Chirp.constructor({
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const wrongChirp = new Chirp({
         id: HASH_ID,
         sender: 'me',
         text: 'text',
@@ -78,7 +82,8 @@ describe('Chirp object', () => {
 
   it('throws an error when likes is undefined', () => {
     const createWrongChirp = () => {
-      Chirp.constructor({
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const wrongChirp = new Chirp({
         id: HASH_ID,
         sender: 'me',
         text: 'text',

--- a/fe1-web/model/objects/__tests__/Chirp.test.ts
+++ b/fe1-web/model/objects/__tests__/Chirp.test.ts
@@ -3,7 +3,12 @@ import '__tests__/utils/matchers';
 import {
   Chirp, ChirpState,
 } from '../Chirp';
-import { ProtocolError } from '../../network';
+import { Timestamp } from '../Timestamp';
+import { Hash } from '../Hash';
+
+const TIMESTAMP = new Timestamp(12345);
+const HASH_ID = new Hash('id');
+const HASH_PARENT = new Hash('parent');
 
 describe('Chirp object', () => {
   it('can do a state round trip', () => {
@@ -19,93 +24,68 @@ describe('Chirp object', () => {
     expect(chirp.toState()).toStrictEqual(chirpState);
   });
 
-  it('throws an error when object is undefined', () => {
-    const createWrongChirp = () => {
-      const wrongChirpState: ChirpState = {};
-      Chirp.fromState(wrongChirpState);
-    };
-    expect(createWrongChirp).toThrow(Error);
-  });
-
   it('throws an error when id is undefined', () => {
     const createWrongChirp = () => {
-      const wrongChirpState: ChirpState = {
-        id: undefined,
+      Chirp.constructor({
         sender: 'me',
         text: 'text',
-        time: 1234,
+        time: TIMESTAMP,
         likes: 0,
-        parentId: '5678',
-      };
-      Chirp.fromState(wrongChirpState);
+        parentId: HASH_PARENT,
+      });
     };
     expect(createWrongChirp).toThrow(Error);
   });
 
   it('throws an error when sender is undefined', () => {
     const createWrongChirp = () => {
-      const wrongChirpState: ChirpState = {
-        id: '1234',
-        sender: undefined,
+      Chirp.constructor({
+        id: HASH_ID,
         text: 'text',
-        time: 1234,
+        time: TIMESTAMP,
         likes: 0,
-        parentId: '5678',
-      };
-      Chirp.fromState(wrongChirpState);
+        parentId: HASH_PARENT,
+      });
     };
     expect(createWrongChirp).toThrow(Error);
   });
 
   it('throws an error when text is undefined', () => {
     const createWrongChirp = () => {
-      const wrongChirpState: ChirpState = {
-        id: '1234',
+      Chirp.constructor({
+        id: HASH_ID,
         sender: 'me',
-        text: undefined,
-        time: 1234,
+        time: TIMESTAMP,
         likes: 0,
-        parentId: '5678',
-      };
-      Chirp.fromState(wrongChirpState);
+        parentId: HASH_PARENT,
+      });
     };
     expect(createWrongChirp).toThrow(Error);
   });
 
   it('throws an error when time is undefined', () => {
     const createWrongChirp = () => {
-      const wrongChirpState: ChirpState = {
-        id: '1234',
+      Chirp.constructor({
+        id: HASH_ID,
         sender: 'me',
         text: 'text',
-        time: undefined,
         likes: 0,
-        parentId: '5678',
-      };
-      Chirp.fromState(wrongChirpState);
+        parentId: HASH_PARENT,
+      });
     };
     expect(createWrongChirp).toThrow(Error);
   });
 
   it('throws an error when likes is undefined', () => {
     const createWrongChirp = () => {
-      const wrongChirpState: ChirpState = {
-        id: '1234',
+      Chirp.constructor({
+        id: HASH_ID,
         sender: 'me',
         text: 'text',
-        time: 1234,
-        likes: undefined,
-        parentId: '5678',
-      };
-      Chirp.fromState(wrongChirpState);
+        time: TIMESTAMP,
+        parentId: HASH_PARENT,
+      });
     };
     expect(createWrongChirp).toThrow(Error);
-  });
-
-  it('throws an error', () => {
-    const throwError = () => {
-      throw new ProtocolError('Error');
-    };
-    expect(throwError).toThrow('Error');
   });
 });


### PR DESCRIPTION
I added a Chirp object, along with its tests.

I wanted to a test for line 37 of Chirp.ts (to achieve a coverage of 100%), but the TSlint told me that Object could not be null/undefined, so it would mean 2 lines for eslint-disable comments, which I prefer to avoid.

Please tell me there is a better way of handling unused constants than disabling it in the linter... I couldn't find anything that worked without declaring an unused variable.