### PR TITLE
Check if the start time is in the past, and add tests

### DIFF
--- a/fe2-android/app/src/androidTest/java/com/github/dedis/popstellar/ui/detail/event/fragments/ElectionSetupFragmentTest.java
+++ b/fe2-android/app/src/androidTest/java/com/github/dedis/popstellar/ui/detail/event/fragments/ElectionSetupFragmentTest.java
@@ -233,9 +233,9 @@ public class ElectionSetupFragmentTest {
   }
 
   @Test
-  public void cannotChooseStartTimeInPast() {
+  public void cannotChooseStartTimeTooFarInPast() {
     Calendar today = Calendar.getInstance();
-    today.add(Calendar.MINUTE, -1);
+    today.add(Calendar.MINUTE, -10);
     int year = today.get(Calendar.YEAR);
     int monthOfYear = today.get(Calendar.MONTH) + 1;
     int dayOfMonth = today.get(Calendar.DAY_OF_MONTH);
@@ -255,7 +255,7 @@ public class ElectionSetupFragmentTest {
   @Test
   public void choosingStartDateInvalidateAStartTimeInPast() {
     Calendar today = Calendar.getInstance();
-    today.add(Calendar.MINUTE, -1);
+    today.add(Calendar.MINUTE, -10);
     int year = today.get(Calendar.YEAR);
     int monthOfYear = today.get(Calendar.MONTH) + 1;
     int dayOfMonth = today.get(Calendar.DAY_OF_MONTH);

--- a/fe2-android/app/src/androidTest/java/com/github/dedis/popstellar/ui/detail/event/fragments/ElectionSetupFragmentTest.java
+++ b/fe2-android/app/src/androidTest/java/com/github/dedis/popstellar/ui/detail/event/fragments/ElectionSetupFragmentTest.java
@@ -231,4 +231,45 @@ public class ElectionSetupFragmentTest {
     pickerAcceptButton().perform(click());
     endTimeView().check(matches(withText(String.format(TIME_FORMAT, HOURS + 1, MINUTES))));
   }
+
+  @Test
+  public void cannotChooseStartTimeInPast() {
+    Calendar today = Calendar.getInstance();
+    today.add(Calendar.MINUTE, -1);
+    int year = today.get(Calendar.YEAR);
+    int monthOfYear = today.get(Calendar.MONTH) + 1;
+    int dayOfMonth = today.get(Calendar.DAY_OF_MONTH);
+    int hourOfDay = today.get(Calendar.HOUR_OF_DAY);
+    int minutes = today.get(Calendar.MINUTE);
+
+    startDateView().perform(click());
+    datePicker().perform(PickerActions.setDate(year, monthOfYear, dayOfMonth));
+    pickerAcceptButton().perform(click());
+
+    startTimeView().perform(click());
+    timePicker().perform(PickerActions.setTime(hourOfDay, minutes));
+    pickerAcceptButton().perform(click());
+    startTimeView().check(matches(withText("")));
+  }
+
+  @Test
+  public void choosingStartDateInvalidateAStartTimeInPast() {
+    Calendar today = Calendar.getInstance();
+    today.add(Calendar.MINUTE, -1);
+    int year = today.get(Calendar.YEAR);
+    int monthOfYear = today.get(Calendar.MONTH) + 1;
+    int dayOfMonth = today.get(Calendar.DAY_OF_MONTH);
+    int hourOfDay = today.get(Calendar.HOUR_OF_DAY);
+    int minutes = today.get(Calendar.MINUTE);
+
+    startTimeView().perform(click());
+    timePicker().perform(PickerActions.setTime(hourOfDay, minutes));
+    pickerAcceptButton().perform(click());
+    startTimeView().check(matches(withText(String.format(TIME_FORMAT, hourOfDay, minutes))));
+
+    startDateView().perform(click());
+    datePicker().perform(PickerActions.setDate(year, monthOfYear, dayOfMonth));
+    pickerAcceptButton().perform(click());
+    startTimeView().check(matches(withText("")));
+  }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
@@ -462,7 +462,6 @@ public class LaoDetailViewModel extends AndroidViewModel
    * @param proposedStart the proposed start time of the roll call
    * @param proposedEnd the proposed end time of the roll call
    * @param open true if we want to directly open the roll call
-   * @return the id of the newly created roll call event, null if fails to create the event
    */
   public void createNewRollCall(
       String title,

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/AbstractEventCreationFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/AbstractEventCreationFragment.java
@@ -21,7 +21,9 @@ import com.github.dedis.popstellar.ui.detail.event.pickers.TimePickerFragment;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.Locale;
 
 /**
@@ -39,8 +41,7 @@ public abstract class AbstractEventCreationFragment extends Fragment {
   private final Calendar completeStartTime = Calendar.getInstance();
   private final Calendar completeEndTime = Calendar.getInstance();
 
-  protected final long creationTimeInSeconds = Instant.now().getEpochSecond();
-
+  protected long creationTimeInSeconds;
   protected long startTimeInSeconds;
   protected long endTimeInSeconds;
 
@@ -144,10 +145,6 @@ public abstract class AbstractEventCreationFragment extends Fragment {
 
     if (compareWithNowByDay(newDate) == 0) {
       computeTimesInSeconds();
-      if (startTimeInSeconds < creationTimeInSeconds) {
-        startTime = null;
-        startTimeEditText.setText("");
-      }
     }
   }
 
@@ -190,11 +187,6 @@ public abstract class AbstractEventCreationFragment extends Fragment {
       startTimeEditText.setText("");
     } else if (startDate != null && compareWithNowByDay(startDate) == 0) {
       computeTimesInSeconds();
-      if (startTimeInSeconds < creationTimeInSeconds) {
-        showToast(R.string.past_date_not_allowed);
-        startTime = null;
-        startTimeEditText.setText("");
-      }
     }
   }
 
@@ -235,37 +227,69 @@ public abstract class AbstractEventCreationFragment extends Fragment {
     Toast.makeText(getActivity(), getString(text), Toast.LENGTH_LONG).show();
   }
 
-  public void computeTimesInSeconds() {
-    if (startDate == null) {
-      startDate = Calendar.getInstance();
-    }
-    if (startTime == null) {
-      startTime = Calendar.getInstance();
+  /**
+   * Compute the creationTimeInSeconds, completeStartTime, completeEndTime. And check if the
+   * start/end are still valid. (end can be null in the case of RollCall)
+   *
+   * @return true if the date/times are all valid
+   */
+  public boolean computeTimesInSeconds() {
+    if (startDate == null || startTime == null) {
+      return false;
     }
     completeStartTime.set(
         startDate.get(Calendar.YEAR),
         startDate.get(Calendar.MONTH),
         startDate.get(Calendar.DAY_OF_MONTH),
         startTime.get(Calendar.HOUR_OF_DAY),
-        startTime.get(Calendar.MINUTE));
-    Instant start = Instant.ofEpochMilli(completeStartTime.getTimeInMillis());
-    startTimeInSeconds = start.getEpochSecond();
-    if (endDate != null) {
-      if (endTime == null) {
-        completeEndTime.set(
-            endDate.get(Calendar.YEAR),
-            endDate.get(Calendar.MONTH),
-            endDate.get(Calendar.DAY_OF_MONTH));
+        startTime.get(Calendar.MINUTE),
+        0);
+
+    Instant creation = Instant.now();
+    Instant start = completeStartTime.toInstant();
+    if (start.isBefore(creation)) {
+      // If the start is more than 5 minutes in the past, invalidate the time
+      if (start.plus(5, ChronoUnit.MINUTES).isBefore(creation)) {
+        showToast(R.string.past_date_not_allowed);
+        startTime = null;
+        startTimeEditText.setText("");
+        return false;
       } else {
-        completeEndTime.set(
-            endDate.get(Calendar.YEAR),
-            endDate.get(Calendar.MONTH),
-            endDate.get(Calendar.DAY_OF_MONTH),
-            endTime.get(Calendar.HOUR_OF_DAY),
-            endTime.get(Calendar.MINUTE));
+        // Else (if start is only a little in the past), set the start to creation
+        start = creation;
+        startTimeEditText.setText(timeFormat.format(Date.from(start).getTime()));
       }
-      Instant end = Instant.ofEpochMilli(completeEndTime.getTimeInMillis());
-      endTimeInSeconds = end.getEpochSecond();
     }
+    creationTimeInSeconds = creation.getEpochSecond();
+    startTimeInSeconds = start.getEpochSecond();
+    if (endDate == null ^ endTime == null) {
+      return false;
+    }
+    if (endDate != null) {
+      completeEndTime.set(
+          endDate.get(Calendar.YEAR),
+          endDate.get(Calendar.MONTH),
+          endDate.get(Calendar.DAY_OF_MONTH),
+          endTime.get(Calendar.HOUR_OF_DAY),
+          endTime.get(Calendar.MINUTE),
+          0);
+      Instant end = completeEndTime.toInstant();
+      if (end.isBefore(start)) {
+        if (end.truncatedTo(ChronoUnit.MINUTES).equals(start.truncatedTo(ChronoUnit.MINUTES))) {
+          // If the endTime was set on the same minute as the start, use same time for start and end
+          end = start;
+          endTimeEditText.setText(timeFormat.format(Date.from(end).getTime()));
+        } else {
+          showToast(R.string.past_date_not_allowed);
+          endTime = null;
+          endTimeEditText.setText("");
+          return false;
+        }
+      }
+      endTimeInSeconds = end.getEpochSecond();
+      return true;
+    }
+    endTimeInSeconds = 0;
+    return true;
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/AbstractEventCreationFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/AbstractEventCreationFragment.java
@@ -141,6 +141,14 @@ public abstract class AbstractEventCreationFragment extends Fragment {
       endTime = null;
       endTimeEditText.setText("");
     }
+
+    if (compareWithNowByDay(newDate) == 0) {
+      computeTimesInSeconds();
+      if (startTimeInSeconds < creationTimeInSeconds) {
+        startTime = null;
+        startTimeEditText.setText("");
+      }
+    }
   }
 
   private void onEndDate(String requestKey, Bundle bundle) {
@@ -180,6 +188,13 @@ public abstract class AbstractEventCreationFragment extends Fragment {
       showToast(R.string.start_time_after_end_time_not_allowed);
       startTime = null;
       startTimeEditText.setText("");
+    } else if (startDate != null && compareWithNowByDay(startDate) == 0) {
+      computeTimesInSeconds();
+      if (startTimeInSeconds < creationTimeInSeconds) {
+        showToast(R.string.past_date_not_allowed);
+        startTime = null;
+        startTimeEditText.setText("");
+      }
     }
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/election/fragments/ElectionSetupFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/election/fragments/ElectionSetupFragment.java
@@ -182,7 +182,9 @@ public class ElectionSetupFragment extends AbstractEventCreationFragment {
           // elections at once
           submitButton.setEnabled(false);
           // When submitting, we compute the timestamps for the selected start and end time
-          computeTimesInSeconds();
+          if (!computeTimesInSeconds()) {
+            return;
+          }
 
           final List<Integer> validPositions = viewPagerAdapter.getValidInputs();
 
@@ -220,6 +222,8 @@ public class ElectionSetupFragment extends AbstractEventCreationFragment {
               TAG,
               "Creating election with name "
                   + electionName
+                  + ", creation time "
+                  + creationTimeInSeconds
                   + ", start time "
                   + startTimeInSeconds
                   + ", end time "

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/rollcall/RollCallEventCreationFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/rollcall/RollCallEventCreationFragment.java
@@ -135,7 +135,9 @@ public final class RollCallEventCreationFragment extends AbstractEventCreationFr
   }
 
   private void createRollCall(boolean open) {
-    computeTimesInSeconds();
+    if (!computeTimesInSeconds()) {
+        return;
+    }
 
     String title = mFragBinding.rollCallTitleText.getText().toString();
     String description = mFragBinding.rollCallEventDescriptionText.getText().toString();


### PR DESCRIPTION
- computeTimesInSeconds now return false if there was a problem with start/end.
- if start is in the past (when we select or if we wait and then click on confirm)
  - more than 5 min => invalidate time
  - less thant 5 min => replace start by now
- if the end is before the start => invalidate time
  for example : set start to 16:00, end to 16:02, wait 4 min (start is updated to 16:04 > 16:02)
- If the start/end time are in the future, they are truncated to the minute
  16h05m25s => 16h05m00s