### PR TITLE
Rename wallet reducer for tests

### DIFF
--- a/fe1-web/store/reducers/WalletReducer.ts
+++ b/fe1-web/store/reducers/WalletReducer.ts
@@ -51,7 +51,7 @@ export const {
   clearWallet,
 } = walletSlice.actions;
 
-export const { reducer } = walletSlice;
+export const walletReducer = walletSlice.reducer;
 
 export default {
   [walletReducerPath]: walletSlice.reducer,

--- a/fe1-web/store/reducers/WalletReducer.ts
+++ b/fe1-web/store/reducers/WalletReducer.ts
@@ -51,7 +51,7 @@ export const {
   clearWallet,
 } = walletSlice.actions;
 
-export const walletReducer = walletSlice.reducer;
+export const walletReduce = walletSlice.reducer;
 
 export default {
   [walletReducerPath]: walletSlice.reducer,

--- a/fe1-web/store/reducers/__tests__/WalletReducer.test.ts
+++ b/fe1-web/store/reducers/__tests__/WalletReducer.test.ts
@@ -1,6 +1,6 @@
 import 'jest-extended';
 import { AnyAction } from 'redux';
-import { walletReducer, clearWallet, setWallet } from '../WalletReducer';
+import { walletReduce, clearWallet, setWallet } from '../WalletReducer';
 
 const emptyState = {
   seed: undefined,
@@ -13,16 +13,16 @@ const filledState = {
 };
 
 test('should return the initial state', () => {
-  expect(walletReducer(undefined, {} as AnyAction))
+  expect(walletReduce(undefined, {} as AnyAction))
     .toEqual(emptyState);
 });
 
 test('should handle the wallet being set', () => {
-  expect(walletReducer({}, setWallet(filledState)))
+  expect(walletReduce({}, setWallet(filledState)))
     .toEqual(filledState);
 });
 
 test('should handle the wallet being set', () => {
-  expect(walletReducer(filledState, clearWallet()))
+  expect(walletReduce(filledState, clearWallet()))
     .toEqual(emptyState);
 });

--- a/fe1-web/store/reducers/__tests__/WalletReducer.test.ts
+++ b/fe1-web/store/reducers/__tests__/WalletReducer.test.ts
@@ -1,6 +1,6 @@
 import 'jest-extended';
 import { AnyAction } from 'redux';
-import { reducer, clearWallet, setWallet } from '../WalletReducer';
+import { walletReducer, clearWallet, setWallet } from '../WalletReducer';
 
 const emptyState = {
   seed: undefined,
@@ -13,16 +13,16 @@ const filledState = {
 };
 
 test('should return the initial state', () => {
-  expect(reducer(undefined, {} as AnyAction))
+  expect(walletReducer(undefined, {} as AnyAction))
     .toEqual(emptyState);
 });
 
 test('should handle the wallet being set', () => {
-  expect(reducer({}, setWallet(filledState)))
+  expect(walletReducer({}, setWallet(filledState)))
     .toEqual(filledState);
 });
 
 test('should handle the wallet being set', () => {
-  expect(reducer(filledState, clearWallet()))
+  expect(walletReducer(filledState, clearWallet()))
     .toEqual(emptyState);
 });


### PR DESCRIPTION
I modified the name of the exported wallet reducer constant, to avoid any name collision during tests of other reducers.