### PR TITLE
Make ChirpCard tests use fake time

### DIFF
--- a/fe1-web/components/__tests__/ChirpCard.test.tsx
+++ b/fe1-web/components/__tests__/ChirpCard.test.tsx
@@ -8,8 +8,13 @@ const chirp = new Chirp({
   id: new Hash('1234'),
   text: 'Don\'t panic.',
   sender: new PublicKey('Douglas Adams'),
-  time: new Timestamp(1609455600),
+  time: new Timestamp(1609455600), // 31 December 2020
   likes: 42,
+});
+
+beforeAll(() => {
+  jest.useFakeTimers('modern');
+  jest.setSystemTime(new Date(1620255600000)); // 5 May 2021
 });
 
 describe('ChirpCard', () => {
@@ -21,4 +26,8 @@ describe('ChirpCard', () => {
     );
     expect(obj.toJSON()).toMatchSnapshot();
   });
+});
+
+afterAll(() => {
+  jest.useRealTimers();
 });

--- a/fe1-web/components/__tests__/__snapshots__/ChirpCard.test.tsx.snap
+++ b/fe1-web/components/__tests__/__snapshots__/ChirpCard.test.tsx.snap
@@ -138,7 +138,7 @@ exports[`ChirpCard renders correctly 1`] = `
         dateTime="2020-12-31T23:00:00.000Z"
         title="2020-12-31 23:00"
       >
-        11 months ago
+        4 months ago
       </time>
     </View>
   </View>


### PR DESCRIPTION
Since ChirpCard tests depended on the actual time, I modified them by setting the system time directly.