### PR TITLE
Enhance SonarCloud reports for Android

### DIFF
--- a/fe2-android/app/build.gradle
+++ b/fe2-android/app/build.gradle
@@ -97,11 +97,11 @@ sonarqube {
         property "sonar.organization", "dedis"
         property "sonar.host.url", "https://sonarcloud.io"
         // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
-        property "sonar.junit.reportPaths", "./build/test-results/*/TEST-*.xml"
+        property "sonar.junit.reportPaths", "${project.buildDir}/test-results/testMockDebugUnitTest/,${project.buildDir}/outputs/connected/flavors/mock/"
         // Paths (absolute or relative) to xml files with Android Lint issues.
-        property "sonar.androidLint.reportPaths", "./build/reports/lint-results-*.xml"
+        property "sonar.androidLint.reportPaths", "${project.buildDir}/reports/lint-results-*.xml"
         // Paths to JaCoCo XML coverage report files.
-        property "sonar.coverage.jacoco.xmlReportPaths", "./build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
+        property "sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
     }
 }
 

--- a/fe2-android/app/build.gradle
+++ b/fe2-android/app/build.gradle
@@ -101,9 +101,9 @@ sonarqube {
         property "sonar.organization", "dedis"
         property "sonar.host.url", "https://sonarcloud.io"
         // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
-        property "sonar.junit.reportPaths", "${project.buildDir}/test-results/testMockDebugUnitTest/,${project.buildDir}/outputs/connected/flavors/mock/"
-        // Paths (absolute or relative) to xml files with Android Lint issues.
-        property "sonar.androidLint.reportPaths", "${project.buildDir}/reports/lint-results-*.xml"
+        property "sonar.junit.reportPaths", "${project.buildDir}/test-results/testMockDebugUnitTest/,${project.buildDir}/outputs/androidTest-results/connected/flavors/mock/"
+        // Paths to xml files with Android Lint issues. If the main flavor is changed, this file will have to be changed too.
+        property "sonar.androidLint.reportPaths", "${project.buildDir}/reports/lint-results-prodDebug.xml"
         // Paths to JaCoCo XML coverage report files.
         property "sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
     }

--- a/fe2-android/app/build.gradle
+++ b/fe2-android/app/build.gradle
@@ -68,7 +68,7 @@ android {
             testInstrumentationRunnerArguments clearPackageData: 'true'
         }
 
-        // Flavor used only to compute the coverage of teh tests as it cannot be done with
+        // Flavor used only to compute the coverage of the tests as it cannot be done with
         // the android orchestrator enabled. More informations :
         // https://developer.android.com/training/testing/junit-runner#using-android-test-orchestrator
         cov {
@@ -109,13 +109,14 @@ jacoco {
     toolVersion = "0.8.7"
 }
 
-tasks.withType(Test) {
-    jacoco.excludes = ['jdk.internal.*']
-}
-
 project.gradle.taskGraph.whenReady {
     connectedCovDebugAndroidTest {
         ignoreFailures = true
+    }
+
+    tasks.withType(Test) {
+        jacoco.includeNoLocationClasses = true
+        jacoco.excludes = ['jdk.internal.*']
     }
 }
 
@@ -197,7 +198,7 @@ copy {
     include 'jsonRPC.json'
 }
 
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testCovDebugUnitTest', 'createCovDebugCoverageReport']) {
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testCovReleaseUnitTest', 'createCovDebugCoverageReport']) {
     reports {
         xml.enabled = true
         html.enabled = true
@@ -209,13 +210,25 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testCovDebugUnitTest', 'c
         '**/BuildConfig.*',
         '**/Manifest*.*',
         '**/*Test*.*',
-        'android/**/*.*',
+        'androidx/**/*.*',
         // Exclude Hilt generated classes
-        '**/*Hilt*.*',
-        'hilt_aggregated_deps/**',
-        '**/*_HiltComponents*.class',
-        '**/*_Factory.class',
-        '**/*_MembersInjector.class'
+        '*_*Factory.class',
+        '*_ComponentTreeDeps.class',
+        '*_Factory.class',
+        '*_GeneratedInjector.class',
+        '*_HiltComponents.class',
+        '*_HiltModules.class',
+        '*_HiltModules_BindsModule.class',
+        '*_HiltModules_KeyModule.class',
+        '*_MembersInjector.class',
+        '*_ProvideFactory.class',
+        '*_SingletonC.class',
+        '*_TestComponentDataSupplier.class',
+        'BR.class',
+        'BuildConfig.class',
+        'DataBinderMapperImpl.class',
+        'Hilt_*.class',
+        '_test_*.class'
     ]
     def debugTree = fileTree(dir: "$project.buildDir/intermediates/javac/covDebug/classes", excludes: fileFilter)
     def mainSrc = "$project.projectDir/src/main/java"
@@ -223,7 +236,7 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testCovDebugUnitTest', 'c
     sourceDirectories.setFrom(files([mainSrc]))
     classDirectories.setFrom(files([debugTree]))
     executionData.setFrom(fileTree(dir: project.buildDir, includes: [
-        'outputs/unit_test_code_coverage/covDebugUnitTest/testCovDebugUnitTest.exec',
-        'outputs/code_coverage/covDebugAndroidTest/connected/**/*.ec'
+        'jacoco/*.exec',
+        'outputs/code_coverage/covDebugAndroidTest/connected/**/*.ec',
     ]))
 }

--- a/fe2-android/app/build.gradle
+++ b/fe2-android/app/build.gradle
@@ -88,6 +88,10 @@ android {
             resources.srcDirs += mock.resources.srcDirs
         }
     }
+
+    jacoco {
+        jacocoVersion = "0.8.7"
+    }
 }
 
 sonarqube {
@@ -105,18 +109,9 @@ sonarqube {
     }
 }
 
-jacoco {
-    toolVersion = "0.8.7"
-}
-
 project.gradle.taskGraph.whenReady {
     connectedCovDebugAndroidTest {
         ignoreFailures = true
-    }
-
-    tasks.withType(Test) {
-        jacoco.includeNoLocationClasses = true
-        jacoco.excludes = ['jdk.internal.*']
     }
 }
 
@@ -198,7 +193,7 @@ copy {
     include 'jsonRPC.json'
 }
 
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testCovReleaseUnitTest', 'createCovDebugCoverageReport']) {
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testCovDebugUnitTest', 'createCovDebugCoverageReport']) {
     reports {
         xml.enabled = true
         html.enabled = true

--- a/fe2-android/app/src/debug/AndroidManifest.xml
+++ b/fe2-android/app/src/debug/AndroidManifest.xml
@@ -2,10 +2,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.github.dedis.popstellar">
 
-  <application>
+  <application
+    android:allowBackup="true"
+    android:fullBackupContent="@xml/backup_rules"
+    android:icon="@mipmap/ic_launcher">
     <activity
       android:name="com.github.dedis.popstellar.testutils.fragment.EmptyHiltActivity"
-      android:exported="false"
+      android:exported="true"
       android:multiprocess="true"
       android:taskAffinity="">
       <intent-filter>

--- a/fe2-android/build.gradle
+++ b/fe2-android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.0.3'
         classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.1.1'
         classpath 'com.google.dagger:hilt-android-gradle-plugin:2.38.1'
 


### PR DESCRIPTION
Enhance Jacoco filter to exclude more hilt-generated files.

Fix the issue where the coverage of the unit tests were not computed anymore.
Fix the report paths for Lint report and test results.

Upgrade Android plugin version as it might be a cause of the issue

