### PR TITLE
Fix consensus UI and subscription

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
@@ -267,10 +267,6 @@ public class LAORepository {
   }
 
   public Single<Answer> sendSubscribe(String channel) {
-    if (subscribedChannels.contains(channel)) {
-      return Single.error(new IllegalStateException("Already subscribed to " + channel));
-    }
-
     Log.d(TAG, "sending a subscribe to the channel " + channel);
     int id = mRemoteDataSource.incrementAndGetRequestId();
     Subscribe subscribe = new Subscribe(channel, id);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
@@ -313,6 +313,43 @@ public class LAORepository {
   }
 
   /**
+   * Publish a MessageGeneral containing the given data.
+   *
+   * @param channel the channel on which the message will be send
+   * @param data the data to encapsulate in the message
+   */
+  public Single<Answer> sendMessageGeneral(String channel, Data data) {
+    try {
+      KeysetHandle publicKeysetHandle = mKeysetManager.getKeysetHandle().getPublicKeysetHandle();
+      String publicKey = Keys.getEncodedKey(publicKeysetHandle);
+      byte[] sender = Base64.getUrlDecoder().decode(publicKey);
+
+      PublicKeySign signer = mKeysetManager.getKeysetHandle().getPrimitive(PublicKeySign.class);
+      MessageGeneral msg = new MessageGeneral(sender, data, signer, mGson);
+
+      return sendPublish(channel, msg);
+    } catch (GeneralSecurityException | IOException e) {
+      Log.e(TAG, "failed to retrieve public key");
+      return Single.error(e);
+    }
+  }
+
+  /**
+   * Returns the public key or null if an error occurred.
+   *
+   * @return the public key
+   */
+  public String getPublicKey() {
+    try {
+      KeysetHandle publicKeysetHandle = mKeysetManager.getKeysetHandle().getPublicKeysetHandle();
+      return Keys.getEncodedKey(publicKeysetHandle);
+    } catch (GeneralSecurityException | IOException e) {
+      Log.e(TAG, "failed to retrieve public key", e);
+      return null;
+    }
+  }
+
+  /**
    * Checks that a given channel corresponds to a LAO channel, i.e /root/laoId
    *
    * @param channel the channel we want to check

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
@@ -347,7 +347,7 @@ public class LAORepository {
     try {
       KeysetHandle publicKeysetHandle = mKeysetManager.getKeysetHandle().getPublicKeysetHandle();
       return Keys.getEncodedKey(publicKeysetHandle);
-    } catch (GeneralSecurityException | IOException e) {
+    } catch (Exception e) {
       Log.e(TAG, "failed to retrieve public key", e);
       return null;
     }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
@@ -19,6 +19,7 @@ import com.github.dedis.popstellar.model.network.method.Publish;
 import com.github.dedis.popstellar.model.network.method.Subscribe;
 import com.github.dedis.popstellar.model.network.method.Unsubscribe;
 import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
+import com.github.dedis.popstellar.model.network.method.message.data.Data;
 import com.github.dedis.popstellar.model.network.method.message.data.lao.CreateLao;
 import com.github.dedis.popstellar.model.network.method.message.data.lao.StateLao;
 import com.github.dedis.popstellar.model.network.method.message.data.lao.UpdateLao;
@@ -266,6 +267,10 @@ public class LAORepository {
   }
 
   public Single<Answer> sendSubscribe(String channel) {
+    if (subscribedChannels.contains(channel)) {
+      return Single.error(new IllegalStateException("Already subscribed to " + channel));
+    }
+
     Log.d(TAG, "sending a subscribe to the channel " + channel);
     int id = mRemoteDataSource.incrementAndGetRequestId();
     Subscribe subscribe = new Subscribe(channel, id);
@@ -288,6 +293,9 @@ public class LAORepository {
 
     Single<Answer> answer = createSingle(id);
     mRemoteDataSource.sendMessage(unsubscribe);
+
+    subscribedChannels.remove(channel);
+
     return answer;
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
@@ -641,61 +641,6 @@ public class LaoDetailViewModel extends AndroidViewModel
   }
 
   /**
-   * Sends a ConsensusLearn
-   *
-   * <p>Publish a GeneralMessage containing ConsensusLearn data.
-   *
-   * @param consensus the corresponding consensus
-   */
-  public void sendConsensusLearn(Consensus consensus) {
-    Log.d(
-        TAG,
-        "sending a consensus learn for consensus with messageId : " + consensus.getMessageId());
-
-    List<String> acceptorsMessageIds =
-        new ArrayList<>(consensus.getAcceptorsToMessageId().values());
-    ConsensusLearn consensusLearn =
-        new ConsensusLearn(consensus.getId(), consensus.getMessageId(), acceptorsMessageIds);
-
-    try {
-      KeysetHandle publicKeysetHandle = mKeysetManager.getKeysetHandle().getPublicKeysetHandle();
-      String publicKey = Keys.getEncodedKey(publicKeysetHandle);
-      byte[] sender = Base64.getUrlDecoder().decode(publicKey);
-
-      PublicKeySign signer = mKeysetManager.getKeysetHandle().getPrimitive(PublicKeySign.class);
-      MessageGeneral msg = new MessageGeneral(sender, consensusLearn, signer, mGson);
-
-      Log.d(TAG, PUBLISH_MESSAGE);
-      Disposable disposable =
-          mLAORepository
-              .sendPublish(consensus.getChannel(), msg)
-              .subscribeOn(Schedulers.io())
-              .observeOn(AndroidSchedulers.mainThread())
-              .timeout(5, TimeUnit.SECONDS)
-              .subscribe(
-                  answer -> {
-                    if (answer instanceof Result) {
-                      Log.d(
-                          TAG,
-                          "sent a consensus learn successfully for consensus with messageId : "
-                              + consensusLearn.getMessageId());
-                    } else {
-                      Log.d(
-                          TAG,
-                          "failed to send the learn for consensus with messageId : "
-                              + consensusLearn.getMessageId());
-                    }
-                  },
-                  throwable ->
-                      Log.d(TAG, "timed out waiting for result on consensus/learn", throwable));
-
-      disposables.add(disposable);
-    } catch (GeneralSecurityException | IOException e) {
-      Log.d(TAG, PK_FAILURE_MESSAGE, e);
-    }
-  }
-
-  /**
    * Opens a roll call event.
    *
    * <p>Publish a GeneralMessage containing OpenRollCall data.

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
@@ -22,7 +22,6 @@ import com.github.dedis.popstellar.model.network.answer.Result;
 import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
 import com.github.dedis.popstellar.model.network.method.message.data.consensus.ConsensusElect;
 import com.github.dedis.popstellar.model.network.method.message.data.consensus.ConsensusElectAccept;
-import com.github.dedis.popstellar.model.network.method.message.data.consensus.ConsensusLearn;
 import com.github.dedis.popstellar.model.network.method.message.data.election.CastVote;
 import com.github.dedis.popstellar.model.network.method.message.data.election.ElectionEnd;
 import com.github.dedis.popstellar.model.network.method.message.data.election.ElectionSetup;

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/consensus/ElectionStartFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/consensus/ElectionStartFragment.java
@@ -93,7 +93,7 @@ public class ElectionStartFragment extends Fragment {
 
     setupTimerUpdate(election);
 
-    setupButtonListeners(binding, mLaoDetailViewModel, electionId, instanceId);
+    setupButtonListeners(binding, mLaoDetailViewModel, electionId);
 
     List<ConsensusNode> nodes = mLaoDetailViewModel.getCurrentLaoValue().getNodes();
 
@@ -181,21 +181,11 @@ public class ElectionStartFragment extends Fragment {
   private void setupButtonListeners(
       ElectionStartFragmentBinding binding,
       LaoDetailViewModel mLaoDetailViewModel,
-      String electionId,
-      String instanceId) {
+      String electionId) {
     electionStart.setOnClickListener(
-        clicked -> {
-          Optional<Consensus> acceptedConsensus =
-              ownNode
-                  .getLastConsensus(instanceId)
-                  .filter(consensus -> consensus.canBeAccepted() && !consensus.isFailed());
-          if (acceptedConsensus.isPresent()) {
-            mLaoDetailViewModel.sendConsensusLearn(acceptedConsensus.get());
-          } else {
+        clicked ->
             mLaoDetailViewModel.createNewConsensus(
-                Instant.now().getEpochSecond(), electionId, "election", "state", "started");
-          }
-        });
+                Instant.now().getEpochSecond(), electionId, "election", "state", "started"));
 
     binding
         .backLayout
@@ -220,10 +210,7 @@ public class ElectionStartFragment extends Fragment {
       electionStart.setEnabled(false);
     } else {
       State ownState = ownNode.getState(instanceId);
-      boolean canAccept =
-          ownState == State.STARTING
-              && ownNode.getLastConsensus(instanceId).map(Consensus::canBeAccepted).orElse(false);
-      boolean canClick = canAccept || ownState == State.WAITING || ownState == State.FAILED;
+      boolean canClick = ownState == State.WAITING || ownState == State.FAILED;
       electionStart.setEnabled(canClick);
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
@@ -121,7 +121,6 @@ public class HomeViewModel extends AndroidViewModel
   public void onQRCodeDetected(Barcode barcode) {
     Log.d(TAG, "Detected barcode with value: " + barcode.rawValue);
     String channel = "/root/" + barcode.rawValue;
-    String consensusChannel = channel + "/consensus";
     disposables.add(
         mLAORepository
             .sendSubscribe(channel)
@@ -131,7 +130,6 @@ public class HomeViewModel extends AndroidViewModel
                 answer -> {
                   if (answer instanceof Result) {
                     Log.d(TAG, "got success result for subscribe to lao");
-                    mLAORepository.sendSubscribe(consensusChannel);
                   } else {
                     Log.d(
                         TAG,

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/GenericHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/GenericHandler.java
@@ -73,6 +73,8 @@ public final class GenericHandler {
 
       // Send catchup after subscribing to a LAO
       laoRepository.sendCatchup(channel);
+    } else if (channel != null) {
+      laoRepository.sendCatchup(channel);
     } else {
       Log.e(TAG, "Invalid Subscribe request id : " + id);
     }
@@ -144,11 +146,6 @@ public final class GenericHandler {
 
     // Send subscribe and catchup after creating a LAO
     laoRepository.sendSubscribe(channel);
-    laoRepository.sendCatchup(channel);
-
-    String consensusChannel = channel + "/consensus";
-    laoRepository.sendSubscribe(consensusChannel);
-    laoRepository.sendCatchup(consensusChannel);
   }
 
   /**

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/GenericHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/GenericHandler.java
@@ -146,6 +146,7 @@ public final class GenericHandler {
 
     // Send subscribe and catchup after creating a LAO
     laoRepository.sendSubscribe(channel);
+    laoRepository.sendSubscribe(channel + "/consensus");
   }
 
   /**

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/LaoHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/LaoHandler.java
@@ -82,6 +82,11 @@ public final class LaoHandler {
     lao.setOrganizer(createLao.getOrganizer());
     lao.setId(createLao.getId());
     lao.setWitnesses(new HashSet<>(createLao.getWitnesses()));
+
+    String publicKey = laoRepository.getPublicKey();
+    if (lao.getOrganizer().equals(publicKey) || lao.getWitnesses().contains(publicKey)) {
+      laoRepository.sendSubscribe(lao.getChannel() + "/consensus");
+    }
   }
 
   /**

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/LaoHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/LaoHandler.java
@@ -161,6 +161,11 @@ public final class LaoHandler {
     lao.setLastModified(stateLao.getLastModified());
     lao.setModificationId(stateLao.getModificationId());
 
+    String publicKey = laoRepository.getPublicKey();
+    if (lao.getOrganizer().equals(publicKey) || lao.getWitnesses().contains(publicKey)) {
+      laoRepository.sendSubscribe(lao.getChannel() + "/consensus");
+    }
+
     // Now we're going to remove all pending updates which came prior to this state lao
     long targetTime = stateLao.getLastModified();
     lao.getPendingUpdates()

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/ConsensusHandlerTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/ConsensusHandlerTest.java
@@ -22,8 +22,10 @@ import com.github.dedis.popstellar.repository.remote.LAORemoteDataSource;
 import com.github.dedis.popstellar.utility.error.DataHandlingException;
 import com.github.dedis.popstellar.utility.scheduler.SchedulerProvider;
 import com.github.dedis.popstellar.utility.scheduler.TestSchedulerProvider;
+import com.google.crypto.tink.KeysetHandle;
 import com.google.crypto.tink.PublicKeySign;
 import com.google.crypto.tink.integration.android.AndroidKeysetManager;
+import com.google.crypto.tink.signature.Ed25519PrivateKeyManager;
 import com.google.gson.Gson;
 
 import org.junit.After;
@@ -103,6 +105,11 @@ public class ConsensusHandlerTest {
 
     Mockito.when(remoteDataSource.observeMessage()).thenReturn(upstream);
     Mockito.when(remoteDataSource.observeWebsocket()).thenReturn(Observable.empty());
+
+    Ed25519PrivateKeyManager.registerPair(true);
+    KeysetHandle keysetHandle =
+        KeysetHandle.generateNew(Ed25519PrivateKeyManager.rawEd25519Template());
+    Mockito.when(androidKeysetManager.getKeysetHandle()).thenReturn(keysetHandle);
 
     LAORepository.destroyInstance();
     laoRepository =

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/LaoHandlerTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/LaoHandlerTest.java
@@ -22,8 +22,10 @@ import com.github.dedis.popstellar.repository.remote.LAORemoteDataSource;
 import com.github.dedis.popstellar.utility.error.DataHandlingException;
 import com.github.dedis.popstellar.utility.scheduler.SchedulerProvider;
 import com.github.dedis.popstellar.utility.scheduler.TestSchedulerProvider;
+import com.google.crypto.tink.KeysetHandle;
 import com.google.crypto.tink.PublicKeySign;
 import com.google.crypto.tink.integration.android.AndroidKeysetManager;
+import com.google.crypto.tink.signature.Ed25519PrivateKeyManager;
 
 import org.junit.After;
 import org.junit.Before;
@@ -88,6 +90,11 @@ public class LaoHandlerTest {
 
     Mockito.when(remoteDataSource.observeMessage()).thenReturn(upstream);
     Mockito.when(remoteDataSource.observeWebsocket()).thenReturn(Observable.empty());
+
+    Ed25519PrivateKeyManager.registerPair(true);
+    KeysetHandle keysetHandle =
+        KeysetHandle.generateNew(Ed25519PrivateKeyManager.rawEd25519Template());
+    Mockito.when(androidKeysetManager.getKeysetHandle()).thenReturn(keysetHandle);
 
     laoRepository =
         LAORepository.getInstance(


### PR DESCRIPTION
- When proposer received all elect-accept, now it send directly a learn message instead of asking to confirm it.
- Change how subscription to consensus are done : only witness and organizer subscribe now.
- Always send a catchup after receiving a subscribe response.