### PR TITLE
Add json validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,7 @@
 be1-go/pop
 be1-go/validation/protocol
 
+fe2-android/app/src/main/resources/protocol
+
 .DS_Store
 **/.DS_Store

--- a/fe2-android/app/build.gradle
+++ b/fe2-android/app/build.gradle
@@ -132,6 +132,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-vision:20.1.3'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.google.crypto.tink:tink-android:1.5.0'
+    implementation 'com.networknt:json-schema-validator:1.0.46'
     implementation 'com.squareup.okhttp3:logging-interceptor:4.9.1'
     implementation 'com.tinder.scarlet:scarlet:0.1.11'
     implementation 'com.tinder.scarlet:message-adapter-gson:0.1.11'
@@ -160,7 +161,6 @@ dependencies {
 
     testImplementation 'org.slf4j:slf4j-api:1.7.30'
     testImplementation 'org.slf4j:slf4j-simple:1.7.30'
-    implementation 'com.networknt:json-schema-validator:1.0.46'
 
     testImplementation 'org.mockito:mockito-core:3.9.0'
 

--- a/fe2-android/app/build.gradle
+++ b/fe2-android/app/build.gradle
@@ -160,7 +160,7 @@ dependencies {
 
     testImplementation 'org.slf4j:slf4j-api:1.7.30'
     testImplementation 'org.slf4j:slf4j-simple:1.7.30'
-    testImplementation 'com.networknt:json-schema-validator:1.0.46'
+    implementation 'com.networknt:json-schema-validator:1.0.46'
 
     testImplementation 'org.mockito:mockito-core:3.9.0'
 
@@ -177,6 +177,15 @@ dependencies {
     androidTestImplementation 'org.mockito:mockito-android:3.9.0'
 
     androidTestUtil 'androidx.test:orchestrator:1.4.0'
+}
+
+copy {
+    from '../../protocol'
+    into 'src/main/resources/protocol'
+    include 'answer/**'
+    include 'examples/**'
+    include 'query/**'
+    include 'jsonRPC.json'
 }
 
 task jacocoTestReport(type: JacocoReport, dependsOn: ['testCovDebugUnitTest', 'createCovDebugCoverageReport']) {

--- a/fe2-android/app/src/androidTest/java/com/github/dedis/popstellar/ui/detail/event/consensus/ElectionStartFragmentTest.java
+++ b/fe2-android/app/src/androidTest/java/com/github/dedis/popstellar/ui/detail/event/consensus/ElectionStartFragmentTest.java
@@ -30,6 +30,7 @@ import com.github.dedis.popstellar.model.network.method.message.data.consensus.C
 import com.github.dedis.popstellar.model.network.method.message.data.consensus.ConsensusElectAccept;
 import com.github.dedis.popstellar.model.network.method.message.data.consensus.ConsensusKey;
 import com.github.dedis.popstellar.model.network.method.message.data.consensus.ConsensusLearn;
+import com.github.dedis.popstellar.model.network.serializer.JsonUtils;
 import com.github.dedis.popstellar.model.objects.Consensus;
 import com.github.dedis.popstellar.model.objects.Election;
 import com.github.dedis.popstellar.model.objects.Lao;
@@ -76,6 +77,9 @@ public class ElectionStartFragmentTest {
       new ExternalResource() {
         @Override
         protected void before() {
+          // Preload the data schema before the test run
+          JsonUtils.loadSchema(JsonUtils.DATA_SCHEMA);
+
           when(remoteDataSource.incrementAndGetRequestId()).thenReturn(42);
           when(remoteDataSource.observeWebsocket()).thenReturn(Observable.empty());
           Observable<GenericMessage> upstream =

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/PublicKeySignaturePair.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/PublicKeySignaturePair.java
@@ -4,29 +4,29 @@ import java.util.Base64;
 
 public class PublicKeySignaturePair {
 
-  private final byte[] witness;
+  private final String witness;
 
-  private final byte[] signature;
+  private final String signature;
 
   public PublicKeySignaturePair(byte[] witness, byte[] signature) {
-    this.witness = witness;
-    this.signature = signature;
+    this.witness = Base64.getUrlEncoder().encodeToString(witness);
+    this.signature = Base64.getUrlEncoder().encodeToString(signature);
   }
 
   public byte[] getWitness() {
-    return witness;
+    return Base64.getUrlDecoder().decode(witness);
   }
 
   public byte[] getSignature() {
-    return signature;
+    return Base64.getUrlDecoder().decode(signature);
   }
 
   public String getWitnessEncoded() {
-    return Base64.getUrlEncoder().encodeToString(this.witness);
+    return witness;
   }
 
   public String getSignatureEncoded() {
-    return Base64.getUrlEncoder().encodeToString(this.signature);
+    return signature;
   }
 
   @Override

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionEnd.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionEnd.java
@@ -58,6 +58,27 @@ public class ElectionEnd extends Data {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ElectionEnd that = (ElectionEnd) o;
+
+    return createdAt == that.createdAt
+        && java.util.Objects.equals(electionId, that.electionId)
+        && java.util.Objects.equals(laoId, that.laoId)
+        && java.util.Objects.equals(registeredVotes, that.registeredVotes);
+  }
+
+  @Override
+  public int hashCode() {
+    return java.util.Objects.hash(electionId, createdAt, laoId, registeredVotes);
+  }
+
+  @Override
   public String toString() {
     return "ElectionEnd{"
         + "electionId='"

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionResult.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionResult.java
@@ -5,6 +5,7 @@ import com.github.dedis.popstellar.model.network.method.message.data.Data;
 import com.github.dedis.popstellar.model.network.method.message.data.Objects;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class ElectionResult extends Data {
@@ -15,7 +16,7 @@ public class ElectionResult extends Data {
     if (questions == null || questions.isEmpty()) {
       throw new IllegalArgumentException();
     }
-    this.questions = questions;
+    this.questions = Collections.unmodifiableList(questions);
   }
 
   @Override
@@ -30,6 +31,24 @@ public class ElectionResult extends Data {
 
   public List<ElectionResultQuestion> getElectionQuestionResults() {
     return questions;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ElectionResult that = (ElectionResult) o;
+
+    return java.util.Objects.equals(questions, that.questions);
+  }
+
+  @Override
+  public int hashCode() {
+    return java.util.Objects.hash(questions);
   }
 
   @Override

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionResultQuestion.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionResultQuestion.java
@@ -1,7 +1,9 @@
 package com.github.dedis.popstellar.model.network.method.message.data.election;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class ElectionResultQuestion {
 
@@ -13,7 +15,7 @@ public class ElectionResultQuestion {
       throw new IllegalArgumentException();
     }
     this.id = id;
-    this.result = result;
+    this.result = Collections.unmodifiableList(result);
   }
 
   public String getId() {
@@ -22,6 +24,24 @@ public class ElectionResultQuestion {
 
   public List<QuestionResult> getResult() {
     return result;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ElectionResultQuestion that = (ElectionResultQuestion) o;
+
+    return Objects.equals(id, that.id) && Objects.equals(result, that.result);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, result);
   }
 
   @Override

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionResultQuestion.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionResultQuestion.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.model.network.method.message.data.election;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -15,7 +14,7 @@ public class ElectionResultQuestion {
       throw new IllegalArgumentException();
     }
     this.id = id;
-    this.result = Collections.unmodifiableList(result);
+    this.result = result;
   }
 
   public String getId() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/election/QuestionResult.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/election/QuestionResult.java
@@ -2,6 +2,8 @@ package com.github.dedis.popstellar.model.network.method.message.data.election;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Objects;
+
 public class QuestionResult {
 
   @SerializedName(value = "ballot_option")
@@ -23,6 +25,24 @@ public class QuestionResult {
 
   public Integer getCount() {
     return count;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    QuestionResult that = (QuestionResult) o;
+
+    return count == that.count && Objects.equals(ballotOption, that.ballotOption);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(ballotOption, count);
   }
 
   @Override

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/CloseRollCall.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/CloseRollCall.java
@@ -65,6 +65,27 @@ public class CloseRollCall extends Data {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CloseRollCall that = (CloseRollCall) o;
+
+    return closedAt == that.closedAt
+        && java.util.Objects.equals(updateId, that.updateId)
+        && java.util.Objects.equals(closes, that.closes)
+        && java.util.Objects.equals(attendees, that.attendees);
+  }
+
+  @Override
+  public int hashCode() {
+    return java.util.Objects.hash(updateId, closes, closedAt, attendees);
+  }
+
+  @Override
   public String toString() {
     return "CloseRollCall{"
         + "updateId='"

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/OpenRollCall.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/OpenRollCall.java
@@ -70,6 +70,27 @@ public class OpenRollCall extends Data {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    OpenRollCall that = (OpenRollCall) o;
+
+    return openedAt == that.openedAt
+        && java.util.Objects.equals(updateId, that.updateId)
+        && java.util.Objects.equals(opens, that.opens)
+        && java.util.Objects.equals(action, that.action);
+  }
+
+  @Override
+  public int hashCode() {
+    return java.util.Objects.hash(updateId, opens, openedAt, action);
+  }
+
+  @Override
   public String toString() {
     return "OpenRollCall{"
         + "updateId='"

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonAnswerSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonAnswerSerializer.java
@@ -39,7 +39,6 @@ public class JsonAnswerSerializer implements JsonSerializer<Answer>, JsonDeseria
   public JsonElement serialize(Answer src, Type typeOfSrc, JsonSerializationContext context) {
     JsonObject obj = context.serialize(src).getAsJsonObject();
     obj.addProperty(JsonUtils.JSON_RPC, JsonUtils.JSON_RPC_VERSION);
-    JsonUtils.verifyJson(JsonUtils.ROOT_SCHEMA, obj.toString());
     return obj;
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonAnswerSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonAnswerSerializer.java
@@ -39,6 +39,7 @@ public class JsonAnswerSerializer implements JsonSerializer<Answer>, JsonDeseria
   public JsonElement serialize(Answer src, Type typeOfSrc, JsonSerializationContext context) {
     JsonObject obj = context.serialize(src).getAsJsonObject();
     obj.addProperty(JsonUtils.JSON_RPC, JsonUtils.JSON_RPC_VERSION);
+    JsonUtils.verifyJson(JsonUtils.ROOT_SCHEMA, obj.toString());
     return obj;
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonAnswerSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonAnswerSerializer.java
@@ -24,7 +24,7 @@ public class JsonAnswerSerializer implements JsonSerializer<Answer>, JsonDeseria
       throws JsonParseException {
     JsonObject obj = json.getAsJsonObject();
     JsonUtils.testRPCVersion(obj);
-    JsonUtils.verifyJson(json.toString());
+    JsonUtils.verifyJson(JsonUtils.ROOT_SCHEMA, json.toString());
 
     if (obj.has(RESULT)) {
       return context.deserialize(json, Result.class);
@@ -39,7 +39,7 @@ public class JsonAnswerSerializer implements JsonSerializer<Answer>, JsonDeseria
   public JsonElement serialize(Answer src, Type typeOfSrc, JsonSerializationContext context) {
     JsonObject obj = context.serialize(src).getAsJsonObject();
     obj.addProperty(JsonUtils.JSON_RPC, JsonUtils.JSON_RPC_VERSION);
-    JsonUtils.verifyJson(obj.toString());
+    JsonUtils.verifyJson(JsonUtils.ROOT_SCHEMA, obj.toString());
     return obj;
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonAnswerSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonAnswerSerializer.java
@@ -24,6 +24,7 @@ public class JsonAnswerSerializer implements JsonSerializer<Answer>, JsonDeseria
       throws JsonParseException {
     JsonObject obj = json.getAsJsonObject();
     JsonUtils.testRPCVersion(obj);
+    JsonUtils.verifyJson(json.toString());
 
     if (obj.has(RESULT)) {
       return context.deserialize(json, Result.class);
@@ -38,6 +39,7 @@ public class JsonAnswerSerializer implements JsonSerializer<Answer>, JsonDeseria
   public JsonElement serialize(Answer src, Type typeOfSrc, JsonSerializationContext context) {
     JsonObject obj = context.serialize(src).getAsJsonObject();
     obj.addProperty(JsonUtils.JSON_RPC, JsonUtils.JSON_RPC_VERSION);
+    JsonUtils.verifyJson(obj.toString());
     return obj;
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonDataSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonDataSerializer.java
@@ -24,7 +24,7 @@ public class JsonDataSerializer implements JsonSerializer<Data>, JsonDeserialize
   public Data deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
     JsonObject obj = json.getAsJsonObject();
-    JsonUtils.verifyJson(obj.toString());
+    JsonUtils.verifyJson(JsonUtils.DATA_SCHEMA, obj.toString());
     Objects object = Objects.find(obj.get(OBJECT).getAsString());
     Action action = Action.find(obj.get(ACTION).getAsString());
 
@@ -53,7 +53,7 @@ public class JsonDataSerializer implements JsonSerializer<Data>, JsonDeserialize
     JsonObject obj = context.serialize(src).getAsJsonObject();
     obj.addProperty(OBJECT, src.getObject());
     obj.addProperty(ACTION, src.getAction());
-    JsonUtils.verifyJson(obj.toString());
+    JsonUtils.verifyJson(JsonUtils.DATA_SCHEMA, obj.toString());
     return obj;
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonDataSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonDataSerializer.java
@@ -53,7 +53,6 @@ public class JsonDataSerializer implements JsonSerializer<Data>, JsonDeserialize
     JsonObject obj = context.serialize(src).getAsJsonObject();
     obj.addProperty(OBJECT, src.getObject());
     obj.addProperty(ACTION, src.getAction());
-    JsonUtils.verifyJson(JsonUtils.DATA_SCHEMA, obj.toString());
     return obj;
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonDataSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonDataSerializer.java
@@ -53,6 +53,7 @@ public class JsonDataSerializer implements JsonSerializer<Data>, JsonDeserialize
     JsonObject obj = context.serialize(src).getAsJsonObject();
     obj.addProperty(OBJECT, src.getObject());
     obj.addProperty(ACTION, src.getAction());
+    JsonUtils.verifyJson(JsonUtils.DATA_SCHEMA, obj.toString());
     return obj;
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonDataSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonDataSerializer.java
@@ -24,6 +24,7 @@ public class JsonDataSerializer implements JsonSerializer<Data>, JsonDeserialize
   public Data deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
     JsonObject obj = json.getAsJsonObject();
+    JsonUtils.verifyJson(obj.toString());
     Objects object = Objects.find(obj.get(OBJECT).getAsString());
     Action action = Action.find(obj.get(ACTION).getAsString());
 
@@ -52,6 +53,7 @@ public class JsonDataSerializer implements JsonSerializer<Data>, JsonDeserialize
     JsonObject obj = context.serialize(src).getAsJsonObject();
     obj.addProperty(OBJECT, src.getObject());
     obj.addProperty(ACTION, src.getAction());
+    JsonUtils.verifyJson(obj.toString());
     return obj;
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonMessageGeneralSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonMessageGeneralSerializer.java
@@ -31,6 +31,7 @@ public class JsonMessageGeneralSerializer
       JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
     JsonObject root = json.getAsJsonObject();
+    JsonUtils.verifyJson(JsonUtils.GENERAL_MESSAGE_SCHEMA, json.toString());
 
     byte[] messageId = root.get("message_id").getAsString().getBytes(StandardCharsets.UTF_8);
     byte[] dataBuf = Base64.getUrlDecoder().decode(root.get("data").getAsString());
@@ -80,6 +81,8 @@ public class JsonMessageGeneralSerializer
     }
     result.add("witness_signatures", jsonArray);
     Log.d("JSON", result.toString());
+
+    JsonUtils.verifyJson(JsonUtils.GENERAL_MESSAGE_SCHEMA, result.toString());
 
     return result;
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonMessageGeneralSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonMessageGeneralSerializer.java
@@ -82,6 +82,8 @@ public class JsonMessageGeneralSerializer
     result.add("witness_signatures", jsonArray);
     Log.d("JSON", result.toString());
 
+    JsonUtils.verifyJson(JsonUtils.GENERAL_MESSAGE_SCHEMA, result.toString());
+
     return result;
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonMessageGeneralSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonMessageGeneralSerializer.java
@@ -82,8 +82,6 @@ public class JsonMessageGeneralSerializer
     result.add("witness_signatures", jsonArray);
     Log.d("JSON", result.toString());
 
-    JsonUtils.verifyJson(JsonUtils.GENERAL_MESSAGE_SCHEMA, result.toString());
-
     return result;
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonMessageSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonMessageSerializer.java
@@ -24,6 +24,7 @@ public class JsonMessageSerializer implements JsonSerializer<Message>, JsonDeser
     Log.d("deserializer", "deserializing message");
     JSONRPCRequest container = context.deserialize(json, JSONRPCRequest.class);
     JsonUtils.testRPCVersion(container.getJsonrpc());
+    JsonUtils.verifyJson(json.toString());
 
     Method method = Method.find(container.getMethod());
     if (method == null) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonMessageSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonMessageSerializer.java
@@ -24,7 +24,6 @@ public class JsonMessageSerializer implements JsonSerializer<Message>, JsonDeser
     Log.d("deserializer", "deserializing message");
     JSONRPCRequest container = context.deserialize(json, JSONRPCRequest.class);
     JsonUtils.testRPCVersion(container.getJsonrpc());
-    JsonUtils.verifyJson(json.toString());
 
     Method method = Method.find(container.getMethod());
     if (method == null) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonUtils.java
@@ -17,9 +17,8 @@ import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 
-import java.io.InputStream;
+import java.net.URI;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.Set;
 
 /** Json utility class */
@@ -36,8 +35,10 @@ public final class JsonUtils {
       JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
 
   public static final JsonSchema ROOT_SCHEMA = loadSchema("protocol/jsonRPC.json");
-  public static final JsonSchema GENERAL_MESSAGE_SCHEMA = loadSchema("protocol/query/method/message/message.json");
-  public static final JsonSchema DATA_SCHEMA = loadSchema("protocol/query/method/message/data/data.json");
+  public static final JsonSchema GENERAL_MESSAGE_SCHEMA =
+      loadSchema("protocol/query/method/message/message.json");
+  public static final JsonSchema DATA_SCHEMA =
+      loadSchema("protocol/query/method/message/data/data.json");
 
   private JsonUtils() {}
 
@@ -110,9 +111,6 @@ public final class JsonUtils {
    * @return the JsonSchema
    */
   public static JsonSchema loadSchema(String resourcePath) {
-    InputStream is =
-        Objects.requireNonNull(Thread.currentThread().getContextClassLoader())
-            .getResourceAsStream(resourcePath);
-    return FACTORY.getSchema(is);
+    return FACTORY.getSchema(URI.create("resource:/" + resourcePath));
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
@@ -2,6 +2,7 @@ package com.github.dedis.popstellar.ui.home;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
@@ -18,6 +19,7 @@ import androidx.lifecycle.ViewModelProvider;
 import com.github.dedis.popstellar.Injection;
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.ViewModelFactory;
+import com.github.dedis.popstellar.model.network.serializer.JsonUtils;
 import com.github.dedis.popstellar.ui.detail.LaoDetailActivity;
 import com.github.dedis.popstellar.ui.qrcode.CameraPermissionFragment;
 import com.github.dedis.popstellar.ui.qrcode.QRCodeScanningFragment;
@@ -46,6 +48,14 @@ public class HomeActivity extends AppCompatActivity {
     setupHomeFragment();
 
     mViewModel = obtainViewModel(this);
+
+    // Load all the json schemas in background when the app is started.
+    AsyncTask.execute(
+        () -> {
+          JsonUtils.loadSchema(JsonUtils.ROOT_SCHEMA);
+          JsonUtils.loadSchema(JsonUtils.DATA_SCHEMA);
+          JsonUtils.loadSchema(JsonUtils.GENERAL_MESSAGE_SCHEMA);
+        });
 
     setupHomeButton();
     setupLaunchButton();

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/JsonTestUtils.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/JsonTestUtils.java
@@ -1,0 +1,44 @@
+package com.github.dedis.popstellar.model.network;
+
+import static org.junit.Assert.assertEquals;
+
+import com.github.dedis.popstellar.Injection;
+import com.github.dedis.popstellar.model.network.method.message.data.Data;
+import com.github.dedis.popstellar.model.network.serializer.JsonUtils;
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+
+import junit.framework.AssertionFailedError;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
+public class JsonTestUtils {
+
+  private static final Gson GSON = Injection.provideGson();
+
+  public static String loadFile(String path) {
+    InputStream is = JsonTestUtils.class.getClassLoader().getResourceAsStream(path);
+    BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+    return reader.lines().collect(Collectors.joining("\n"));
+  }
+
+  /**
+   * Convert the given data to a json String, convert it back to a Data and compare them.
+   *
+   * @param data the Data to test
+   * @throws JsonParseException if it failed to parse
+   * @throws AssertionError if the converted data is not equals to data
+   */
+  public static void testData(Data data) throws JsonParseException {
+    String json = GSON.toJson(data, Data.class);
+    JsonUtils.verifyJson(JsonUtils.DATA_SCHEMA, json);
+    assertEquals(data, GSON.fromJson(json, Data.class));
+  }
+
+  public static Data parse(String json) throws JsonParseException {
+    return GSON.fromJson(json, Data.class);
+  }
+}

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/JsonTestUtils.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/JsonTestUtils.java
@@ -8,8 +8,6 @@ import com.github.dedis.popstellar.model.network.serializer.JsonUtils;
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
 
-import junit.framework.AssertionFailedError;
-
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusElectAcceptTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusElectAcceptTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.github.dedis.popstellar.model.network.JsonTestUtils;
 import com.github.dedis.popstellar.model.network.method.message.data.Action;
 import com.github.dedis.popstellar.model.network.method.message.data.Objects;
 
@@ -54,5 +55,10 @@ public class ConsensusElectAcceptTest {
     assertNotEquals(consensusElectAcceptAccept, new ConsensusElectAccept(instanceId, "random", true));
     assertNotEquals(consensusElectAcceptAccept, new ConsensusElectAccept(instanceId, messageId, false));
     assertNotEquals(consensusElectAcceptReject, new ConsensusElectAccept(instanceId, messageId, true));
+  }
+
+  @Test
+  public void jsonValidationTest() {
+    JsonTestUtils.testData(consensusElectAcceptAccept);
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusElectTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/consensus/ConsensusElectTest.java
@@ -2,10 +2,13 @@ package com.github.dedis.popstellar.model.network.method.message.data.consensus;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
+import com.github.dedis.popstellar.model.network.JsonTestUtils;
 import com.github.dedis.popstellar.model.network.method.message.data.Action;
 import com.github.dedis.popstellar.model.network.method.message.data.Objects;
 import com.github.dedis.popstellar.utility.security.Hash;
+import com.google.gson.JsonParseException;
 
 import org.junit.Test;
 
@@ -69,5 +72,14 @@ public class ConsensusElectTest {
     assertNotEquals(consensusElect, new ConsensusElect(timeInSeconds, objId, type, random, value));
     assertNotEquals(
         consensusElect, new ConsensusElect(timeInSeconds, objId, type, property, random));
+  }
+
+  @Test
+  public void jsonValidationTest() {
+    JsonTestUtils.testData(consensusElect);
+    String jsonInvalid =
+            JsonTestUtils.loadFile(
+                    "protocol/examples/messageData/consensus_elect/wrong_elect_negative_created_at.json");
+    assertThrows(JsonParseException.class, () -> JsonTestUtils.parse(jsonInvalid));
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/election/CastVoteTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/election/CastVoteTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
+import com.github.dedis.popstellar.model.network.JsonTestUtils;
+
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -52,5 +54,10 @@ public class CastVoteTest {
         castVote, new CastVote(Collections.singletonList(electionVote1), "random", laoId));
     assertNotEquals(
         castVote, new CastVote(Collections.singletonList(electionVote1), electionId, "random"));
+  }
+
+  @Test
+  public void jsonValidationTest() {
+    JsonTestUtils.testData(castVote);
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionEndTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionEndTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import com.github.dedis.popstellar.model.network.JsonTestUtils;
 import com.github.dedis.popstellar.model.network.method.message.data.Action;
 import com.github.dedis.popstellar.model.network.method.message.data.Objects;
 
@@ -48,5 +49,10 @@ public class ElectionEndTest {
     assertThrows(
         IllegalArgumentException.class, () -> new ElectionEnd(electionId, null, registeredVotes));
     assertThrows(IllegalArgumentException.class, () -> new ElectionEnd(electionId, laoId, null));
+  }
+
+  @Test
+  public void jsonValidationTest() {
+    JsonTestUtils.testData(electionEnd);
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionQuestionTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionQuestionTest.java
@@ -3,6 +3,7 @@ package com.github.dedis.popstellar.model.network.method.message.data.election;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.github.dedis.popstellar.model.network.JsonTestUtils;
 import com.github.dedis.popstellar.utility.security.Hash;
 
 import org.junit.Test;
@@ -61,5 +62,10 @@ public class ElectionQuestionTest {
   @Test
   public void electionQuestionGetterReturnsCorrectBallotOptions() {
     assertThat(electionQuestion.getBallotOptions(), is(new ArrayList<>()));
+  }
+
+  @Test
+  public void jsonValidationTest() {
+    JsonTestUtils.testData(electionSetup);
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionQuestionTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionQuestionTest.java
@@ -9,7 +9,6 @@ import com.github.dedis.popstellar.utility.security.Hash;
 import org.junit.Test;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -23,6 +22,8 @@ public class ElectionQuestionTest {
   private final String question = "Question";
   private final List<String> allMethods = Arrays.asList("Plurality", "Plurality");
   private final List<String> allQuestions = Arrays.asList("Question", "Question2");
+  private final List<String> ballotOptions1 = Arrays.asList("a", "b");
+  private final List<String> ballotOptions2 = Arrays.asList("a", "b");
   private final List<Boolean> allWriteIns = Arrays.asList(false, false);
   private final ElectionSetup electionSetup =
       new ElectionSetup(
@@ -32,7 +33,7 @@ public class ElectionQuestionTest {
           end,
           allMethods,
           allWriteIns,
-          Arrays.asList(new ArrayList<>(), new ArrayList<>()),
+          Arrays.asList(ballotOptions1, ballotOptions2),
           allQuestions,
           laoId);
   private final ElectionQuestion electionQuestion = electionSetup.getQuestions().get(0);
@@ -61,7 +62,7 @@ public class ElectionQuestionTest {
 
   @Test
   public void electionQuestionGetterReturnsCorrectBallotOptions() {
-    assertThat(electionQuestion.getBallotOptions(), is(new ArrayList<>()));
+    assertThat(electionQuestion.getBallotOptions(), is(ballotOptions1));
   }
 
   @Test

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionResultTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionResultTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import com.github.dedis.popstellar.model.network.JsonTestUtils;
 import com.github.dedis.popstellar.model.network.method.message.data.Action;
 import com.github.dedis.popstellar.model.network.method.message.data.Objects;
 
@@ -45,5 +46,10 @@ public class ElectionResultTest {
   @Test
   public void electionResultGetterReturnsCorrectAction() {
     assertThat(electionResult.getAction(), is(Action.RESULT.getAction()));
+  }
+
+  @Test
+  public void jsonValidationTest() {
+    JsonTestUtils.testData(electionResult);
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionSetupTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/election/ElectionSetupTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 
+import com.github.dedis.popstellar.model.network.JsonTestUtils;
 import com.github.dedis.popstellar.model.network.method.message.data.Action;
 import com.github.dedis.popstellar.model.network.method.message.data.Objects;
 import com.github.dedis.popstellar.model.objects.event.EventType;
@@ -218,5 +219,10 @@ public class ElectionSetupTest {
   @Test
   public void electionSetupEqualsTrueForSameInstance() {
     assertThat(electionSetup.equals(electionSetup), is(true));
+  }
+
+  @Test
+  public void jsonValidationTest() {
+    JsonTestUtils.testData(electionSetup);
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/lao/CreateLaoTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/lao/CreateLaoTest.java
@@ -6,10 +6,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 
+import com.github.dedis.popstellar.model.network.JsonTestUtils;
 import com.github.dedis.popstellar.model.network.method.message.data.Action;
 import com.github.dedis.popstellar.model.network.method.message.data.Objects;
 import com.github.dedis.popstellar.model.objects.Lao;
 import com.github.dedis.popstellar.utility.security.Hash;
+import com.google.gson.JsonParseException;
 
 import org.junit.Test;
 
@@ -84,5 +86,16 @@ public class CreateLaoTest {
     assertEquals(new CreateLao(name, organizer), new CreateLao(name, organizer));
     assertNotEquals(createLao1, new CreateLao("random", organizer));
     assertNotEquals(createLao1, new CreateLao(name, "random"));
+  }
+
+  @Test
+  public void jsonValidationTest() {
+    JsonTestUtils.testData(createLao);
+
+    String pathDir = "protocol/examples/messageData/laoCreate/";
+    String jsonInvalid1 = JsonTestUtils.loadFile(pathDir + "wrong_lao_create_additional_params.json");
+    String jsonInvalid2 = JsonTestUtils.loadFile(pathDir + "wrong_lao_create_missing_params.json");
+    assertThrows(JsonParseException.class, () -> JsonTestUtils.parse(jsonInvalid1));
+    assertThrows(JsonParseException.class, () -> JsonTestUtils.parse(jsonInvalid2));
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/lao/CreateLaoTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/lao/CreateLaoTest.java
@@ -92,7 +92,7 @@ public class CreateLaoTest {
   public void jsonValidationTest() {
     JsonTestUtils.testData(createLao);
 
-    String pathDir = "protocol/examples/messageData/laoCreate/";
+    String pathDir = "protocol/examples/messageData/lao_create/";
     String jsonInvalid1 = JsonTestUtils.loadFile(pathDir + "wrong_lao_create_additional_params.json");
     String jsonInvalid2 = JsonTestUtils.loadFile(pathDir + "wrong_lao_create_missing_params.json");
     assertThrows(JsonParseException.class, () -> JsonTestUtils.parse(jsonInvalid1));

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/lao/StateLaoTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/lao/StateLaoTest.java
@@ -6,10 +6,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 
+import com.github.dedis.popstellar.model.network.JsonTestUtils;
 import com.github.dedis.popstellar.model.network.method.message.PublicKeySignaturePair;
 import com.github.dedis.popstellar.model.network.method.message.data.Action;
 import com.github.dedis.popstellar.model.network.method.message.data.Objects;
 import com.github.dedis.popstellar.model.objects.Lao;
+import com.google.gson.JsonParseException;
 
 import org.junit.Test;
 
@@ -195,5 +197,16 @@ public class StateLaoTest {
             modificationId,
             new HashSet<>(Collections.singletonList("0x3434")),
             modificationSignatures));
+  }
+
+  @Test
+  public void jsonValidationTest() {
+    JsonTestUtils.testData(stateLao);
+
+    String pathDir = "protocol/examples/messageData/lao_state/";
+    String jsonInvalid1 = JsonTestUtils.loadFile(pathDir + "wrong_lao_state_additional_params.json");
+    String jsonInvalid2 = JsonTestUtils.loadFile(pathDir + "wrong_lao_state_missing_params.json");
+    assertThrows(JsonParseException.class, () -> JsonTestUtils.parse(jsonInvalid1));
+    assertThrows(JsonParseException.class, () -> JsonTestUtils.parse(jsonInvalid2));
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/lao/UpdateLaoTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/lao/UpdateLaoTest.java
@@ -94,7 +94,7 @@ public class UpdateLaoTest {
   public void jsonValidationTest() {
     JsonTestUtils.testData(updateLao);
 
-    String pathDir = "protocol/examples/messageData/laoUpdate/";
+    String pathDir = "protocol/examples/messageData/lao_update/";
     String jsonInvalid1 = JsonTestUtils.loadFile(pathDir + "wrong_lao_update_additional_params.json");
     String jsonInvalid2 = JsonTestUtils.loadFile(pathDir + "wrong_lao_update_missing_params.json");
     assertThrows(JsonParseException.class, () -> JsonTestUtils.parse(jsonInvalid1));

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/lao/UpdateLaoTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/lao/UpdateLaoTest.java
@@ -4,13 +4,16 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 import android.util.ArraySet;
 
+import com.github.dedis.popstellar.model.network.JsonTestUtils;
 import com.github.dedis.popstellar.model.network.method.message.data.Action;
 import com.github.dedis.popstellar.model.network.method.message.data.Objects;
 import com.github.dedis.popstellar.model.objects.Lao;
 import com.github.dedis.popstellar.utility.security.Hash;
+import com.google.gson.JsonParseException;
 
 import org.junit.Test;
 
@@ -85,5 +88,16 @@ public class UpdateLaoTest {
             name,
             lastModified,
             new HashSet<>(Collections.singletonList("0x3434"))));
+  }
+
+  @Test
+  public void jsonValidationTest() {
+    JsonTestUtils.testData(updateLao);
+
+    String pathDir = "protocol/examples/messageData/laoUpdate/";
+    String jsonInvalid1 = JsonTestUtils.loadFile(pathDir + "wrong_lao_update_additional_params.json");
+    String jsonInvalid2 = JsonTestUtils.loadFile(pathDir + "wrong_lao_update_missing_params.json");
+    assertThrows(JsonParseException.class, () -> JsonTestUtils.parse(jsonInvalid1));
+    assertThrows(JsonParseException.class, () -> JsonTestUtils.parse(jsonInvalid2));
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/CloseRollCallTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/CloseRollCallTest.java
@@ -3,6 +3,7 @@ package com.github.dedis.popstellar.model.network.method.message.data.rollcall;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.github.dedis.popstellar.model.network.JsonTestUtils;
 import com.github.dedis.popstellar.model.network.method.message.data.Action;
 import com.github.dedis.popstellar.model.network.method.message.data.Objects;
 import com.github.dedis.popstellar.model.objects.event.EventState;
@@ -62,5 +63,10 @@ public class CloseRollCallTest {
   @Test
   public void getClosesTest() {
     assertThat(closeRollCall.getCloses(), is(openRollCall.getUpdateId()));
+  }
+
+  @Test
+  public void jsonValidationTest() {
+    JsonTestUtils.testData(closeRollCall);
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/CreateRollCallTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/CreateRollCallTest.java
@@ -3,6 +3,7 @@ package com.github.dedis.popstellar.model.network.method.message.data.rollcall;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.github.dedis.popstellar.model.network.JsonTestUtils;
 import com.github.dedis.popstellar.model.network.method.message.data.Action;
 import com.github.dedis.popstellar.model.network.method.message.data.Objects;
 import com.github.dedis.popstellar.model.objects.event.EventType;
@@ -62,5 +63,10 @@ public class CreateRollCallTest {
   @Test
   public void getDescriptionTest() {
     assertThat(createRollCall.getLocation(), is(location));
+  }
+
+  @Test
+  public void jsonValidationTest() {
+    JsonTestUtils.testData(createRollCall);
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/OpenRollCallTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/OpenRollCallTest.java
@@ -3,6 +3,7 @@ package com.github.dedis.popstellar.model.network.method.message.data.rollcall;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.github.dedis.popstellar.model.network.JsonTestUtils;
 import com.github.dedis.popstellar.model.network.method.message.data.Action;
 import com.github.dedis.popstellar.model.network.method.message.data.Objects;
 import com.github.dedis.popstellar.model.objects.event.EventState;
@@ -57,5 +58,10 @@ public class OpenRollCallTest {
   @Test
   public void getOpensTest() {
     assertThat(reopenRollCall.getOpens(), is(createRollCall.getId()));
+  }
+
+  @Test
+  public void jsonValidationTest() {
+    JsonTestUtils.testData(reopenRollCall);
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/ElectionHandlerTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/ElectionHandlerTest.java
@@ -42,6 +42,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.security.GeneralSecurityException;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
@@ -127,7 +128,7 @@ public class ElectionHandlerTest extends TestCase {
     election.setChannel(lao.getChannel() + "/" + election.getId());
     electionQuestion =
         new ElectionQuestion(
-            "question", "voting method", false, Collections.singletonList("a"), election.getId());
+            "question", "Plurality", false, Arrays.asList("a", "b"), election.getId());
     election.setElectionQuestions(Collections.singletonList(electionQuestion));
     lao.setElections(
         new HashMap<String, Election>() {

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/RollCallHandlerTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/RollCallHandlerTest.java
@@ -109,6 +109,7 @@ public class RollCallHandlerTest {
 
     // Create one Roll Call and add it to the LAO
     rollCall = new RollCall(lao.getId(), Instant.now().getEpochSecond(), "roll call 1");
+    rollCall.setLocation("EPFL");
     lao.setRollCalls(
         new HashMap<String, RollCall>() {
           {


### PR DESCRIPTION
Some infos
- The validation of json is done when serializing/deserializing, using the schemas from the protocol
- All schemas/examples are copied into 'src/main/resources/protocol' and ignored in the .gitignore
- Fix PublicKeySignaturePair serialization (fields need to be base64 string, not bytes array)
- Fix some tests that was using invalid data
- Add some json tests
- Add equals/hashcode to immutable classes
- Currently the schemas are loaded asynchronously in HomeActivity, but in Android 11 it seems that AsyncTask is depreacted ?
- If a test use the json validation, it could need to load schemas in @Before (it could take up to 1 seconds the first time to load)
- Once the json schemas are loaded, it doesn't seems to slow the app