### PR TITLE
Quick fix in NotifyAddChirp and changes in Chirp

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/socialmedia/NotifyAddChirp.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/socialmedia/NotifyAddChirp.java
@@ -9,19 +9,19 @@ import com.google.gson.annotations.SerializedName;
 /** Data sent to broadcast AddChirp to the general channel */
 public class NotifyAddChirp extends Data {
 
-  @SerializedName("post_id")
-  private final MessageID postId;
+  @SerializedName("chirp_id")
+  private final MessageID chirpId;
 
   private final String channel;
   private final long timestamp;
 
   /**
-   * @param postId message ID of the post
+   * @param chirpId message ID of the chirp
    * @param channel channel where the post is located
    * @param timestamp UNIX timestamp in UTC
    */
-  public NotifyAddChirp(MessageID postId, String channel, long timestamp) {
-    this.postId = postId;
+  public NotifyAddChirp(MessageID chirpId, String channel, long timestamp) {
+    this.chirpId = chirpId;
     this.channel = channel;
     this.timestamp = timestamp;
   }
@@ -36,8 +36,8 @@ public class NotifyAddChirp extends Data {
     return Action.NOTIFY_ADD.getAction();
   }
 
-  public MessageID getPostId() {
-    return postId;
+  public MessageID getChirpId() {
+    return chirpId;
   }
 
   public String getChannel() {
@@ -57,21 +57,21 @@ public class NotifyAddChirp extends Data {
       return false;
     }
     NotifyAddChirp that = (NotifyAddChirp) o;
-    return java.util.Objects.equals(getPostId(), that.getPostId())
+    return java.util.Objects.equals(getChirpId(), that.getChirpId())
         && java.util.Objects.equals(getChannel(), that.getChannel())
         && java.util.Objects.equals(getTimestamp(), that.getTimestamp());
   }
 
   @Override
   public int hashCode() {
-    return java.util.Objects.hash(getPostId(), getChannel(), getTimestamp());
+    return java.util.Objects.hash(getChirpId(), getChannel(), getTimestamp());
   }
 
   @Override
   public String toString() {
     return "NotifyAddChirp{"
-        + "postId='"
-        + postId
+        + "chirpId='"
+        + chirpId
         + '\''
         + ", channel='"
         + channel

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/socialmedia/NotifyAddChirp.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/socialmedia/NotifyAddChirp.java
@@ -71,7 +71,7 @@ public class NotifyAddChirp extends Data {
   public String toString() {
     return "NotifyAddChirp{"
         + "chirpId='"
-        + chirpId
+        + chirpId.getEncoded()
         + '\''
         + ", channel='"
         + channel

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/Chirp.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/Chirp.java
@@ -16,7 +16,7 @@ public class Chirp {
   private PublicKey sender;
   private String text;
   private long timestamp;
-  private int likes;
+  private boolean isDeleted;
   private MessageID parentId;
 
   public Chirp(MessageID id) {
@@ -76,12 +76,12 @@ public class Chirp {
     this.timestamp = timestamp;
   }
 
-  public int getLikes() {
-    return likes;
+  public boolean getIsDeleted() {
+    return isDeleted;
   }
 
-  public void setLikes(int likes) {
-    this.likes = likes;
+  public void setIsDeleted(boolean isDeleted) {
+    this.isDeleted = isDeleted;
   }
 
   public MessageID getParentId() {
@@ -96,7 +96,7 @@ public class Chirp {
   @Override
   public String toString() {
     return String.format(
-        "Chirp{id='%s', channel='%s', sender='%s', text='%s', timestamp='%s', likes='%s', parentId='%s'",
-        id.getEncoded(), channel, sender, text, timestamp, likes, parentId.getEncoded());
+        "Chirp{id='%s', channel='%s', sender='%s', text='%s', timestamp='%s', isDeleted='%s', parentId='%s'",
+        id.getEncoded(), channel, sender, text, timestamp, isDeleted, parentId.getEncoded());
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/socialmedia/AddChirpTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/socialmedia/AddChirpTest.java
@@ -6,9 +6,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 
+import com.github.dedis.popstellar.model.network.JsonTestUtils;
 import com.github.dedis.popstellar.model.network.method.message.data.Action;
 import com.github.dedis.popstellar.model.network.method.message.data.Objects;
 import com.github.dedis.popstellar.model.objects.security.MessageID;
+import com.google.gson.JsonParseException;
 
 import org.junit.Test;
 
@@ -63,7 +65,17 @@ public class AddChirpTest {
 
     String random = "random";
     assertNotEquals(ADD_CHIRP, new AddChirp(random, PARENT_ID, TIMESTAMP));
-    assertNotEquals(ADD_CHIRP, new AddChirp(TEXT, generateMessageIDOtherThan(PARENT_ID), TIMESTAMP));
+    assertNotEquals(
+        ADD_CHIRP, new AddChirp(TEXT, generateMessageIDOtherThan(PARENT_ID), TIMESTAMP));
     assertNotEquals(ADD_CHIRP, new AddChirp(TEXT, PARENT_ID, TIMESTAMP + 1));
+  }
+
+  @Test
+  public void jsonValidationTest() {
+    JsonTestUtils.testData(ADD_CHIRP);
+
+    String pathDir =
+        "protocol/examples/messageData/chirp_add_publish/wrong_chirp_add_publish_negative_time.json";
+    assertThrows(JsonParseException.class, () -> JsonTestUtils.parse(pathDir));
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/socialmedia/AddChirpTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/socialmedia/AddChirpTest.java
@@ -74,8 +74,8 @@ public class AddChirpTest {
   public void jsonValidationTest() {
     JsonTestUtils.testData(ADD_CHIRP);
 
-    String pathDir =
+    String path =
         "protocol/examples/messageData/chirp_add_publish/wrong_chirp_add_publish_negative_time.json";
-    assertThrows(JsonParseException.class, () -> JsonTestUtils.parse(pathDir));
+    assertThrows(JsonParseException.class, () -> JsonTestUtils.parse(path));
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/socialmedia/NotifyAddChirpTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/socialmedia/NotifyAddChirpTest.java
@@ -4,21 +4,24 @@ import static com.github.dedis.popstellar.Base64DataUtils.generateMessageID;
 import static com.github.dedis.popstellar.Base64DataUtils.generateMessageIDOtherThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
+import com.github.dedis.popstellar.model.network.JsonTestUtils;
 import com.github.dedis.popstellar.model.network.method.message.data.Action;
 import com.github.dedis.popstellar.model.network.method.message.data.Objects;
 import com.github.dedis.popstellar.model.objects.security.MessageID;
+import com.google.gson.JsonParseException;
 
 import org.junit.Test;
 
 public class NotifyAddChirpTest {
 
-  private static final MessageID POST_ID = generateMessageID();
+  private static final MessageID CHIRP_ID = generateMessageID();
   private static final String CHANNEL = "/root/laoId/social/myChannel";
   private static final long TIMESTAMP = 1631280815;
 
   private static final NotifyAddChirp NOTIFY_ADD_CHIRP =
-      new NotifyAddChirp(POST_ID, CHANNEL, TIMESTAMP);
+      new NotifyAddChirp(CHIRP_ID, CHANNEL, TIMESTAMP);
 
   @Test
   public void getObjectTest() {
@@ -31,8 +34,8 @@ public class NotifyAddChirpTest {
   }
 
   @Test
-  public void getPostIdTest() {
-    assertEquals(POST_ID, NOTIFY_ADD_CHIRP.getPostId());
+  public void getChirpIdTest() {
+    assertEquals(CHIRP_ID, NOTIFY_ADD_CHIRP.getChirpId());
   }
 
   @Test
@@ -47,13 +50,22 @@ public class NotifyAddChirpTest {
 
   @Test
   public void equalsTest() {
-    assertEquals(NOTIFY_ADD_CHIRP, new NotifyAddChirp(POST_ID, CHANNEL, TIMESTAMP));
+    assertEquals(NOTIFY_ADD_CHIRP, new NotifyAddChirp(CHIRP_ID, CHANNEL, TIMESTAMP));
 
     String random = "random";
     assertNotEquals(
         NOTIFY_ADD_CHIRP,
-        new NotifyAddChirp(generateMessageIDOtherThan(POST_ID), CHANNEL, TIMESTAMP));
-    assertNotEquals(NOTIFY_ADD_CHIRP, new NotifyAddChirp(POST_ID, random, TIMESTAMP));
-    assertNotEquals(NOTIFY_ADD_CHIRP, new NotifyAddChirp(POST_ID, CHANNEL, TIMESTAMP + 1));
+        new NotifyAddChirp(generateMessageIDOtherThan(CHIRP_ID), CHANNEL, TIMESTAMP));
+    assertNotEquals(NOTIFY_ADD_CHIRP, new NotifyAddChirp(CHIRP_ID, random, TIMESTAMP));
+    assertNotEquals(NOTIFY_ADD_CHIRP, new NotifyAddChirp(CHIRP_ID, CHANNEL, TIMESTAMP + 1));
+  }
+
+  @Test
+  public void jsonValidationTest() {
+    JsonTestUtils.testData(NOTIFY_ADD_CHIRP);
+
+    String pathDir =
+        "protocol/examples/messageData/chirp_notify_add/wrong_chirp_notify_add_negative_time.json";
+    assertThrows(JsonParseException.class, () -> JsonTestUtils.parse(pathDir));
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/socialmedia/NotifyAddChirpTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/network/method/message/data/socialmedia/NotifyAddChirpTest.java
@@ -64,8 +64,8 @@ public class NotifyAddChirpTest {
   public void jsonValidationTest() {
     JsonTestUtils.testData(NOTIFY_ADD_CHIRP);
 
-    String pathDir =
+    String path =
         "protocol/examples/messageData/chirp_notify_add/wrong_chirp_notify_add_negative_time.json";
-    assertThrows(JsonParseException.class, () -> JsonTestUtils.parse(pathDir));
+    assertThrows(JsonParseException.class, () -> JsonTestUtils.parse(path));
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/objects/ChirpTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/model/objects/ChirpTest.java
@@ -73,10 +73,10 @@ public class ChirpTest {
   }
 
   @Test
-  public void setAndGetLikesTest() {
-    int likes = 2021;
-    CHIRP.setLikes(likes);
-    assertEquals(likes, CHIRP.getLikes());
+  public void setAndGetIsDeletedTest() {
+    boolean isDeleted = true;
+    CHIRP.setIsDeleted(isDeleted);
+    assertEquals(isDeleted, CHIRP.getIsDeleted());
   }
 
   @Test


### PR DESCRIPTION
As pointed out by Arnaud, one of the variable was still called post_id despite being named chirp_id in the protocol.
He also recommended to add test for data validation.
I deleted a variable to count the number of likes in the Chirp object because it won't be counted that way, then I added a flag isDeleted to know whether a chirp is deleted or not.