### PR TITLE
display latest posted chirp UI

### DIFF
--- a/fe1-web/components/ChirpCard.tsx
+++ b/fe1-web/components/ChirpCard.tsx
@@ -59,7 +59,7 @@ const ChirpCard = (props: IPropTypes) => {
 const propTypes = {
   sender: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
-  time: PropTypes.instanceOf(Date).isRequired,
+  time: PropTypes.instanceOf(Timestamp).isRequired,
   likes: PropTypes.number.isRequired,
 };
 

--- a/fe1-web/components/ChirpCard.tsx
+++ b/fe1-web/components/ChirpCard.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import {
+  StyleSheet, ViewStyle, View, TextStyle, Text,
+} from 'react-native';
+import PropTypes from 'prop-types';
+import TimeAgo from 'react-timeago';
+import { Ionicons } from '@expo/vector-icons';
+import { Timestamp } from '../model/objects';
+import TextBlock from './TextBlock';
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 50,
+    justifyContent: 'center',
+    borderWidth: 2,
+    flexDirection: 'column',
+    display: 'flex',
+  } as ViewStyle,
+  textView: {
+    padding: 10,
+    borderWidth: 1,
+    width: 600,
+    alignContent: 'flex-end',
+  } as TextStyle,
+  senderView: {
+    fontSize: 20,
+    fontWeight: '600',
+    marginTop: 7,
+  } as TextStyle,
+});
+
+const ChirpCard = (props: IPropTypes) => {
+  const { sender } = props;
+  const { text } = props;
+  const { time } = props;
+  const { likes } = props;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.senderView}>{sender}</Text>
+      <View style={styles.textView}>
+        <TextBlock text={text} />
+      </View>
+      <View style={{ flexDirection: 'row' }}>
+        <View style={{ flex: 1 }}>
+          <Ionicons name="thumbs-up" size={16} color="black" />
+        </View>
+        <View style={{ flex: 3 }}>
+          <Text>{likes}</Text>
+        </View>
+        <View style={{ flex: 6 }}>
+          <TimeAgo date={time.valueOf() * 1000} />
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const propTypes = {
+  sender: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
+  time: PropTypes.instanceOf(Date).isRequired,
+  likes: PropTypes.number.isRequired,
+};
+
+ChirpCard.prototype = propTypes;
+
+type IPropTypes = {
+  sender: string,
+  text: string,
+  time: Timestamp,
+  likes: number,
+};
+
+export default ChirpCard;

--- a/fe1-web/components/__tests__/ChirpCard.test.tsx
+++ b/fe1-web/components/__tests__/ChirpCard.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { Timestamp } from 'model/objects';
+import ChirpCard from '../ChirpCard';
+
+const text = 'Don\'t panic.';
+const sender = 'Douglas Adams';
+const time = new Timestamp(1609455600);
+
+describe('ChirpCard', () => {
+  it('renders correctly', () => {
+    const obj = render(
+      <ChirpCard
+        sender={sender}
+        text={text}
+        time={time}
+        likes={42}
+      />,
+    );
+    expect(obj.toJSON()).toMatchSnapshot();
+  });
+});

--- a/fe1-web/components/__tests__/__snapshots__/ChirpCard.test.tsx.snap
+++ b/fe1-web/components/__tests__/__snapshots__/ChirpCard.test.tsx.snap
@@ -1,0 +1,92 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ChirpCard renders correctly 1`] = `
+<View
+  style={
+    Object {
+      "borderWidth": 2,
+      "display": "flex",
+      "flexDirection": "column",
+      "justifyContent": "center",
+      "marginTop": 50,
+    }
+  }
+>
+  <Text
+    style={
+      Object {
+        "fontSize": 20,
+        "fontWeight": "600",
+        "marginTop": 7,
+      }
+    }
+  >
+    Douglas Adams
+  </Text>
+  <View
+    style={
+      Object {
+        "alignContent": "flex-end",
+        "borderWidth": 1,
+        "padding": 10,
+        "width": 600,
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "black",
+          "fontSize": 25,
+          "marginHorizontal": 10,
+          "textAlign": "center",
+        }
+      }
+    >
+      Don't panic.
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
+      <Text />
+    </View>
+    <View
+      style={
+        Object {
+          "flex": 3,
+        }
+      }
+    >
+      <Text>
+        42
+      </Text>
+    </View>
+    <View
+      style={
+        Object {
+          "flex": 6,
+        }
+      }
+    >
+      <time
+        dateTime="2020-12-31T23:00:00.000Z"
+        title="2020-12-31 23:00"
+      >
+        11 months ago
+      </time>
+    </View>
+  </View>
+</View>
+`;

--- a/fe1-web/package-lock.json
+++ b/fe1-web/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@expo/vector-icons": "^12.0.5",
         "@jest/globals": "^27.3.1",
         "@react-native-async-storage/async-storage": "^1.15.7",
         "@react-native-community/datetimepicker": "3.5.2",

--- a/fe1-web/package.json
+++ b/fe1-web/package.json
@@ -13,6 +13,7 @@
     "docs": "typedoc"
   },
   "dependencies": {
+    "@expo/vector-icons": "^12.0.5",
     "@jest/globals": "^27.3.1",
     "@react-native-async-storage/async-storage": "^1.15.7",
     "@react-native-community/datetimepicker": "3.5.2",

--- a/fe1-web/parts/Social.tsx
+++ b/fe1-web/parts/Social.tsx
@@ -25,12 +25,6 @@ const styles = StyleSheet.create({
     width: 500,
     alignContent: 'flex-end',
   } as TextStyle,
-  item: {
-    backgroundColor: '#f9c2ff',
-    padding: 20,
-    marginVertical: 8,
-    marginHorizontal: 16,
-  },
 });
 
 const DATA = [

--- a/fe1-web/parts/Social.tsx
+++ b/fe1-web/parts/Social.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import {
+  FlatList,
   StyleSheet, TextStyle, View, ViewStyle,
 } from 'react-native';
 
@@ -8,6 +9,8 @@ import TextInputChirp from 'components/TextInputChirp';
 import STRINGS from 'res/strings';
 
 import { requestAddChirp } from 'network/MessageApi';
+import ChirpCard from 'components/ChirpCard';
+import { Hash, Timestamp } from 'model/objects';
 
 /**
  * UI for the Social Media component
@@ -22,7 +25,30 @@ const styles = StyleSheet.create({
     width: 500,
     alignContent: 'flex-end',
   } as TextStyle,
+  item: {
+    backgroundColor: '#f9c2ff',
+    padding: 20,
+    marginVertical: 8,
+    marginHorizontal: 16,
+  },
 });
+
+const DATA = [
+  {
+    id: Hash.fromString('1234'),
+    sender: 'Gandalf',
+    text: 'You shall not pass! You shall not pass! You shall not pass! You shall not pass! You shall not pass! You shall not pass!',
+    time: new Timestamp(1609455600),
+    likes: 0,
+  },
+  {
+    id: Hash.fromString('5678'),
+    sender: 'Douglas Adams',
+    text: 'Don\'t panic.',
+    time: new Timestamp(1609455600),
+    likes: 100,
+  },
+];
 
 const Social = () => {
   const [inputChirp, setInputChirp] = useState('');
@@ -34,6 +60,15 @@ const Social = () => {
       });
   };
 
+  const renderItem = ({ item }) => (
+    <ChirpCard
+      sender={item.sender}
+      text={item.text}
+      time={item.time}
+      likes={item.likes}
+    />
+  );
+
   return (
     <View style={styles.view}>
       <TextInputChirp
@@ -41,6 +76,11 @@ const Social = () => {
         onPress={publishChirp}
       />
       <TextBlock text={STRINGS.feed_description} />
+      <FlatList
+        data={DATA}
+        renderItem={renderItem}
+        keyExtractor={(item) => item.id.toString()}
+      />
     </View>
   );
 };


### PR DESCRIPTION
I add a simple component for showing the latest posted chirp
<img width="647" alt="Screenshot 2021-11-17 at 22 07 07" src="https://user-images.githubusercontent.com/60721007/142282556-32390a11-ffbe-421b-b607-fd2301f5544f.png">
(with hard-code data on Social page)
Same as the following one but solve snapshot fails problem by merging this to the master (on a new branch) 
https://github.com/dedis/student_21_pop/pull/592 