### PR TITLE
Enter attendees manually

### DIFF
--- a/fe1-web/components/ConfirmModal.tsx
+++ b/fe1-web/components/ConfirmModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   View, Modal, Text,
@@ -6,9 +6,11 @@ import {
 import STRINGS from 'res/strings';
 import styles from 'styles/stylesheets/modal';
 import WideButtonView from './WideButtonView';
+import TextInputLine from './TextInputLine';
 
 /**
  * A modal used to ask for the confirmation or cancellation of the user.
+ * It can also ask for a user input.
  */
 
 const ConfirmModal = (props: IPropTypes) => {
@@ -19,6 +21,8 @@ const ConfirmModal = (props: IPropTypes) => {
   const { buttonConfirmText } = props;
   const { buttonCancelText } = props;
   const { onConfirmPress } = props;
+  const { hasTextInput } = props;
+  const [textInput, setTextInput] = useState('');
 
   return (
     <Modal
@@ -30,14 +34,18 @@ const ConfirmModal = (props: IPropTypes) => {
           <Text style={styles.modalTitle}>{title}</Text>
         </View>
         <Text style={styles.modalDescription}>{description}</Text>
+        { hasTextInput ? <TextInputLine onChangeText={(input) => setTextInput(input)} /> : null }
         <View style={styles.buttonView}>
           <WideButtonView
             title={buttonConfirmText}
-            onPress={() => onConfirmPress()}
+            onPress={() => onConfirmPress(textInput)}
           />
           <WideButtonView
             title={buttonCancelText}
-            onPress={() => setVisibility(!visibility)}
+            onPress={() => {
+              setVisibility(!visibility);
+              setTextInput('');
+            }}
           />
         </View>
       </View>
@@ -53,6 +61,7 @@ const propTypes = {
   buttonCancelText: PropTypes.string,
   buttonConfirmText: PropTypes.string,
   onConfirmPress: PropTypes.func.isRequired,
+  hasTextInput: PropTypes.bool,
 };
 
 ConfirmModal.propTypes = propTypes;
@@ -60,6 +69,7 @@ ConfirmModal.propTypes = propTypes;
 ConfirmModal.defaultProps = {
   buttonCancelText: STRINGS.general_button_cancel,
   buttonConfirmText: STRINGS.general_button_confirm,
+  hasTextInput: false,
 };
 
 type IPropTypes = {
@@ -70,6 +80,7 @@ type IPropTypes = {
   buttonCancelText: string,
   buttonConfirmText: string,
   onConfirmPress: Function,
+  hasTextInput: boolean,
 };
 
 export default ConfirmModal;

--- a/fe1-web/components/ConfirmModal.tsx
+++ b/fe1-web/components/ConfirmModal.tsx
@@ -22,6 +22,7 @@ const ConfirmModal = (props: IPropTypes) => {
   const { buttonCancelText } = props;
   const { onConfirmPress } = props;
   const { hasTextInput } = props;
+  const { textInputPlaceholder } = props;
   const [textInput, setTextInput] = useState('');
 
   return (
@@ -34,7 +35,13 @@ const ConfirmModal = (props: IPropTypes) => {
           <Text style={styles.modalTitle}>{title}</Text>
         </View>
         <Text style={styles.modalDescription}>{description}</Text>
-        { hasTextInput ? <TextInputLine onChangeText={(input) => setTextInput(input)} /> : null }
+        { hasTextInput
+          ? (
+            <TextInputLine
+              onChangeText={(input) => setTextInput(input)}
+              placeholder={textInputPlaceholder}
+            />
+          ) : null }
         <View style={styles.buttonView}>
           <WideButtonView
             title={buttonConfirmText}
@@ -62,6 +69,7 @@ const propTypes = {
   buttonConfirmText: PropTypes.string,
   onConfirmPress: PropTypes.func.isRequired,
   hasTextInput: PropTypes.bool,
+  textInputPlaceholder: PropTypes.string,
 };
 
 ConfirmModal.propTypes = propTypes;
@@ -70,6 +78,7 @@ ConfirmModal.defaultProps = {
   buttonCancelText: STRINGS.general_button_cancel,
   buttonConfirmText: STRINGS.general_button_confirm,
   hasTextInput: false,
+  textInputPlaceholder: '',
 };
 
 type IPropTypes = {
@@ -81,6 +90,7 @@ type IPropTypes = {
   buttonConfirmText: string,
   onConfirmPress: Function,
   hasTextInput: boolean,
+  textInputPlaceholder: string,
 };
 
 export default ConfirmModal;

--- a/fe1-web/components/__tests__/ConfirmModal.test.tsx
+++ b/fe1-web/components/__tests__/ConfirmModal.test.tsx
@@ -29,6 +29,20 @@ describe('ConfirmModal', () => {
     expect(component).toMatchSnapshot();
   });
 
+  it('renders correctly with text input', () => {
+    const component = render(
+      <ConfirmModal
+        visibility
+        setVisibility={setModalIsVisible}
+        title={TITLE}
+        description={DESCRIPTION}
+        onConfirmPress={() => onConfirmPress()}
+        hasTextInput
+      />,
+    ).toJSON();
+    expect(component).toMatchSnapshot();
+  });
+
   it('disappears correctly after dismissing', () => {
     const { getByText, toJSON } = render(
       <ConfirmModal
@@ -59,5 +73,24 @@ describe('ConfirmModal', () => {
     const confirmButton = getByText(CONFIRM);
     fireEvent.press(confirmButton);
     expect(onConfirmPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onConfirmPress with textInput', () => {
+    const { getByText, getByDisplayValue } = render(
+      <ConfirmModal
+        visibility
+        setVisibility={setModalIsVisible}
+        title={TITLE}
+        description={DESCRIPTION}
+        onConfirmPress={onConfirmPress}
+        buttonConfirmText={CONFIRM}
+        hasTextInput
+      />,
+    );
+    const textInput = getByDisplayValue('');
+    fireEvent.changeText(textInput, 'input');
+    const confirmButton = getByText(CONFIRM);
+    fireEvent.press(confirmButton);
+    expect(onConfirmPress).toHaveBeenCalledWith('input');
   });
 });

--- a/fe1-web/components/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
+++ b/fe1-web/components/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
@@ -363,3 +363,200 @@ exports[`ConfirmModal renders correctly 1`] = `
   </View>
 </Modal>
 `;
+
+exports[`ConfirmModal renders correctly with text input 1`] = `
+<Modal
+  hardwareAccelerated={false}
+  transparent={true}
+  visible={true}
+>
+  <View
+    style={
+      Object {
+        "backgroundColor": "white",
+        "borderRadius": 10,
+        "borderWidth": 1,
+        "margin": "auto",
+        "width": 550,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "borderBottomWidth": 1,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "alignSelf": "flex-start",
+            "fontSize": 25,
+            "fontWeight": "bold",
+            "marginHorizontal": 10,
+            "padding": 20,
+            "paddingLeft": 10,
+            "textAlign": "center",
+          }
+        }
+      >
+        Title
+      </Text>
+    </View>
+    <Text
+      style={
+        Object {
+          "alignSelf": "flex-start",
+          "fontSize": 20,
+          "marginHorizontal": 10,
+          "padding": 20,
+          "paddingLeft": 10,
+          "textAlign": "left",
+        }
+      }
+    >
+      Description
+    </Text>
+    <TextInput
+      defaultValue=""
+      onChangeText={[Function]}
+      placeholder=""
+      selectTextOnFocus={true}
+      style={
+        Object {
+          "borderBottomWidth": 2,
+          "fontSize": 25,
+          "marginHorizontal": 50,
+          "marginVertical": 20,
+          "textAlign": "center",
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "alignSelf": "center",
+          "flexDirection": "row",
+          "paddingBottom": 20,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "marginHorizontal": 50,
+            "marginVertical": 10,
+          }
+        }
+      >
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          nativeID="animatedComponent"
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {},
+              ]
+            }
+          >
+            <Text
+              disabled={false}
+              style={
+                Array [
+                  Object {
+                    "color": "#007AFF",
+                    "fontSize": 18,
+                    "margin": 8,
+                    "textAlign": "center",
+                  },
+                ]
+              }
+            >
+              Confirm
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "marginHorizontal": 50,
+            "marginVertical": 10,
+          }
+        }
+      >
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            Object {
+              "disabled": false,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          nativeID="animatedComponent"
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {},
+              ]
+            }
+          >
+            <Text
+              disabled={false}
+              style={
+                Array [
+                  Object {
+                    "color": "#007AFF",
+                    "fontSize": 18,
+                    "margin": 8,
+                    "textAlign": "center",
+                  },
+                ]
+              }
+            >
+              Cancel
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</Modal>
+`;

--- a/fe1-web/parts/lao/organizer/RollCallOpened.tsx
+++ b/fe1-web/parts/lao/organizer/RollCallOpened.tsx
@@ -19,6 +19,7 @@ import {
 import { makeCurrentLao, OpenedLaoStore } from 'store';
 import { useToast } from 'react-native-toast-notifications';
 import { useSelector } from 'react-redux';
+import ConfirmModal from '../../../components/ConfirmModal';
 
 const styles = StyleSheet.create({
   viewCenter: {
@@ -36,6 +37,7 @@ const RollCallOpened = () => {
   const { rollCallID, time } = route.params;
   const navigation = useNavigation();
   const [attendees, updateAttendees] = useState(new Set<string>());
+  const [inputModalIsVisible, setInputModalIsVisible] = useState(false);
   const toast = useToast();
   const laoSelect = makeCurrentLao();
   const lao = useSelector(laoSelect);
@@ -61,6 +63,19 @@ const RollCallOpened = () => {
       if (!attendees.has(data)) {
         updateAttendees((prev) => new Set<string>(prev.add(data)));
         toast.show(STRINGS.roll_call_scan_participant, {
+          type: 'success',
+          placement: 'top',
+          duration: FOUR_SECONDS,
+        });
+      }
+    }
+  };
+
+  const handleEnterManually = (input: string) => {
+    if (input) {
+      if (!attendees.has(input)) {
+        updateAttendees((prev) => new Set<string>(prev.add(input)));
+        toast.show(STRINGS.roll_call_participant_added, {
           type: 'success',
           placement: 'top',
           duration: FOUR_SECONDS,
@@ -103,7 +118,20 @@ const RollCallOpened = () => {
           title={STRINGS.roll_call_scan_close}
           onPress={() => onCloseRollCall()}
         />
+        <WideButtonView
+          title={STRINGS.roll_call_add_attendee_manually}
+          onPress={() => setInputModalIsVisible(true)}
+        />
       </View>
+      <ConfirmModal
+        visibility={inputModalIsVisible}
+        setVisibility={setInputModalIsVisible}
+        title={STRINGS.roll_call_modal_add_attendee}
+        description={STRINGS.roll_call_modal_enter_token}
+        onConfirmPress={handleEnterManually}
+        buttonConfirmText={STRINGS.general_add}
+        hasTextInput
+      />
     </View>
   );
 };

--- a/fe1-web/parts/lao/organizer/RollCallOpened.tsx
+++ b/fe1-web/parts/lao/organizer/RollCallOpened.tsx
@@ -9,6 +9,7 @@ import QrReader from 'react-qr-reader';
 import STRINGS from 'res/strings';
 import TextBlock from 'components/TextBlock';
 import WideButtonView from 'components/WideButtonView';
+import ConfirmModal from 'components/ConfirmModal';
 import { Badge } from 'react-native-elements';
 import { useNavigation } from '@react-navigation/native';
 import { useRoute } from '@react-navigation/core';
@@ -19,7 +20,11 @@ import {
 import { makeCurrentLao, OpenedLaoStore } from 'store';
 import { useToast } from 'react-native-toast-notifications';
 import { useSelector } from 'react-redux';
-import ConfirmModal from '../../../components/ConfirmModal';
+
+/**
+ * UI for a currently opened roll call. From there, the organizer can scan attendees or add them
+ * manually. At the end, he can close it by pressing on the close button.
+ */
 
 const styles = StyleSheet.create({
   viewCenter: {
@@ -31,6 +36,7 @@ const styles = StyleSheet.create({
 });
 
 const FOUR_SECONDS = 4000;
+const base64Matcher = new RegExp('^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})([=]{1,2})?$');
 
 const RollCallOpened = () => {
   const route = useRoute();
@@ -72,7 +78,7 @@ const RollCallOpened = () => {
   };
 
   const handleEnterManually = (input: string) => {
-    if (input) {
+    if (base64Matcher.test(input)) {
       if (!attendees.has(input)) {
         updateAttendees((prev) => new Set<string>(prev.add(input)));
         toast.show(STRINGS.roll_call_participant_added, {
@@ -81,6 +87,12 @@ const RollCallOpened = () => {
           duration: FOUR_SECONDS,
         });
       }
+    } else {
+      toast.show(STRINGS.roll_call_invalid_token, {
+        type: 'danger',
+        placement: 'top',
+        duration: FOUR_SECONDS,
+      });
     }
   };
 

--- a/fe1-web/parts/lao/organizer/RollCallOpened.tsx
+++ b/fe1-web/parts/lao/organizer/RollCallOpened.tsx
@@ -36,7 +36,7 @@ const styles = StyleSheet.create({
 });
 
 const FOUR_SECONDS = 4000;
-const base64Matcher = new RegExp('^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})([=]{1,2})?$');
+const tokenMatcher = new RegExp('^[A-Za-z0-9_-]{43}=$');
 
 const RollCallOpened = () => {
   const route = useRoute();
@@ -76,7 +76,7 @@ const RollCallOpened = () => {
   };
 
   const handleEnterManually = (input: string) => {
-    if (base64Matcher.test(input)) {
+    if (tokenMatcher.test(input)) {
       addAttendeeAndShowToast(input, STRINGS.roll_call_participant_added);
     } else {
       toast.show(STRINGS.roll_call_invalid_token, {

--- a/fe1-web/parts/lao/organizer/RollCallOpened.tsx
+++ b/fe1-web/parts/lao/organizer/RollCallOpened.tsx
@@ -64,29 +64,20 @@ const RollCallOpened = () => {
     console.error(err);
   };
 
-  const handleScan = (data: string | null) => {
-    if (data) {
-      if (!attendees.has(data)) {
-        updateAttendees((prev) => new Set<string>(prev.add(data)));
-        toast.show(STRINGS.roll_call_scan_participant, {
-          type: 'success',
-          placement: 'top',
-          duration: FOUR_SECONDS,
-        });
-      }
+  const addAttendeeAndShowToast = (attendee: string, toastMessage: string) => {
+    if (!attendees.has(attendee)) {
+      updateAttendees((prev) => new Set<string>(prev.add(attendee)));
+      toast.show(toastMessage, {
+        type: 'success',
+        placement: 'top',
+        duration: FOUR_SECONDS,
+      });
     }
   };
 
   const handleEnterManually = (input: string) => {
     if (base64Matcher.test(input)) {
-      if (!attendees.has(input)) {
-        updateAttendees((prev) => new Set<string>(prev.add(input)));
-        toast.show(STRINGS.roll_call_participant_added, {
-          type: 'success',
-          placement: 'top',
-          duration: FOUR_SECONDS,
-        });
-      }
+      addAttendeeAndShowToast(input, STRINGS.roll_call_participant_added);
     } else {
       toast.show(STRINGS.roll_call_invalid_token, {
         type: 'danger',
@@ -121,7 +112,11 @@ const RollCallOpened = () => {
         <TextBlock text={STRINGS.roll_call_scan_description} />
         <QrReader
           delay={300}
-          onScan={(data) => handleScan(data)}
+          onScan={(data) => {
+            if (data) {
+              addAttendeeAndShowToast(data, STRINGS.roll_call_scan_participant);
+            }
+          }}
           onError={handleError}
           style={{ width: '30%' }}
         />
@@ -143,6 +138,7 @@ const RollCallOpened = () => {
         onConfirmPress={handleEnterManually}
         buttonConfirmText={STRINGS.general_add}
         hasTextInput
+        textInputPlaceholder={STRINGS.roll_call_attendee_token_placeholder}
       />
     </View>
   );

--- a/fe1-web/parts/lao/organizer/__tests__/RollCallOpened.test.tsx
+++ b/fe1-web/parts/lao/organizer/__tests__/RollCallOpened.test.tsx
@@ -124,7 +124,7 @@ describe('RollCallOpened', () => {
     });
   });
 
-  it('shows toast when trying to add an incorrect token', async () => {
+  it('shows toast when trying to add an incorrect token manually', async () => {
     (useRoute as jest.Mock).mockReturnValue({
       name: STRINGS.roll_call_open,
       params: { rollCallID: rollCallId, time: time },

--- a/fe1-web/parts/lao/organizer/__tests__/RollCallOpened.test.tsx
+++ b/fe1-web/parts/lao/organizer/__tests__/RollCallOpened.test.tsx
@@ -16,6 +16,7 @@ import { fireScan as fakeQrReaderScan } from 'react-qr-reader';
 import RollCallOpened from '../RollCallOpened';
 
 export const mockPublicKey = new PublicKey(keyPair.publicKey);
+const mockPublicKey2 = new PublicKey(keyPair.publicKey2);
 
 const org = mockPublicKey;
 const TIMESTAMP = 1609455600;
@@ -38,7 +39,7 @@ jest.mock('@react-navigation/core');
 jest.mock('react-qr-reader');
 jest.mock('network/MessageApi');
 
-const mockToastShow = jest.fn();
+let mockToastShow = jest.fn();
 jest.mock('react-native-toast-notifications', () => ({
   useToast: () => ({
     show: mockToastShow,
@@ -66,6 +67,10 @@ jest.mock('model/objects/wallet/Token.ts', () => ({
   generateToken: jest.fn(() => Promise.resolve(mockPopToken)),
 }));
 
+beforeEach(() => {
+  mockToastShow = jest.fn();
+});
+
 describe('RollCallOpened', () => {
   const useSelectorMock = jest.spyOn(reactRedux, 'useSelector');
   useSelectorMock.mockReturnValue({ mockLao });
@@ -83,7 +88,7 @@ describe('RollCallOpened', () => {
     });
   });
 
-  it('can scan attendees', async () => {
+  it('shows toast when scanning attendees', async () => {
     (useRoute as jest.Mock).mockReturnValue({
       name: STRINGS.roll_call_open,
       params: { rollCallID: rollCallId, time: time },
@@ -100,7 +105,45 @@ describe('RollCallOpened', () => {
     });
   });
 
-  it('close correctly with no attendee', async () => {
+  it('shows toast when adding an attendee manually', async () => {
+    (useRoute as jest.Mock).mockReturnValue({
+      name: STRINGS.roll_call_open,
+      params: { rollCallID: rollCallId, time: time },
+    });
+    const { getByText, getByPlaceholderText } = render(
+      <RollCallOpened />,
+    );
+    const addAttendeeButton = getByText(STRINGS.roll_call_add_attendee_manually);
+    fireEvent.press(addAttendeeButton);
+    const textInput = getByPlaceholderText(STRINGS.roll_call_attendee_token_placeholder);
+    fireEvent.changeText(textInput, mockPublicKey2.valueOf());
+    const confirmButton = getByText(STRINGS.general_add);
+    fireEvent.press(confirmButton);
+    await waitFor(() => {
+      expect(mockToastShow).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows toast when trying to add an incorrect token', async () => {
+    (useRoute as jest.Mock).mockReturnValue({
+      name: STRINGS.roll_call_open,
+      params: { rollCallID: rollCallId, time: time },
+    });
+    const { getByText, getByPlaceholderText } = render(
+      <RollCallOpened />,
+    );
+    const addAttendeeButton = getByText(STRINGS.roll_call_add_attendee_manually);
+    fireEvent.press(addAttendeeButton);
+    const textInput = getByPlaceholderText(STRINGS.roll_call_attendee_token_placeholder);
+    fireEvent.changeText(textInput, 'data');
+    const confirmButton = getByText(STRINGS.general_add);
+    fireEvent.press(confirmButton);
+    await waitFor(() => {
+      expect(mockToastShow).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('closes correctly with no attendee', async () => {
     (useRoute as jest.Mock).mockReturnValue({
       name: STRINGS.roll_call_open,
       params: { rollCallID: rollCallId, time: time },
@@ -117,7 +160,7 @@ describe('RollCallOpened', () => {
     });
   });
 
-  it('close correctly with two attendees', async () => {
+  it('closes correctly with two attendees', async () => {
     (useRoute as jest.Mock).mockReturnValue({
       name: STRINGS.roll_call_open,
       params: { rollCallID: rollCallId, time: time },

--- a/fe1-web/parts/lao/organizer/__tests__/__snapshots__/RollCallOpened.test.tsx.snap
+++ b/fe1-web/parts/lao/organizer/__tests__/__snapshots__/RollCallOpened.test.tsx.snap
@@ -120,6 +120,257 @@ exports[`RollCallOpened renders correctly when no scan 1`] = `
         </View>
       </View>
     </View>
+    <View
+      style={
+        Object {
+          "marginHorizontal": 50,
+          "marginVertical": 10,
+        }
+      }
+    >
+      <View
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "disabled": false,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        nativeID="animatedComponent"
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {},
+            ]
+          }
+        >
+          <Text
+            disabled={false}
+            style={
+              Array [
+                Object {
+                  "color": "#007AFF",
+                  "fontSize": 18,
+                  "margin": 8,
+                  "textAlign": "center",
+                },
+              ]
+            }
+          >
+            Add an attendee manually
+          </Text>
+        </View>
+      </View>
+    </View>
   </View>
+  <Modal
+    hardwareAccelerated={false}
+    transparent={true}
+    visible={false}
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "white",
+          "borderRadius": 10,
+          "borderWidth": 1,
+          "margin": "auto",
+          "width": 550,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "borderBottomWidth": 1,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "alignSelf": "flex-start",
+              "fontSize": 25,
+              "fontWeight": "bold",
+              "marginHorizontal": 10,
+              "padding": 20,
+              "paddingLeft": 10,
+              "textAlign": "center",
+            }
+          }
+        >
+          Add an attendee
+        </Text>
+      </View>
+      <Text
+        style={
+          Object {
+            "alignSelf": "flex-start",
+            "fontSize": 20,
+            "marginHorizontal": 10,
+            "padding": 20,
+            "paddingLeft": 10,
+            "textAlign": "left",
+          }
+        }
+      >
+        Enter token:
+      </Text>
+      <TextInput
+        defaultValue=""
+        onChangeText={[Function]}
+        placeholder=""
+        selectTextOnFocus={true}
+        style={
+          Object {
+            "borderBottomWidth": 2,
+            "fontSize": 25,
+            "marginHorizontal": 50,
+            "marginVertical": 20,
+            "textAlign": "center",
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "alignSelf": "center",
+            "flexDirection": "row",
+            "paddingBottom": 20,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "marginHorizontal": 50,
+              "marginVertical": 10,
+            }
+          }
+        >
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "disabled": false,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            nativeID="animatedComponent"
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {},
+                ]
+              }
+            >
+              <Text
+                disabled={false}
+                style={
+                  Array [
+                    Object {
+                      "color": "#007AFF",
+                      "fontSize": 18,
+                      "margin": 8,
+                      "textAlign": "center",
+                    },
+                  ]
+                }
+              >
+                Add
+              </Text>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            Object {
+              "marginHorizontal": 50,
+              "marginVertical": 10,
+            }
+          }
+        >
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "disabled": false,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            nativeID="animatedComponent"
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {},
+                ]
+              }
+            >
+              <Text
+                disabled={false}
+                style={
+                  Array [
+                    Object {
+                      "color": "#007AFF",
+                      "fontSize": 18,
+                      "margin": 8,
+                      "textAlign": "center",
+                    },
+                  ]
+                }
+              >
+                Cancel
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </Modal>
 </View>
 `;

--- a/fe1-web/parts/lao/organizer/__tests__/__snapshots__/RollCallOpened.test.tsx.snap
+++ b/fe1-web/parts/lao/organizer/__tests__/__snapshots__/RollCallOpened.test.tsx.snap
@@ -234,7 +234,7 @@ exports[`RollCallOpened renders correctly when no scan 1`] = `
       <TextInput
         defaultValue=""
         onChangeText={[Function]}
-        placeholder=""
+        placeholder="Attendee token"
         selectTextOnFocus={true}
         style={
           Object {

--- a/fe1-web/res/strings.ts
+++ b/fe1-web/res/strings.ts
@@ -7,6 +7,7 @@ const STRINGS = {
   general_button_ok: 'Ok',
   general_yes: 'Yes',
   general_no: 'No',
+  general_add: 'Add',
 
   /* --- Navigation Strings --- */
   navigation_tab_home: 'Home',
@@ -155,9 +156,15 @@ const STRINGS = {
 
   /* --- Roll-call scanning Strings --- */
   roll_call_scan_description: 'Please scan each participant’s Roll-call QR code exactly once.',
-  roll_call_scan_participant: 'participants scanned',
+  roll_call_scan_participant: 'participant scanned',
   roll_call_scan_close: 'Close Roll-Call',
   roll_call_scan_close_confirmation: 'Do you confirm to close the roll-call ?',
+  roll_call_add_attendee_manually: 'Add an attendee manually',
+
+  /* --- Roll-call manually add attendee modal Strings --- */
+  roll_call_modal_add_attendee: 'Add an attendee',
+  roll_call_modal_enter_token: 'Enter token:',
+  roll_call_participant_added: 'participant added manually',
 
   /* --- Poll creation Strings --- */
   poll_create_question: 'Question*',

--- a/fe1-web/res/strings.ts
+++ b/fe1-web/res/strings.ts
@@ -164,8 +164,9 @@ const STRINGS = {
   roll_call_add_attendee_manually: 'Add an attendee manually',
   roll_call_modal_add_attendee: 'Add an attendee',
   roll_call_modal_enter_token: 'Enter token:',
-  roll_call_participant_added: 'participant added manually',
+  roll_call_participant_added: 'participant added',
   roll_call_invalid_token: 'invalid participant token',
+  roll_call_attendee_token_placeholder: 'Attendee token',
 
   /* --- Poll creation Strings --- */
   poll_create_question: 'Question*',

--- a/fe1-web/res/strings.ts
+++ b/fe1-web/res/strings.ts
@@ -159,12 +159,13 @@ const STRINGS = {
   roll_call_scan_participant: 'participant scanned',
   roll_call_scan_close: 'Close Roll-Call',
   roll_call_scan_close_confirmation: 'Do you confirm to close the roll-call ?',
-  roll_call_add_attendee_manually: 'Add an attendee manually',
 
-  /* --- Roll-call manually add attendee modal Strings --- */
+  /* --- Roll-call manually add attendee manually Strings --- */
+  roll_call_add_attendee_manually: 'Add an attendee manually',
   roll_call_modal_add_attendee: 'Add an attendee',
   roll_call_modal_enter_token: 'Enter token:',
   roll_call_participant_added: 'participant added manually',
+  roll_call_invalid_token: 'invalid participant token',
 
   /* --- Poll creation Strings --- */
   poll_create_question: 'Question*',


### PR DESCRIPTION
For testing purposes, we are in the need of adding attendees without having to scan their token.
I added a way to do it. On the opened roll call page, you can now press on the button "Add attendee manually". A modal will pop up on screen, asking for an attendee token.
<img width="970" alt="Capture d’écran 2022-01-10 à 14 03 01" src="https://user-images.githubusercontent.com/33868847/148773540-27d4ba0b-a682-41cb-bbec-f61a6171ee7e.png">

Then, a regex will be used to check that it is a token. It is a simple check that there are 43 chars that are letters, numbers, - or _ and followed by '=' at the end. If is passes, there is a new toast message that is displayed:
<img width="970" alt="Capture d’écran 2022-01-10 à 14 03 46" src="https://user-images.githubusercontent.com/33868847/148773436-14404838-89e4-4986-bfe9-d351ddad4ab6.png">

If not, the organized will be informed:
<img width="970" alt="Capture d’écran 2022-01-10 à 14 02 50" src="https://user-images.githubusercontent.com/33868847/148773482-b32e04e2-c3e4-4316-af13-8fd3d5d48d58.png">

Attendees are correctly added to the list when closing the roll call:
<img width="824" alt="Capture d’écran 2022-01-09 à 17 23 25" src="https://user-images.githubusercontent.com/33868847/148691591-e50a9522-a73b-4444-a2a9-23841aa94d9b.png">