### PR TITLE
Update build configuration for scala

### DIFF
--- a/be2-scala/build.sbt
+++ b/be2-scala/build.sbt
@@ -7,7 +7,7 @@ name := "pop"
 
 version := "0.1"
 
-scalaVersion := "2.13.5"
+scalaVersion := "2.13.7"
 
 
 //Create task to copy the protocol folder to resources
@@ -30,9 +30,11 @@ copyProtocolTask := {
         }
     }
 }
-//Add task to compile time
+//Add the copyProtocolTask to compile time
 (Compile/ compile) := ((Compile/ compile) dependsOn copyProtocolTask).value
 resourceDirectory in (Compile, packageBin) := file(".") / "./src/main/resources"
+//Make resourceDirectory setting global to remove sbt warning
+(Global / excludeLintKeys) += resourceDirectory
 
 //Setup main calass task context/confiuration
 mainClass in (Compile, run) := Some("ch.epfl.pop.Server")
@@ -46,7 +48,7 @@ lazy val scoverageSettings = Seq(
 
 
 
-scapegoatVersion in ThisBuild := "1.4.8"
+scapegoatVersion in ThisBuild := "1.4.11"
 scapegoatReports := Seq("xml")
 
 // temporarily report scapegoat errors as warnings, to avoid broken builds
@@ -61,7 +63,7 @@ sonarProperties := Map(
   "sonar.tests" -> "src/test/scala",
 
   "sonar.sourceEncoding" -> "UTF-8",
-  "sonar.scala.version" -> "2.13.5",
+  "sonar.scala.version" -> "2.13.7",
   // Paths to the test and coverage reports
   "sonar.scala.coverage.reportPaths" -> "./target/scala-2.13/scoverage-report/scoverage.xml",
   "sonar.scala.scapegoat.reportPaths" -> "./target/scala-2.13/scapegoat-report/scapegoat.xml"

--- a/be2-scala/project/build.properties
+++ b/be2-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.13
+sbt.version = 1.6.0

--- a/be2-scala/project/plugins.sbt
+++ b/be2-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
-addSbtPlugin("com.sksamuel.scapegoat" % "sbt-scapegoat" % "1.1.0")
+addSbtPlugin("com.sksamuel.scapegoat" % "sbt-scapegoat" % "1.1.1")
 addSbtPlugin("com.sonar-scala" % "sbt-sonar" % "2.3.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")


### PR DESCRIPTION
Update build configuration to use latest sbt, scapegoat and scala 2.13.7. And update buidl.sbt to resolve compatiibility conflicts between sbt compiler pluging and libraries.