### PR TITLE
Fix BE2 build

### DIFF
--- a/be2-scala/build.sbt
+++ b/be2-scala/build.sbt
@@ -8,12 +8,16 @@ version := "0.1"
 
 scalaVersion := "2.13.7"
 
+//Reload changes automatically
 Global / onChangedBuildSource := ReloadOnSourceChanges
 Global / cancelable := true
+
+//Fork run task in compile scope
 Compile/ run / fork := true
 Compile/ run / connectInput := true
 Compile/ run / javaOptions += "-Dscala.config=src/main/scala/ch/epfl/pop/config"
 
+//Make test execution synchronized
 Test/ test/ parallelExecution := false
 
 //Create task to copy the protocol folder to resources

--- a/be2-scala/build.sbt
+++ b/be2-scala/build.sbt
@@ -8,7 +8,14 @@ version := "0.1"
 
 scalaVersion := "2.13.7"
 
-parallelExecution in ThisBuild := false
+Global / onChangedBuildSource := ReloadOnSourceChanges
+Global / cancelable := true
+Compile/ run / fork := true
+Compile/ run / connectInput := true
+Compile/ run / javaOptions += "-Dscala.config=src/main/scala/ch/epfl/pop/config"
+
+Test/ test/ parallelExecution := false
+
 //Create task to copy the protocol folder to resources
 lazy val copyProtocolTask = taskKey[Unit]("Copy protocol to resources")
 copyProtocolTask := {
@@ -31,27 +38,27 @@ copyProtocolTask := {
 }
 //Add the copyProtocolTask to compile time
 (Compile/ compile) := ((Compile/ compile) dependsOn copyProtocolTask).value
-resourceDirectory in (Compile, packageBin) := file(".") / "./src/main/resources"
+(Compile /packageBin / resourceDirectory) := file(".") / "./src/main/resources"
 //Make resourceDirectory setting global to remove sbt warning
 (Global / excludeLintKeys) += resourceDirectory
 
 //Setup main calass task context/confiuration
-mainClass in (Compile, run) := Some("ch.epfl.pop.Server")
-mainClass in (Compile, packageBin) := Some("ch.epfl.pop.Server")
+Compile/ run/ mainClass := Some("ch.epfl.pop.Server")
+Compile/ packageBin/ mainClass := Some("ch.epfl.pop.Server")
 
 lazy val scoverageSettings = Seq(
-  coverageEnabled in Compile := true,
-  coverageEnabled in Test := true,
-  coverageEnabled in packageBin := false,
+  Compile/ coverageEnabled  := true,
+  Test/ coverageEnabled  := true,
+  packageBin/ coverageEnabled  := false,
 )
 
 
 
-scapegoatVersion in ThisBuild := "1.4.11"
+ThisBuild/ scapegoatVersion := "1.4.11"
 scapegoatReports := Seq("xml")
 
 // temporarily report scapegoat errors as warnings, to avoid broken builds
-scalacOptions in Scapegoat += "-P:scapegoat:overrideLevels:all=Warning"
+Scapegoat/ scalacOptions += "-P:scapegoat:overrideLevels:all=Warning"
 
 // Configure Sonar
 sonarProperties := Map(
@@ -68,7 +75,7 @@ sonarProperties := Map(
   "sonar.scala.scapegoat.reportPaths" -> "./target/scala-2.13/scapegoat-report/scapegoat.xml"
 )
 
-assemblyMergeStrategy in assembly := {
+assembly/ assemblyMergeStrategy  := {
     case PathList("module-info.class") => MergeStrategy.discard
     case PathList("reference.conf") => MergeStrategy.concat
     case PathList("META-INF","MANIFEST.MF") => MergeStrategy.discard

--- a/be2-scala/project/build.properties
+++ b/be2-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.6.0
+sbt.version = 1.6.1


### PR DESCRIPTION
The following changes are required in order to run properly the BE2 server with the new sbt version since some utilities were deprecated and default tasks were upgraded.  