### PR TITLE
Force the encoding to UTF-8 for local files copy

### DIFF
--- a/fe2-android/app/build.gradle
+++ b/fe2-android/app/build.gradle
@@ -198,6 +198,7 @@ copy {
     // This modification is done to force the use of local files when loading json sub-schemas ($ref)
     // https://json-schema.org/understanding-json-schema/structuring.html#base-uri
 
+    filteringCharset = 'UTF-8'
     filter {
         String line -> line.replaceAll("https://raw\\.githubusercontent\\.com/dedis/[a-zA-Z0-9_-]+/master/", "resource:/")
     }


### PR DESCRIPTION
Fix a bug where unicode characters were corrupted by the local files copy because of the default local encoding.
