### PR TITLE
add equals test for ResultObject and refactor Channel prefixes

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Channel.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Channel.scala
@@ -12,8 +12,8 @@ final case class Channel(channel: String) {
    * @return an array of bytes corresponding to the decoded sub-channel name or None if an error occurred
    */
   def decodeSubChannel: Option[Array[Byte]] = channel match {
-    case _ if channel.startsWith(Channel.rootChannelPrefix) =>
-      Try(Base64.getUrlDecoder.decode(channel.substring(Channel.rootChannelPrefix.length).getBytes)) match {
+    case _ if channel.startsWith(Channel.ROOT_CHANNEL_PREFIX) =>
+      Try(Base64.getUrlDecoder.decode(channel.substring(Channel.ROOT_CHANNEL_PREFIX.length).getBytes)) match {
         case Success(value) => Some(value)
         case _ => None
       }
@@ -34,9 +34,9 @@ final case class Channel(channel: String) {
       Hash(Base64Data( c.last))
   }
 
-  def isRootChannel: Boolean = channel == Channel.rootChannel.channel
+  def isRootChannel: Boolean = channel == Channel.ROOT_CHANNEL.channel
 
-  def isSubChannel: Boolean = channel.startsWith(Channel.rootChannelPrefix)
+  def isSubChannel: Boolean = channel.startsWith(Channel.ROOT_CHANNEL_PREFIX)
 
   override def equals(that: Any): Boolean = that match {
     case that: Channel => channel == that.channel
@@ -48,8 +48,8 @@ final case class Channel(channel: String) {
 
 object Channel {
   final val SEPARATOR: Char = '/'
-  final val rootChannel: Channel = Channel(s"${SEPARATOR}root")
-  final val rootChannelPrefix: String = s"${SEPARATOR}root${SEPARATOR}"
+  final val ROOT_CHANNEL: Channel = Channel(s"${SEPARATOR}root")
+  final val ROOT_CHANNEL_PREFIX: String = s"${SEPARATOR}root${SEPARATOR}"
   private final def channelRegex: String = "^/root(/[^/]+)*$"
   final val LAO_DATA_LOCATION: String = s"${SEPARATOR}data"
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/LaoHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/LaoHandler.scala
@@ -40,7 +40,7 @@ case object LaoHandler extends MessageHandler {
       case Some(message: Message) =>
         val data: CreateLao = message.decodedData.get.asInstanceOf[CreateLao]
         // we are using the lao id instead of the message_id at lao creation
-        val channel: Channel = Channel(s"${Channel.rootChannelPrefix}${data.id}")
+        val channel: Channel = Channel(s"${Channel.ROOT_CHANNEL_PREFIX}${data.id}")
         //this prevents a write-through to an already existing LaoId
         val askCreate = (dbActor ? DbActor.CreateChannel(channel, ObjectType.LAO))
         Await.result(askCreate, duration) match {

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/SocialMediaHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/SocialMediaHandler.scala
@@ -41,7 +41,7 @@ case object SocialMediaHandler extends MessageHandler {
         val channelChirp: Channel = rpcMessage.getParamsChannel
         channelChirp.decodeSubChannel match {
           case(Some(lao_id)) => {
-            val broadcastChannel: Channel = Channel(Channel.rootChannelPrefix + Base64Data.encode(lao_id) + Channel.SOCIAL_MEDIA_POSTS_PREFIX)
+            val broadcastChannel: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + Base64Data.encode(lao_id) + Channel.SOCIAL_MEDIA_POSTS_PREFIX)
             rpcMessage.getParamsMessage match {
               case Some(params) => {
                 // we can't get the message_id as a Base64Data, it is a Hash

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/network/JsonRpcRequestSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/network/JsonRpcRequestSuite.scala
@@ -13,7 +13,7 @@ class JsonRpcRequestSuite extends FunSuite with Matchers {
     final val messageEx: Message = MessageExample.MESSAGE
     final val messageLao: Message = MessageExample.MESSAGE_CREATELAO
     private final val laoId: String = "abcd"
-    private final val channelEx: Channel = Channel(Channel.rootChannelPrefix + laoId)
+    private final val channelEx: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + laoId)
     private final val params: Params = new Params(channelEx)
     private final val paramsWithMessage: ParamsWithMessage = new ParamsWithMessage(channelEx, messageEx)
     private final val rpc: String = "rpc"

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/network/ResultObjectSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/network/ResultObjectSuite.scala
@@ -24,4 +24,15 @@ class ResultObjectSuite extends FunSuite with Matchers {
         obj.isIntResult should equal(true)
         obj2.isIntResult should equal (false)
     }
+
+    test("equals works"){
+        val obj: ResultObject = new ResultObject(1)
+        val obj2: ResultObject = new ResultObject(List.empty)
+        val obj3: ResultObject = new ResultObject(1)
+        val obj4: ResultObject = new ResultObject(List.empty)
+
+        obj.equals(obj3) should equal(true)
+        obj2.equals(obj4) should equal(true)
+        obj2.equals(obj) should equal (false)
+    }
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/objects/ChannelSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/objects/ChannelSuite.scala
@@ -5,7 +5,7 @@ import ch.epfl.pop.model.objects.Channel
 
 class ChannelSuite extends FunSuite with Matchers {
   test("Root/Sub channel test (1)") {
-    val channel = Channel.rootChannel
+    val channel = Channel.ROOT_CHANNEL
     channel.isRootChannel should be(true)
     channel.isSubChannel should be(false)
   }
@@ -15,7 +15,7 @@ class ChannelSuite extends FunSuite with Matchers {
   }
 
   test("Root/Sub channel test (3)") {
-    def channel = Channel(Channel.rootChannelPrefix)
+    def channel = Channel(Channel.ROOT_CHANNEL_PREFIX)
     an [IllegalArgumentException] shouldBe thrownBy(channel)
 
   }
@@ -36,13 +36,13 @@ class ChannelSuite extends FunSuite with Matchers {
   }
 
   test("Slash single child channel test") {
-    def channel = Channel(Channel.rootChannelPrefix + "channelID")
+    def channel = Channel(Channel.ROOT_CHANNEL_PREFIX + "channelID")
     val expected = Hash(Base64Data("channelID"))
     noException shouldBe thrownBy(channel)
     channel.extractChildChannel should equal(expected)
   }
   test("Root empty child channel test") {
-    def channel = Channel.rootChannel
+    def channel = Channel.ROOT_CHANNEL
     val expected = Hash(Base64Data("root"))
     channel.extractChildChannel should equal(expected)
   }
@@ -60,7 +60,7 @@ class ChannelSuite extends FunSuite with Matchers {
   }
   test("LaoId extraction channel test") {
     val laoId = "base64_lao_id";
-    def channel = Channel(Channel.rootChannelPrefix + Base64Data.encode(laoId))
+    def channel = Channel(Channel.ROOT_CHANNEL_PREFIX + Base64Data.encode(laoId))
     val expected = laoId.getBytes()
     noException shouldBe thrownBy(channel)
     channel.decodeSubChannel.get should equal(expected)
@@ -68,7 +68,7 @@ class ChannelSuite extends FunSuite with Matchers {
   
   test("Real LaoId extraction channel test") {
     val laoId = "mEKXWFCMwb";
-    def channel = Channel(Channel.rootChannelPrefix + Base64Data.encode(laoId))
+    def channel = Channel(Channel.ROOT_CHANNEL_PREFIX + Base64Data.encode(laoId))
     val expected = laoId.getBytes()
 
     noException shouldBe thrownBy(channel)
@@ -83,7 +83,7 @@ class ChannelSuite extends FunSuite with Matchers {
 
   test("Bad LaoId: not encoded in base64 extraction channel test (2)") {
     val laoId = "base64_lao_id"; // Not encoded in BASE64
-    def channel = Channel(Channel.rootChannelPrefix + laoId)
+    def channel = Channel(Channel.ROOT_CHANNEL_PREFIX + laoId)
     val expected = None
     noException shouldBe thrownBy(channel)
     channel.decodeSubChannel should equal (expected)


### PR DESCRIPTION
need to test broadcast functionality with front-end, but should be good otherwise