### PR TITLE
Wallet tokens update only on rollcall change

### DIFF
--- a/fe1-web/parts/wallet/WalletSyncedSeed.tsx
+++ b/fe1-web/parts/wallet/WalletSyncedSeed.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import {
   ScrollView,
   StyleSheet, View, ViewStyle,
@@ -44,11 +44,13 @@ const WalletSyncedSeed = ({ navigation }: IPropTypes) => {
   const laoSelector = makeLaosMap();
   const laos = useSelector(laoSelector);
 
-  Wallet.recoverWalletPoPTokens()
-    .then((kp) => {
-      setTokensByLao(kp);
-    })
-    .catch((err) => console.debug(err));
+  useEffect(() => {
+    Wallet.recoverWalletPoPTokens()
+      .then((kp) => {
+        setTokensByLao(kp);
+      })
+      .catch((err) => console.debug(err));
+  }, [rollCalls]);
 
   /* the below 4 functions are to manage user interaction with buttons */
   function hidePublicKeyButton() {


### PR DESCRIPTION
This breaks a loop that would happen when setting up the wallet.

Effectively, we would update the state every time we render the component.
Every time we update the state, the component gets rendered again.

Using `useEffect`, bound to the changes to the `rollCalls` state variable, ensures that the rendering happens again ONLY if new roll calls are detected.