### PR TITLE
AnswerValidatorTestSuite and JRPC broadcast parse bug fix   

### DIFF
--- a/be2-scala/.gitignore
+++ b/be2-scala/.gitignore
@@ -21,4 +21,5 @@ database
 database_test
 
 #Protocol folder
-src/main/resources/protocol
+src/main/resources/protocol*
+!src/main/resources/protocol/query/query.json

--- a/be2-scala/src/main/resources/protocol/query/query.json
+++ b/be2-scala/src/main/resources/protocol/query/query.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://raw.githubusercontent.com/dedis/student_21_pop/master/protocol/query/query.json",
+    "title": "Match a custom JsonRpc 2.0 query message",
+    "description": "Match a client query",
+    "type": "object",
+    "properties": {
+        "jsonrpc": {
+            "$comment": "Defined by the parent, but needed here for the validation"
+        },
+
+        "method": {
+            "type": "string"
+        },
+
+        "params": {
+            "type": "object"
+        }
+    },
+    "oneOf": [
+        {
+            "$ref": "method/subscribe.json"
+        },
+        {
+            "$ref": "method/broadcast.json"
+        },
+        {
+            "$ref": "method/unsubscribe.json"
+        },
+        {
+            "$ref": "method/publish.json"
+        },
+        {
+            "$ref": "method/catchup.json"
+        }
+    ],
+
+    "required": ["method", "params", "jsonrpc"],
+
+    "$comment": "can have an additional property `id` if not a broadcast"
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/json/HighLevelProtocol.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/json/HighLevelProtocol.scala
@@ -144,7 +144,6 @@ object HighLevelProtocol extends DefaultJsonProtocol {
 
         val method: MethodType = methodJsString.convertTo[MethodType]
         val params: Params = method match {
-          case MethodType.BROADCAST => paramsJsObject.convertTo[Broadcast]
           case MethodType.PUBLISH => paramsJsObject.convertTo[Publish]
           case MethodType.SUBSCRIBE => paramsJsObject.convertTo[Subscribe]
           case MethodType.UNSUBSCRIBE => paramsJsObject.convertTo[Unsubscribe]
@@ -158,6 +157,15 @@ object HighLevelProtocol extends DefaultJsonProtocol {
         }
 
         JsonRpcRequest(version, method, params, id)
+      }
+      
+      //Broadcast does not have an Id and should be treated appart
+      case Seq(JsString(version), methodJsString@JsString(_), paramsJsObject@JsObject(_)) => {
+        val method: MethodType = methodJsString.convertTo[MethodType]
+        val params: Params = method match {
+          case MethodType.BROADCAST => paramsJsObject.convertTo[Broadcast]
+        }
+        JsonRpcRequest(version, method, params, None)
       }
       case _ => throw new IllegalArgumentException(s"Can't parse json value $json to a JsonRpcRequest object")
     }

--- a/be2-scala/src/main/scala/ch/epfl/pop/json/HighLevelProtocol.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/json/HighLevelProtocol.scala
@@ -148,6 +148,7 @@ object HighLevelProtocol extends DefaultJsonProtocol {
           case MethodType.SUBSCRIBE => paramsJsObject.convertTo[Subscribe]
           case MethodType.UNSUBSCRIBE => paramsJsObject.convertTo[Unsubscribe]
           case MethodType.CATCHUP => paramsJsObject.convertTo[Catchup]
+          case _ => throw new IllegalArgumentException(s"Can't parse json value $json with unknown method ${method.toString}")
         }
 
         val id: Option[Int] = optId match {
@@ -158,12 +159,13 @@ object HighLevelProtocol extends DefaultJsonProtocol {
 
         JsonRpcRequest(version, method, params, id)
       }
-      
-      //Broadcast does not have an Id and should be treated appart
+
+      // Broadcast does not have an Id and should be treated separately
       case Seq(JsString(version), methodJsString@JsString(_), paramsJsObject@JsObject(_)) => {
         val method: MethodType = methodJsString.convertTo[MethodType]
         val params: Params = method match {
           case MethodType.BROADCAST => paramsJsObject.convertTo[Broadcast]
+          case _ => throw new IllegalArgumentException(s"Can't parse json value $json with unknown method ${method.toString}")
         }
         JsonRpcRequest(version, method, params, None)
       }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/ResultObject.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/ResultObject.scala
@@ -9,4 +9,12 @@ class ResultObject(val resultInt: Option[Int], val resultMessages: Option[List[M
   def this(result: List[Message]) = this(None, Some(result))
 
   def isIntResult: Boolean = resultInt.isDefined
+
+  override def equals(o: Any): Boolean = {
+      o match{
+          case that: ResultObject =>
+            this.resultInt == that.resultInt && that.resultMessages == this.resultMessages
+          case _=> false
+      }
+    }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/ResultObject.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/ResultObject.scala
@@ -11,7 +11,7 @@ class ResultObject(val resultInt: Option[Int], val resultMessages: Option[List[M
   def isIntResult: Boolean = resultInt.isDefined
 
   override def equals(o: Any): Boolean = {
-      o match{
+      o match {
           case that: ResultObject =>
             this.resultInt == that.resultInt && that.resultMessages == this.resultMessages
           case _=> false

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/AnswerGenerator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/AnswerGenerator.scala
@@ -16,17 +16,14 @@ import akka.pattern.AskableActorRef
   * Since this is an object only one instance of AnswerGenerator(class) will be created
   *
   */
-object AnswerGenerator  extends AskPatternConstants  {
+object AnswerGenerator extends AskPatternConstants {
   lazy val db = DbActor.getInstance
   val answerGen = new AnswerGenerator(db)
   def generateAnswer(graphMessage: GraphMessage): GraphMessage  = answerGen.generateAnswer(graphMessage)
   val generator: Flow[GraphMessage, GraphMessage, NotUsed] = answerGen.generator
 }
 
-/**
- * /!\ The class can now be tested as the db can directly be injected into it
- */
-sealed class AnswerGenerator(db : => AskableActorRef)  extends AskPatternConstants {
+sealed class AnswerGenerator(db : => AskableActorRef) extends AskPatternConstants {
 
   def generateAnswer(graphMessage: GraphMessage): GraphMessage = graphMessage match {
     // Note: the output message (if successful) is an answer

--- a/be2-scala/src/test/scala/ch/epfl/pop/json/HighLevelProtocolSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/json/HighLevelProtocolSuite.scala
@@ -5,7 +5,6 @@ import ch.epfl.pop.model.objects._
 import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.Inspectors.{forAll,forEvery}
 import org.scalatest.Matchers._
-//import ch.epfl.pop.json.MsgField._
 import org.scalactic.Prettifier
 
 class HighLevelProtocolSuite extends FunSuite with Matchers  {

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/AnswerGeneratorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/AnswerGeneratorSuite.scala
@@ -39,12 +39,4 @@ class AnswerGeneratorSuite extends FunSuite with Matchers with BeforeAndAfterAll
     expected should be (message)
 
   }
-
-
-
-
-
-
-
-
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/AnswerGeneratorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/AnswerGeneratorSuite.scala
@@ -67,6 +67,7 @@ class AnswerGeneratorSuite extends TestKit(ActorSystem("Test")) with FunSuiteLik
   }
 
   test("Publish: correct response test"){
+
     val rpcPublishReq = getJsonRPC(pathPublishJson)
     val message: GraphMessage = AnswerGenerator.generateAnswer(Left(rpcPublishReq))
     val expected: GraphMessage =  Left(JsonRpcResponse(
@@ -87,7 +88,6 @@ class AnswerGeneratorSuite extends TestKit(ActorSystem("Test")) with FunSuiteLik
     message should be (expected)
     system.stop(dbActorRef.actorRef)
   }
-
 
   test("Catchup: correct response test for one Message"){
 
@@ -123,10 +123,10 @@ class AnswerGeneratorSuite extends TestKit(ActorSystem("Test")) with FunSuiteLik
     message shouldBe a [Right[_,PipelineError]]
     message.toOption.isDefined should be (true)
     message.toOption.get.code should be (ErrorCodes.SERVER_ERROR.id)
-
   }
 
   test("Convert Right Pipeline messages into Error Messages test"){
+    
     val optid = Option(1)
     val perror = PipelineError(
          ErrorCodes.SERVER_ERROR.id,

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/AnswerGeneratorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/AnswerGeneratorSuite.scala
@@ -1,0 +1,50 @@
+package ch.epfl.pop.pubsub.graph
+
+import org.scalatest.{Matchers, FunSuite, BeforeAndAfterAll}
+import ch.epfl.pop.model.network.JsonRpcRequest
+import scala.io.Source
+import ch.epfl.pop.model.network.JsonRpcResponse
+import ch.epfl.pop.pubsub.graph.validators.RpcValidator
+import ch.epfl.pop.model.network.ResultObject
+import ch.epfl.pop.pubsub.graph.validator.SchemaValidatorSuite._
+
+
+
+
+class AnswerGeneratorSuite extends FunSuite with Matchers with BeforeAndAfterAll{
+
+  test("Publish: correct response test"){
+    val path = "../protocol/examples/query/publish/publish.json"
+    val jsonStr = getJsonStringFromFile(path)
+    val rpcRequest: JsonRpcRequest = JsonRpcRequest.buildFromJson(jsonStr)
+    val message: GraphMessage = Left(rpcRequest)
+    val expected: GraphMessage =  Left(JsonRpcResponse(
+        RpcValidator.JSON_RPC_VERSION, Some(new ResultObject(0)), None, rpcRequest.id))
+
+    expected should be (message)
+  }
+
+  //FIXME: Requires Actor intervention
+  test("Catchup: correct response test"){
+    val path = "../protocol/examples/query/catchup/catchup.json"
+    val jsonStr = getJsonStringFromFile(path)
+    val rpcRequest : JsonRpcRequest = JsonRpcRequest.buildFromJson(jsonStr)
+
+    val channel = rpcRequest.getParamsChannel //Channel to be used for Catchup
+    val message : GraphMessage = Left(rpcRequest)
+    def objectNumber: Int = ??? //Should probably be definid by mocking the DBactor and =3
+    val expected =  Left(JsonRpcResponse(
+        RpcValidator.JSON_RPC_VERSION, Some(new ResultObject(objectNumber)), None, rpcRequest.id))
+
+    expected should be (message)
+
+  }
+
+
+
+
+
+
+
+
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validator/SchemaValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validator/SchemaValidatorSuite.scala
@@ -7,14 +7,16 @@ import ch.epfl.pop.pubsub.graph.PipelineError
 import ch.epfl.pop.pubsub.graph.ErrorCodes
 import java.io.IOException
 
-object SchemaValidatorSuite extends FunSuite with Matchers {
-
-  def getJsonStringFromFile(filePath: String): String = {
+object SchemaValidatorSuite {
+    def getJsonStringFromFile(filePath: String): String = {
       val source = Source.fromFile(filePath);
       val jsonStr = source.getLines.mkString
       source.close
       jsonStr
     }
+}
+class SchemaValidatorSuite extends FunSuite with Matchers {
+   import SchemaValidatorSuite._
 
   /* Test subscribe query without message format*/
   test("Correct subscribe JSON-RPC query"){

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validator/SchemaValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validator/SchemaValidatorSuite.scala
@@ -16,13 +16,6 @@ object SchemaValidatorSuite extends FunSuite with Matchers {
       jsonStr
     }
 
-  def getJsonStringFromFile(filePath: String): String = {
-      val source = Source.fromFile(filePath);
-      val jsonStr = source.getLines.mkString
-      source.close
-      jsonStr
-    }
-
   /* Test subscribe query without message format*/
   test("Correct subscribe JSON-RPC query"){
     val subscribePath = "../protocol/examples/query/subscribe/subscribe.json"

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validator/SchemaValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validator/SchemaValidatorSuite.scala
@@ -1,0 +1,68 @@
+package ch.epfl.pop.pubsub.graph.validator
+
+import org.scalatest.{Matchers, FunSuite}
+import scala.io.Source
+import ch.epfl.pop.pubsub.graph.Validator._
+import ch.epfl.pop.pubsub.graph.PipelineError
+import ch.epfl.pop.pubsub.graph.ErrorCodes
+
+class SchemaValidatorSuite extends FunSuite with Matchers {
+
+  /* Test subscribe query without message format*/
+  test("Correct subscribe JSON-RPC query"){
+    val subscribePath = "../protocol/examples/query/subscribe/subscribe.json"
+    val source = Source.fromFile(subscribePath);
+    val subscribeJson = source.getLines.mkString
+    source.close
+
+    validateSchema(subscribeJson) should be (Left(subscribeJson))
+  }
+
+  test("Incorrect subscribe query: additional params"){
+    val subscribePath = "../protocol/examples/query/subscribe/wrong_subscribe__additional_params.json"
+    val source = Source.fromFile(subscribePath);
+    val subscribeJson = source.getLines.mkString
+    source.close
+
+    validateSchema(subscribeJson) shouldBe a [Right[_,PipelineError]]
+  }
+
+  test("Incorrect subscribe query: missing channel"){
+    val subscribePath = "../protocol/examples/query/subscribe/wrong_subscribe_missing_channel.json"
+    val source = Source.fromFile(subscribePath);
+    val subscribeJson = source.getLines.mkString
+    source.close
+
+    validateSchema(subscribeJson) shouldBe a [Right[_,PipelineError]]
+  }
+
+  /* Test broadcast query with message format */
+  test("Correct broadcast JSON-RPC query"){
+    val broadcastPath = "../protocol/examples/query/broadcast/broadcast.json"
+    val source = Source.fromFile(broadcastPath);
+    val broadcastJson = source.getLines.mkString
+    source.close
+
+    validateSchema(broadcastJson) should be (Left(broadcastJson))
+  }
+
+  test("Incorrect broadcast query: additional params"){
+    val broadcastPath = "../protocol/examples/query/broadcast/wrong_broadcast_additional_params.json"
+    val source = Source.fromFile(broadcastPath);
+    val broadcastJson = source.getLines.mkString
+    source.close
+
+    validateSchema(broadcastJson) shouldBe a [Right[_,PipelineError]]
+  }
+
+  test("Incorrect broadcast query: missing message"){
+    val broadcastPath = "../protocol/examples/query/broadcast/wrong_broadcast_missing_message.json"
+    val source = Source.fromFile(broadcastPath);
+    val broadcastJson = source.getLines.mkString
+    source.close
+
+    validateSchema(broadcastJson) shouldBe a [Right[_,PipelineError]]
+  }
+
+
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validator/SchemaValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validator/SchemaValidatorSuite.scala
@@ -5,33 +5,35 @@ import scala.io.Source
 import ch.epfl.pop.pubsub.graph.Validator._
 import ch.epfl.pop.pubsub.graph.PipelineError
 import ch.epfl.pop.pubsub.graph.ErrorCodes
+import java.io.IOException
 
 class SchemaValidatorSuite extends FunSuite with Matchers {
+
+  def getJsonStringFromFile(filePath: String): String = {
+      val source = Source.fromFile(filePath);
+      val jsonStr = source.getLines.mkString
+      source.close
+      jsonStr
+    }
 
   /* Test subscribe query without message format*/
   test("Correct subscribe JSON-RPC query"){
     val subscribePath = "../protocol/examples/query/subscribe/subscribe.json"
-    val source = Source.fromFile(subscribePath);
-    val subscribeJson = source.getLines.mkString
-    source.close
+    val subscribeJson = getJsonStringFromFile(subscribePath)
 
     validateSchema(subscribeJson) should be (Left(subscribeJson))
   }
 
   test("Incorrect subscribe query: additional params"){
     val subscribePath = "../protocol/examples/query/subscribe/wrong_subscribe__additional_params.json"
-    val source = Source.fromFile(subscribePath);
-    val subscribeJson = source.getLines.mkString
-    source.close
+    val subscribeJson = getJsonStringFromFile(subscribePath)
 
     validateSchema(subscribeJson) shouldBe a [Right[_,PipelineError]]
   }
 
   test("Incorrect subscribe query: missing channel"){
     val subscribePath = "../protocol/examples/query/subscribe/wrong_subscribe_missing_channel.json"
-    val source = Source.fromFile(subscribePath);
-    val subscribeJson = source.getLines.mkString
-    source.close
+    val subscribeJson = getJsonStringFromFile(subscribePath)
 
     validateSchema(subscribeJson) shouldBe a [Right[_,PipelineError]]
   }
@@ -39,30 +41,22 @@ class SchemaValidatorSuite extends FunSuite with Matchers {
   /* Test broadcast query with message format */
   test("Correct broadcast JSON-RPC query"){
     val broadcastPath = "../protocol/examples/query/broadcast/broadcast.json"
-    val source = Source.fromFile(broadcastPath);
-    val broadcastJson = source.getLines.mkString
-    source.close
+    val broadcastJson = getJsonStringFromFile(broadcastPath)
 
     validateSchema(broadcastJson) should be (Left(broadcastJson))
   }
 
   test("Incorrect broadcast query: additional params"){
     val broadcastPath = "../protocol/examples/query/broadcast/wrong_broadcast_additional_params.json"
-    val source = Source.fromFile(broadcastPath);
-    val broadcastJson = source.getLines.mkString
-    source.close
+    val broadcastJson =getJsonStringFromFile(broadcastPath)
 
     validateSchema(broadcastJson) shouldBe a [Right[_,PipelineError]]
   }
 
   test("Incorrect broadcast query: missing message"){
     val broadcastPath = "../protocol/examples/query/broadcast/wrong_broadcast_missing_message.json"
-    val source = Source.fromFile(broadcastPath);
-    val broadcastJson = source.getLines.mkString
-    source.close
+    val broadcastJson = getJsonStringFromFile(broadcastPath)
 
     validateSchema(broadcastJson) shouldBe a [Right[_,PipelineError]]
   }
-
-
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validator/SchemaValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validator/SchemaValidatorSuite.scala
@@ -7,7 +7,7 @@ import ch.epfl.pop.pubsub.graph.PipelineError
 import ch.epfl.pop.pubsub.graph.ErrorCodes
 import java.io.IOException
 
-class SchemaValidatorSuite extends FunSuite with Matchers {
+object SchemaValidatorSuite extends FunSuite with Matchers {
 
   def getJsonStringFromFile(filePath: String): String = {
       val source = Source.fromFile(filePath);

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validator/SchemaValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validator/SchemaValidatorSuite.scala
@@ -61,4 +61,32 @@ class SchemaValidatorSuite extends FunSuite with Matchers {
 
     validateSchema(broadcastJson) shouldBe a [Right[_,PipelineError]]
   }
+
+  test("Correct unsubscribe JSON-RPC query"){
+    val unsubscribePath = "../protocol/examples/query/unsubscribe/unsubscribe.json"
+    val unsubscribeJson = getJsonStringFromFile(unsubscribePath)
+
+    validateSchema(unsubscribeJson) should be (Left(unsubscribeJson))
+  }
+
+  test("Incorrect unsubscribe query: additional params"){
+    val unsubscribePath = "../protocol/examples/query/unsubscribe/wrong_unsubscribe__additional_params.json"
+    val unsubscribeJson = getJsonStringFromFile(unsubscribePath)
+
+    validateSchema(unsubscribeJson) shouldBe a [Right[_,PipelineError]]
+  }
+
+  test("Incorrect unsubscribe query: missing channel"){
+    val unsubscribePath = "../protocol/examples/query/unsubscribe/wrong_unsubscribe_missing_channel.json"
+    val unsubscribeJson = getJsonStringFromFile(unsubscribePath)
+
+    validateSchema(unsubscribeJson) shouldBe a [Right[_,PipelineError]]
+  }
+
+  test("Incorrect unsubscribe query: wrong channel"){
+    val unsubscribePath = "../protocol/examples/query/unsubscribe/wrong_unsubscribe_channel.json"
+    val unsubscribeJson = getJsonStringFromFile(unsubscribePath)
+
+    validateSchema(unsubscribeJson) shouldBe a [Right[_,PipelineError]]
+  }
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validator/SchemaValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validator/SchemaValidatorSuite.scala
@@ -16,6 +16,13 @@ object SchemaValidatorSuite extends FunSuite with Matchers {
       jsonStr
     }
 
+  def getJsonStringFromFile(filePath: String): String = {
+      val source = Source.fromFile(filePath);
+      val jsonStr = source.getLines.mkString
+      source.close
+      jsonStr
+    }
+
   /* Test subscribe query without message format*/
   test("Correct subscribe JSON-RPC query"){
     val subscribePath = "../protocol/examples/query/subscribe/subscribe.json"


### PR DESCRIPTION
This PR serves three things: 
  -> Fix the json RPC parsing for a broadcast query
  -> Test SchemaValidation
  -> Test AnswerGenerator :
   For context, AnswerGenerator depends heavily on DbActor. However it could not be injected even with Mockito and similar 
   tools (That's why this PR took so long). This following design pattern can similarly be applied to other components.
     1) Extracting previous object into a `sealed class AnswerGenerator(db : => DBActor)`
     2) Keeps the interface of (object)`AnswerGenerator` intact and hence compatible with legacy code