### PR TITLE
Fix election id generation on the web front-end

### DIFF
--- a/fe1-web/model/network/method/message/data/election/SetupElection.ts
+++ b/fe1-web/model/network/method/message/data/election/SetupElection.ts
@@ -81,7 +81,7 @@ export class SetupElection implements MessageData {
     const lao: Lao = OpenedLaoStore.get();
 
     const expectedHash = Hash.fromStringArray(
-      EventTags.ELECTION, lao.id.toString(), lao.creation.toString(), msg.name,
+      EventTags.ELECTION, lao.id.toString(), msg.created_at.toString(), msg.name,
     );
     if (!expectedHash.equals(msg.id)) {
       throw new ProtocolError("Invalid 'id' parameter encountered during 'SetupElection':"

--- a/fe1-web/network/MessageApi.ts
+++ b/fe1-web/network/MessageApi.ts
@@ -243,7 +243,7 @@ export function requestCreateElection(
   const message = new SetupElection({
     lao: currentLao.id,
     id: Hash.fromStringArray(
-      EventTags.ELECTION, currentLao.id.toString(), currentLao.creation.toString(), name,
+      EventTags.ELECTION, currentLao.id.toString(), time.toString(), name,
     ),
     name: name,
     version: version,


### PR DESCRIPTION
The web front-end generates election ids based on the creation time of the LAO instead of the election's.