### PR TITLE
Refactor Key management implementation to make it more object oriented

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/Base64URLData.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/Base64URLData.java
@@ -1,0 +1,38 @@
+package com.github.dedis.popstellar.model.objects.security;
+
+import android.util.Base64;
+
+import java.util.Arrays;
+
+/** Represents a data that can be encoded into a Base64 form */
+public class Base64URLData {
+
+  private static final int BASE64_FLAGS = Base64.NO_WRAP | Base64.URL_SAFE;
+
+  protected final byte[] data;
+
+  public Base64URLData(byte[] data) {
+    this.data = data;
+  }
+
+  public Base64URLData(String data) {
+    this(decode(data));
+  }
+
+  public byte[] getData() {
+    return Arrays.copyOf(data, data.length);
+  }
+
+  /** @return the Base64 - encoded string representation of the data */
+  public String getEncoded() {
+    return encode(data);
+  }
+
+  public static byte[] decode(String data) {
+    return Base64.decode(data, BASE64_FLAGS);
+  }
+
+  private static String encode(byte[] date) {
+    return Base64.encodeToString(date, BASE64_FLAGS);
+  }
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/KeyPair.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/KeyPair.java
@@ -1,0 +1,41 @@
+package com.github.dedis.popstellar.model.objects.security;
+
+import com.google.crypto.tink.PublicKeySign;
+
+import java.security.GeneralSecurityException;
+
+/**
+ * Represent a private/public key pair used for signing data
+ *
+ * <p>This object does not actually store the private key as is it safely stored by another module.
+ */
+public class KeyPair {
+
+  /**
+   * A key pair does not always have access to the actual private key. But it has access to the
+   * functionalities like the signing.
+   */
+  private final PublicKeySign signer;
+
+  private final PublicKey publicKey;
+
+  public KeyPair(PublicKeySign signer, PublicKey publicKey) {
+    this.signer = signer;
+    this.publicKey = publicKey;
+  }
+
+  /**
+   * Signs the given data with the private key of the pair {@link PublicKeySign#sign(byte[])}
+   *
+   * @param data to sign
+   * @return the signature
+   * @throws GeneralSecurityException if an error occurs
+   */
+  public byte[] sign(byte[] data) throws GeneralSecurityException {
+    return signer.sign(data);
+  }
+
+  public PublicKey getPublicKey() {
+    return publicKey;
+  }
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/PoPToken.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/PoPToken.java
@@ -1,0 +1,17 @@
+package com.github.dedis.popstellar.model.objects.security;
+
+/** Represents a PoPToken key pair with its private and public keys */
+public class PoPToken extends KeyPair {
+
+  private final PrivateKey privateKey;
+
+  public PoPToken(PrivateKey privateKey, PublicKey publicKey) {
+    super(privateKey, publicKey);
+
+    this.privateKey = privateKey;
+  }
+
+  public PrivateKey getPrivateKey() {
+    return privateKey;
+  }
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/PrivateKey.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/PrivateKey.java
@@ -1,0 +1,35 @@
+package com.github.dedis.popstellar.model.objects.security;
+
+import com.google.crypto.tink.PublicKeySign;
+import com.google.crypto.tink.subtle.Ed25519Sign;
+
+import java.security.GeneralSecurityException;
+
+/**
+ * A private key that can be used to sign data
+ *
+ * <p>It should never be logged or sent publicly
+ */
+public class PrivateKey extends Base64URLData implements PublicKeySign {
+
+  private final PublicKeySign signer;
+
+  public PrivateKey(byte[] data) throws GeneralSecurityException {
+    super(data);
+    signer = new Ed25519Sign(data);
+  }
+
+  public PrivateKey(String data) throws GeneralSecurityException {
+    super(data);
+    signer = new Ed25519Sign(this.data);
+  }
+
+  public Signature sign(Base64URLData data) throws GeneralSecurityException {
+    return new Signature(sign(data.getData()));
+  }
+
+  @Override
+  public byte[] sign(byte[] data) throws GeneralSecurityException {
+    return signer.sign(data);
+  }
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/PublicKey.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/PublicKey.java
@@ -1,0 +1,36 @@
+package com.github.dedis.popstellar.model.objects.security;
+
+import android.util.Log;
+
+import com.google.crypto.tink.PublicKeyVerify;
+import com.google.crypto.tink.subtle.Ed25519Verify;
+
+import java.security.GeneralSecurityException;
+
+/** A public key that can be used to verify a signature */
+public class PublicKey extends Base64URLData {
+
+  private static final String TAG = PublicKey.class.getSimpleName();
+
+  private final PublicKeyVerify verifier;
+
+  public PublicKey(byte[] data) {
+    super(data);
+    verifier = new Ed25519Verify(data);
+  }
+
+  public PublicKey(String data) {
+    super(data);
+    verifier = new Ed25519Verify(this.data);
+  }
+
+  public boolean verify(Signature signature, Base64URLData data) {
+    try {
+      verifier.verify(signature.getData(), data.getData());
+      return true;
+    } catch (GeneralSecurityException e) {
+      Log.d(TAG, "failed to verify witness signature " + e.getMessage());
+      return false;
+    }
+  }
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/Signature.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/Signature.java
@@ -1,0 +1,17 @@
+package com.github.dedis.popstellar.model.objects.security;
+
+/**
+ * Represents the signature of some date.
+ *
+ * <p>It provides authenticity and integrity of the signed data
+ */
+public class Signature extends Base64URLData {
+
+  public Signature(byte[] data) {
+    super(data);
+  }
+
+  public Signature(String data) {
+    super(data);
+  }
+}


### PR DESCRIPTION
The current implementation relies a lot on String types. This is both unintuitive, and it is hard to understand what really is the String we are reading.

This PR aims to refactor the key system to use different types and make use of the object-oriented possibilities.

This PR closes #664 

Roadmap :

- [x] Create the architecture [1346ff8](https://github.com/dedis/student_21_pop/tree/1346ff80897048febed9bb50121992b419b62403)
- [ ] Test the architecture
- [ ] Create the KeyManager that will be the entry point when retrieving keys
- [ ] Test the KeyManager
- [ ] Add the KeyManager to Hilt
- [ ] Refactor the models to use the new key system
- [ ] Refactor the Wallet implementation to use the new system
- [ ] Use Hilt injection to use the KeyManager object in the rest of the app
- [ ] Test the newly changed code