### PR TITLE
Follow ourselves automatically

### DIFF
--- a/fe1-web/ingestion/handlers/RollCall.ts
+++ b/fe1-web/ingestion/handlers/RollCall.ts
@@ -133,7 +133,7 @@ function handleRollCallCloseMessage(msg: ExtendedMessage): boolean {
 
       // If we had a token in this roll call, we subscribe to our own social media channel
       if (token && hasToken) {
-        subscribeToChannel(getUserSocialChannel(lao.id, token.publicKey))
+        await subscribeToChannel(getUserSocialChannel(lao.id, token.publicKey))
           .catch((err) => {
             console.error(`Could not subscribe to our own social channel ${token.publicKey}, error:`,
               err);

--- a/fe1-web/ingestion/handlers/RollCall.ts
+++ b/fe1-web/ingestion/handlers/RollCall.ts
@@ -130,6 +130,15 @@ function handleRollCallCloseMessage(msg: ExtendedMessage): boolean {
       const token = await Wallet.generateToken(lao.id, rc.id);
       const hasToken = rc.containsToken(token);
       aDispatch(setLaoLastRollCall(lao.id, rc.id, hasToken));
+
+      // If we had a token in this roll call, we subscribe to our own social media channel
+      if (token && hasToken) {
+        subscribeToChannel(getUserSocialChannel(lao.id, token.publicKey))
+          .catch((err) => {
+            console.error(`Could not subscribe to our own social channel ${token.publicKey}, error:`,
+              err);
+          });
+      }
     } catch (err) {
       console.debug(err);
     }


### PR DESCRIPTION
At the end of a Roll Call, you follow yourself automatically if you participated in it.
You can still see your profile in Search (under "Attendees of last roll call") though, but this can be easily fixed once we store Follows of the user. I don't know if we will do it until the end of the project, but it's not a problem since subscribing 2 times to the same channel doesn't do anything.