### PR TITLE
Enter attendees manually

### DIFF
--- a/fe2-android/app/src/androidTest/java/com/github/dedis/popstellar/pages/qrcode/QRCodeScanningPageObject.java
+++ b/fe2-android/app/src/androidTest/java/com/github/dedis/popstellar/pages/qrcode/QRCodeScanningPageObject.java
@@ -1,0 +1,56 @@
+package com.github.dedis.popstellar.pages.qrcode;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.matcher.ViewMatchers.isClickable;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
+import static androidx.test.espresso.matcher.ViewMatchers.withHint;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+
+import androidx.test.espresso.ViewInteraction;
+
+import com.github.dedis.popstellar.R;
+
+public class QRCodeScanningPageObject {
+
+  public static ViewInteraction addAttendeeButton() {
+    return onView(
+        allOf(withId(R.id.add_attendee_manually), isClickable(), isEnabled(), isDisplayed()));
+  }
+
+  public static ViewInteraction closeRollCallButton() {
+    return onView(
+        allOf(withId(R.id.add_attendee_confirm), isClickable(), isEnabled(), isDisplayed()));
+  }
+
+  public static ViewInteraction addAttendeeTokenTextInput() {
+    return onView(
+        allOf(withHint(R.string.add_attendee_hint), isClickable(), isEnabled(), isDisplayed()));
+  }
+
+  public static ViewInteraction cancelButton() {
+    return onView(allOf(withText(R.string.cancel), isClickable(), isEnabled(), isDisplayed()));
+  }
+
+  public static ViewInteraction confirmButton() {
+    return onView(allOf(withText(R.string.confirm), isClickable(), isEnabled(), isDisplayed()));
+  }
+
+  public static ViewInteraction successPopup() {
+    return onView(withText(R.string.attendee_added));
+  }
+
+  public static ViewInteraction invalidTokenPopup() {
+    return onView(withText(R.string.invalid_token));
+  }
+
+  public static ViewInteraction tokenAlreadyAddedPopup() {
+    return onView(withText(R.string.qrcode_already_scanned));
+  }
+
+  public static ViewInteraction okButton() {
+    return onView(allOf(withText(R.string.ok), isClickable(), isEnabled(), isDisplayed()));
+  }
+}

--- a/fe2-android/app/src/androidTest/java/com/github/dedis/popstellar/ui/qrcode/QRCodeScanningFragmentTest.java
+++ b/fe2-android/app/src/androidTest/java/com/github/dedis/popstellar/ui/qrcode/QRCodeScanningFragmentTest.java
@@ -18,9 +18,11 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.when;
 
+import android.Manifest.permission;
 import android.os.Bundle;
 
 import androidx.test.filters.LargeTest;
+import androidx.test.rule.GrantPermissionRule;
 
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.model.network.GenericMessage;
@@ -187,11 +189,14 @@ public class QRCodeScanningFragmentTest {
         }
       };
 
+  @Rule public GrantPermissionRule permissionRule = GrantPermissionRule.grant(permission.CAMERA);
+
   @Rule
   public final RuleChain chain =
       RuleChain.outerRule(MockitoJUnit.testRule(this))
           .around(hiltRule)
           .around(setupRule)
+          .around(permissionRule)
           .around(activityFragmentScenarioRule);
 
   private void setupScanningFragment() {

--- a/fe2-android/app/src/androidTest/java/com/github/dedis/popstellar/ui/qrcode/QRCodeScanningFragmentTest.java
+++ b/fe2-android/app/src/androidTest/java/com/github/dedis/popstellar/ui/qrcode/QRCodeScanningFragmentTest.java
@@ -1,34 +1,300 @@
 package com.github.dedis.popstellar.ui.qrcode;
 
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static com.github.dedis.popstellar.pages.qrcode.QRCodeScanningPageObject.addAttendeeButton;
+import static com.github.dedis.popstellar.pages.qrcode.QRCodeScanningPageObject.addAttendeeTokenTextInput;
+import static com.github.dedis.popstellar.pages.qrcode.QRCodeScanningPageObject.cancelButton;
+import static com.github.dedis.popstellar.pages.qrcode.QRCodeScanningPageObject.closeRollCallButton;
+import static com.github.dedis.popstellar.pages.qrcode.QRCodeScanningPageObject.confirmButton;
+import static com.github.dedis.popstellar.pages.qrcode.QRCodeScanningPageObject.invalidTokenPopup;
+import static com.github.dedis.popstellar.pages.qrcode.QRCodeScanningPageObject.okButton;
+import static com.github.dedis.popstellar.pages.qrcode.QRCodeScanningPageObject.successPopup;
+import static com.github.dedis.popstellar.pages.qrcode.QRCodeScanningPageObject.tokenAlreadyAddedPopup;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.when;
+
+import android.os.Bundle;
+
+import androidx.test.filters.LargeTest;
+
+import com.github.dedis.popstellar.R;
+import com.github.dedis.popstellar.model.network.GenericMessage;
+import com.github.dedis.popstellar.model.network.answer.Result;
+import com.github.dedis.popstellar.model.network.method.Message;
+import com.github.dedis.popstellar.model.network.method.Publish;
+import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
+import com.github.dedis.popstellar.model.network.method.message.data.lao.CreateLao;
+import com.github.dedis.popstellar.model.network.method.message.data.rollcall.CloseRollCall;
+import com.github.dedis.popstellar.model.network.method.message.data.rollcall.CreateRollCall;
+import com.github.dedis.popstellar.model.network.method.message.data.rollcall.OpenRollCall;
+import com.github.dedis.popstellar.model.objects.Lao;
+import com.github.dedis.popstellar.model.objects.RollCall;
+import com.github.dedis.popstellar.model.objects.event.EventState;
+import com.github.dedis.popstellar.model.objects.security.PublicKey;
+import com.github.dedis.popstellar.repository.LAODataSource;
+import com.github.dedis.popstellar.repository.LAORepository;
+import com.github.dedis.popstellar.repository.LAOState;
+import com.github.dedis.popstellar.testutils.fragment.ActivityFragmentScenarioRule;
+import com.github.dedis.popstellar.ui.detail.LaoDetailActivity;
+import com.github.dedis.popstellar.ui.detail.LaoDetailFragment;
+import com.github.dedis.popstellar.ui.detail.LaoDetailViewModel;
+import com.github.dedis.popstellar.utility.error.DataHandlingException;
+import com.github.dedis.popstellar.utility.handler.MessageHandler;
+import com.github.dedis.popstellar.utility.scheduler.ProdSchedulerProvider;
+import com.github.dedis.popstellar.utility.security.KeyManager;
+import com.google.gson.Gson;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import dagger.hilt.android.testing.BindValue;
+import dagger.hilt.android.testing.HiltAndroidRule;
+import dagger.hilt.android.testing.HiltAndroidTest;
+import io.reactivex.Observable;
+
 /** Class handling connect fragment tests */
+@LargeTest
+@HiltAndroidTest
 public class QRCodeScanningFragmentTest {
 
-  //  private static final String TEST_URL = "Test url";
-  //
-  //  @Rule
-  //  public final GrantPermissionRule rule = GrantPermissionRule.grant(Manifest.permission.CAMERA);
-  //
-  //  @Test
-  //  @Ignore("No matching view exception")
-  //  public void testSimpleBarcodeReaction() {
-  //    ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class);
-  //
-  //    // Set good fragment
-  //    onView(ViewMatchers.withId(R.id.tab_connect)).perform(click());
-  //    onView(withId(R.id.fragment_qrcode)).check(matches(isDisplayed()));
-  //
-  //    // Simulate a detected url
-  //    scenario.onActivity(
-  //        a -> {
-  //          Fragment fragment =
-  //              a.getSupportFragmentManager().findFragmentByTag(QRCodeScanningFragment.TAG);
-  //          Assert.assertNotNull(fragment);
-  //          Assert.assertTrue(fragment instanceof QRCodeScanningFragment);
-  //          ((QRCodeScanningFragment) fragment).onQRCodeDetected(TEST_URL, CONNECT_LAO, null);
-  //        });
-  //
-  //    // Check everything
-  //    onView(withId(R.id.fragment_connecting)).check(matches(isDisplayed()));
-  //    onView(withId(R.id.connecting_url)).check(matches(withText(TEST_URL)));
-  //  }
+  @Inject KeyManager keyManager;
+  @Inject MessageHandler messageHandler;
+  @Inject Gson gson;
+
+  @BindValue LAORepository laoRepository;
+
+  @Mock LAODataSource.Remote remoteDataSource;
+  @Mock LAODataSource.Local localDataSource;
+
+  private static final ArgumentCaptor<Message> CAPTOR = ArgumentCaptor.forClass(Message.class);
+
+  private static final String LAO_NAME = "aaaa";
+  private static final String ROLL_CALL_NAME = "bbbb";
+  private static final long creation = 946684800;
+  private static final String ATTENDEE_VALID_1 = "M5ZychEi5rwm22FjwjNuljL1qMJWD2sE7oX9fcHNMDU=";
+  private static final String ATTENDEE_VALID_2 = "ywWU4tMX8CR7CtXuutCZNyWBYRbtyk9NJqopvqSFgfI=";
+  private static final String ATTENDEE_INVALID_1 = "M5ZychEi5rwm22FjwjNuljL1qMJ";
+  private static final String ATTENDEE_INVALID_2 = "%&/()=?`";
+  private static final String ATTENDEE_INVALID_3 = "";
+
+  private final Bundle bundle = new Bundle();
+  private String rollCallId;
+
+  private final HiltAndroidRule hiltRule = new HiltAndroidRule(this);
+
+  private final ActivityFragmentScenarioRule<LaoDetailActivity, LaoDetailFragment>
+      activityFragmentScenarioRule =
+          ActivityFragmentScenarioRule.launchIn(
+              LaoDetailActivity.class,
+              bundle,
+              R.id.fragment_container_lao_detail,
+              LaoDetailFragment.class,
+              LaoDetailFragment::new);
+
+  private final TestRule setupRule =
+      new ExternalResource() {
+        @Override
+        protected void before()
+            throws IOException, GeneralSecurityException, DataHandlingException {
+          // Injection with hilt
+          hiltRule.inject();
+
+          when(remoteDataSource.incrementAndGetRequestId()).thenReturn(42);
+          when(remoteDataSource.observeWebsocket()).thenReturn(Observable.empty());
+          Observable<GenericMessage> upstream = Observable.fromArray(new Result(42));
+
+          // Mock the remote data source to receive a response
+          when(remoteDataSource.observeMessage()).thenReturn(upstream);
+
+          laoRepository =
+              new LAORepository(
+                  remoteDataSource,
+                  localDataSource,
+                  keyManager,
+                  messageHandler,
+                  gson,
+                  new ProdSchedulerProvider());
+
+          Lao lao = new Lao(LAO_NAME, keyManager.getMainPublicKey(), creation);
+          lao.setChannel("/root/" + lao.getId());
+          RollCall rollCall = new RollCall(lao.getId(), creation, ROLL_CALL_NAME);
+          rollCallId = rollCall.getId();
+          lao.updateRollCall(rollCallId, rollCall);
+
+          CreateLao createLao =
+              new CreateLao(
+                  lao.getId(),
+                  LAO_NAME,
+                  creation,
+                  keyManager.getMainPublicKey(),
+                  Collections.emptyList());
+
+          CreateRollCall createRollCall =
+              new CreateRollCall(
+                  ROLL_CALL_NAME,
+                  creation,
+                  creation,
+                  creation + 1846684800,
+                  "Lausanne",
+                  "desc",
+                  lao.getId());
+
+          OpenRollCall openRollCall =
+              new OpenRollCall(lao.getId(), createRollCall.getId(), creation, EventState.OPENED);
+
+          MessageGeneral createLaoMsg =
+              new MessageGeneral(keyManager.getMainKeyPair(), createLao, gson);
+
+          MessageGeneral createRollCallMsg =
+              new MessageGeneral(keyManager.getMainKeyPair(), createRollCall, gson);
+
+          MessageGeneral openRollCallMsg =
+              new MessageGeneral(keyManager.getMainKeyPair(), openRollCall, gson);
+
+          Map<Integer, String> createLaoRequests = new HashMap<>();
+          createLaoRequests.put(1, lao.getChannel());
+          messageHandler.handleCreateLao(laoRepository, 1, createLaoRequests);
+          laoRepository.setAllLaoSubject();
+          laoRepository.getLaoById().put(lao.getId(), new LAOState(lao));
+
+          messageHandler.handleMessage(laoRepository, lao.getChannel(), createLaoMsg);
+          messageHandler.handleMessage(laoRepository, lao.getChannel(), createRollCallMsg);
+          messageHandler.handleMessage(laoRepository, lao.getChannel(), openRollCallMsg);
+
+          bundle.putString("LAO_ID", lao.getId());
+          bundle.putString("FRAGMENT_TO_OPEN", "LaoDetail");
+        }
+      };
+
+  @Rule
+  public final RuleChain chain =
+      RuleChain.outerRule(MockitoJUnit.testRule(this))
+          .around(hiltRule)
+          .around(setupRule)
+          .around(activityFragmentScenarioRule);
+
+  private void setupScanningFragment() {
+    activityFragmentScenarioRule
+        .getScenario()
+        .onActivity(
+            activity -> {
+              LaoDetailViewModel laoDetailViewModel = LaoDetailActivity.obtainViewModel(activity);
+              laoDetailViewModel.openRollCall(rollCallId);
+              laoDetailViewModel.openQrCodeScanningRollCall();
+            });
+  }
+
+  private List<PublicKey> getAttendeesFromInterceptedCloseRollCallMsg() {
+    Mockito.verify(remoteDataSource, atLeast(1)).sendMessage(CAPTOR.capture());
+    Publish publish = (Publish) CAPTOR.getValue();
+    MessageGeneral closeRollCallMsg = publish.getMessage();
+    CloseRollCall closeRollCall = (CloseRollCall) closeRollCallMsg.getData();
+    return closeRollCall.getAttendees();
+  }
+
+  @Test
+  public void addingAttendeesManuallyTest() throws InterruptedException {
+    setupScanningFragment();
+
+    // Add ATTENDEE_VALID_1
+    addAttendeeButton().perform(click());
+    addAttendeeTokenTextInput().perform(click(), typeText(ATTENDEE_VALID_1));
+    confirmButton().perform(click());
+    successPopup().check(matches(isDisplayed()));
+    Thread.sleep(2200); // wait for the success popup to disappear
+
+    // Add ATTENDEE_VALID_2
+    addAttendeeButton().perform(click());
+    addAttendeeTokenTextInput().perform(click(), typeText(ATTENDEE_VALID_2));
+    confirmButton().perform(click());
+    successPopup().check(matches(isDisplayed()));
+    Thread.sleep(2200); // wait for the success popup to disappear
+
+    // Try to add ATTENDEE_VALID_1 again, should show a warning popup
+    addAttendeeButton().perform(click());
+    addAttendeeTokenTextInput().perform(click(), typeText(ATTENDEE_VALID_1));
+    confirmButton().perform(click());
+    tokenAlreadyAddedPopup().check(matches(isDisplayed()));
+    okButton().perform(click()); // close the warning popup
+
+    // Close the roll call and get the attendees list
+    closeRollCallButton().perform(click());
+    confirmButton().perform(click());
+    List<PublicKey> attendees = getAttendeesFromInterceptedCloseRollCallMsg();
+
+    assertEquals(2, attendees.size());
+    assertTrue(attendees.contains(new PublicKey(ATTENDEE_VALID_1)));
+    assertTrue(attendees.contains(new PublicKey(ATTENDEE_VALID_2)));
+  }
+
+  @Test
+  public void invalidTokenTest() {
+    setupScanningFragment();
+
+    // Try to add ATTENDEE_INVALID_1, should show an invalid token popup
+    addAttendeeButton().perform(click());
+    addAttendeeTokenTextInput().perform(click(), typeText(ATTENDEE_INVALID_1)); // Base64 wrong size
+    confirmButton().perform(click());
+    invalidTokenPopup().check(matches(isDisplayed()));
+    okButton().perform(click()); // close the warning popup
+
+    // Try to add ATTENDEE_INVALID_2, should show an invalid token popup
+    addAttendeeButton().perform(click());
+    addAttendeeTokenTextInput().perform(click(), typeText(ATTENDEE_INVALID_2)); // Not Base64
+    confirmButton().perform(click());
+    invalidTokenPopup().check(matches(isDisplayed()));
+    okButton().perform(click()); // close the warning popup
+
+    // Try to add ATTENDEE_INVALID_3, should show an invalid token popup
+    addAttendeeButton().perform(click());
+    addAttendeeTokenTextInput().perform(click(), typeText(ATTENDEE_INVALID_3)); // Empty token
+    confirmButton().perform(click());
+    invalidTokenPopup().check(matches(isDisplayed()));
+    okButton().perform(click()); // close the warning popup
+
+    // Close the roll call and get the attendees list
+    closeRollCallButton().perform(click());
+    confirmButton().perform(click());
+    List<PublicKey> attendees = getAttendeesFromInterceptedCloseRollCallMsg();
+
+    assertTrue(attendees.isEmpty());
+  }
+
+  @Test
+  public void cancelShouldNotAddAttendeeTest() {
+    setupScanningFragment();
+
+    // Cancel with ATTENDEE_INVALID_1 in the text input, should not add it
+    addAttendeeButton().perform(click());
+    addAttendeeTokenTextInput().perform(click(), typeText(ATTENDEE_INVALID_1)); // Base64 wrong size
+    cancelButton().perform(click());
+
+    // Close the roll call and get the attendees list
+    closeRollCallButton().perform(click());
+    confirmButton().perform(click());
+    List<PublicKey> attendees = getAttendeesFromInterceptedCloseRollCallMsg();
+
+    assertTrue(attendees.isEmpty());
+  }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailFragment.java
@@ -16,9 +16,7 @@ import androidx.fragment.app.Fragment;
 
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.LaoDetailFragmentBinding;
-import com.github.dedis.popstellar.model.objects.RollCall;
 import com.github.dedis.popstellar.model.objects.event.Event;
-import com.github.dedis.popstellar.model.objects.event.EventType;
 import com.github.dedis.popstellar.ui.detail.event.EventExpandableListViewAdapter;
 import com.github.dedis.popstellar.ui.detail.witness.WitnessListViewAdapter;
 import com.github.dedis.popstellar.ui.qrcode.ScanningAction;
@@ -193,9 +191,7 @@ public class LaoDetailFragment extends Fragment {
             events -> {
               Log.d(TAG, "Got an event list update");
               for (Event event : events) {
-                if (event.getType() == EventType.ROLL_CALL) {
-                  Log.d(TAG, ((RollCall) event).getDescription());
-                }
+                Log.d(TAG, "event : " + event.toString());
               }
               mEventListViewEventAdapter.replaceList(events);
             });

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
@@ -1360,6 +1360,18 @@ public class LaoDetailViewModel extends AndroidViewModel
     mOpenAttendeesListEvent.postValue(new SingleEvent<>(rollCallId));
   }
 
+  public void addAttendee(PublicKey attendee) {
+    if (attendees.contains(attendee)) {
+      mScanWarningEvent.postValue(
+          new SingleEvent<>("This QR code has already been scanned. Please try again."));
+      return;
+    }
+
+    attendees.add(attendee);
+    mAttendeeScanConfirmEvent.postValue(new SingleEvent<>("Attendee has been added."));
+    mNbAttendeesEvent.postValue(new SingleEvent<>(attendees.size()));
+  }
+
   @Override
   public void onPermissionGranted() {
     if (scanningAction == ScanningAction.ADD_ROLL_CALL_ATTENDEE) {
@@ -1396,9 +1408,7 @@ public class LaoDetailViewModel extends AndroidViewModel
       return;
     }
     if (scanningAction == (ScanningAction.ADD_ROLL_CALL_ATTENDEE)) {
-      attendees.add(attendee);
-      mAttendeeScanConfirmEvent.postValue(new SingleEvent<>("Attendee has been added."));
-      mNbAttendeesEvent.postValue(new SingleEvent<>(attendees.size()));
+      addAttendee(attendee);
     } else if (scanningAction == (ScanningAction.ADD_WITNESS)) {
       witnesses.add(attendee);
       mWitnessScanConfirmEvent.postValue(new SingleEvent<>(true));

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
@@ -1363,12 +1363,13 @@ public class LaoDetailViewModel extends AndroidViewModel
   public void addAttendee(PublicKey attendee) {
     if (attendees.contains(attendee)) {
       mScanWarningEvent.postValue(
-          new SingleEvent<>("This QR code has already been scanned. Please try again."));
+          new SingleEvent<>(getApplication().getString(R.string.qrcode_already_scanned)));
       return;
     }
 
     attendees.add(attendee);
-    mAttendeeScanConfirmEvent.postValue(new SingleEvent<>("Attendee has been added."));
+    mAttendeeScanConfirmEvent.postValue(
+        new SingleEvent<>(getApplication().getString(R.string.attendee_added)));
     mNbAttendeesEvent.postValue(new SingleEvent<>(attendees.size()));
   }
 
@@ -1397,14 +1398,15 @@ public class LaoDetailViewModel extends AndroidViewModel
     try {
       attendee = new PublicKey(barcode.rawValue);
     } catch (IllegalArgumentException e) {
-      mScanWarningEvent.postValue(new SingleEvent<>("Invalid QR code. Please try again."));
+      mScanWarningEvent.postValue(
+          new SingleEvent<>(getApplication().getString(R.string.invalid_qrcode)));
       return;
     }
 
     if (attendees.contains(attendee)
         || Objects.requireNonNull(mWitnesses.getValue()).contains(attendee)) {
       mScanWarningEvent.postValue(
-          new SingleEvent<>("This QR code has already been scanned. Please try again."));
+          new SingleEvent<>(getApplication().getString(R.string.qrcode_already_scanned)));
       return;
     }
     if (scanningAction == (ScanningAction.ADD_ROLL_CALL_ATTENDEE)) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/CameraPreview.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/CameraPreview.java
@@ -125,7 +125,7 @@ public class CameraPreview extends ViewGroup {
       startIfReady();
     } catch (SecurityException se) {
       Log.e(TAG, "Do not have permission to start the camera", se);
-    } catch (IOException e) {
+    } catch (Exception e) {
       Log.e(TAG, "Could not start camera source.", e);
     }
   }
@@ -139,7 +139,7 @@ public class CameraPreview extends ViewGroup {
         startIfReady();
       } catch (SecurityException se) {
         Log.e(TAG, "Do not have permission to start the camera", se);
-      } catch (IOException e) {
+      } catch (Exception e) {
         Log.e(TAG, "Could not start camera source.", e);
       }
     }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/QRCodeScanningFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/QRCodeScanningFragment.java
@@ -178,17 +178,17 @@ public final class QRCodeScanningFragment extends Fragment {
         clicked -> {
           // create the Alert Dialog to add manually an attendee token
           AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
-          builder.setTitle("Add an attendee");
-          builder.setMessage("Enter token:");
+          builder.setTitle(R.string.add_attendee_title);
+          builder.setMessage(R.string.add_attendee_ask_input);
           // Set up the input
           final EditText attendeeTokenText = new EditText(getContext());
 
-          attendeeTokenText.setHint("Attendee Token");
+          attendeeTokenText.setHint(R.string.add_attendee_hint);
           builder.setView(attendeeTokenText);
 
           // Set up the buttons
           builder.setPositiveButton(
-              "ADD",
+              R.string.confirm,
               (dialog, which) -> {
                 String attendeeTokenString = attendeeTokenText.getText().toString();
                 if (!attendeeTokenString.isEmpty()) {
@@ -197,11 +197,11 @@ public final class QRCodeScanningFragment extends Fragment {
                     ((LaoDetailViewModel) mQRCodeScanningViewModel).addAttendee(attendeeToken);
                   } catch (Exception e) {
                     Log.e(TAG, "Invalid token : " + attendeeTokenString, e);
-                    setupWarningPopup("Invalid token");
+                    setupWarningPopup(getString(R.string.invalid_token));
                   }
                 }
               });
-          builder.setNegativeButton("CANCEL", (dialog, which) -> dialog.cancel());
+          builder.setNegativeButton(R.string.cancel, (dialog, which) -> dialog.cancel());
           builder.show();
         });
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/QRCodeScanningFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/QRCodeScanningFragment.java
@@ -166,7 +166,7 @@ public final class QRCodeScanningFragment extends Fragment {
     if (camera != null) {
       try {
         mPreview.start(camera);
-      } catch (IOException e) {
+      } catch (Exception e) {
         Log.e(TAG, "Unable to start camera source.", e);
         camera.release();
       }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/QRCodeScanningFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/QRCodeScanningFragment.java
@@ -191,14 +191,12 @@ public final class QRCodeScanningFragment extends Fragment {
               R.string.confirm,
               (dialog, which) -> {
                 String attendeeTokenString = attendeeTokenText.getText().toString();
-                if (!attendeeTokenString.isEmpty()) {
-                  try {
-                    PublicKey attendeeToken = new PublicKey(attendeeTokenText.getText().toString());
-                    ((LaoDetailViewModel) mQRCodeScanningViewModel).addAttendee(attendeeToken);
-                  } catch (Exception e) {
-                    Log.e(TAG, "Invalid token : " + attendeeTokenString, e);
-                    setupWarningPopup(getString(R.string.invalid_token));
-                  }
+                try {
+                  PublicKey attendeeToken = new PublicKey(attendeeTokenString);
+                  ((LaoDetailViewModel) mQRCodeScanningViewModel).addAttendee(attendeeToken);
+                } catch (Exception e) {
+                  Log.e(TAG, "Invalid token : " + attendeeTokenString, e);
+                  setupWarningPopup(getString(R.string.invalid_token));
                 }
               });
           builder.setNegativeButton(R.string.cancel, (dialog, which) -> dialog.cancel());
@@ -253,7 +251,7 @@ public final class QRCodeScanningFragment extends Fragment {
     builder.setMessage(msg);
     builder.setOnDismissListener(dialog -> startCamera());
     builder.setPositiveButton(
-        "Ok",
+        R.string.ok,
         (dialog, which) -> {
           if (dialog != null) {
             dialog.dismiss();

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/QRCodeScanningFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/QRCodeScanningFragment.java
@@ -10,6 +10,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.EditText;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -18,6 +19,7 @@ import androidx.fragment.app.FragmentActivity;
 
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.QrcodeFragmentBinding;
+import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.ui.detail.LaoDetailActivity;
 import com.github.dedis.popstellar.ui.detail.LaoDetailViewModel;
 import com.github.dedis.popstellar.ui.home.HomeActivity;
@@ -86,6 +88,7 @@ public final class QRCodeScanningFragment extends Fragment {
       mQrCodeFragBinding.setScanningAction(ScanningAction.ADD_ROLL_CALL_ATTENDEE);
       mQrCodeFragBinding.addAttendeeTotalText.setVisibility(View.VISIBLE);
       mQrCodeFragBinding.addAttendeeNumberText.setVisibility(View.VISIBLE);
+      mQrCodeFragBinding.addAttendeeManually.setVisibility(View.VISIBLE);
       mQrCodeFragBinding.addAttendeeConfirm.setVisibility(View.VISIBLE);
 
       // Subscribe to " Nb of attendees"  event
@@ -93,6 +96,9 @@ public final class QRCodeScanningFragment extends Fragment {
 
       // Subscribe to " Attendees scan confirm " event
       observeAttendeeScanConfirmEvent();
+
+      // set up the listener for the button for adding an attendee manually
+      setupAddAttendeeManually();
 
       // set up the listener for the button that closes the roll call
       setupCloseRollCallButton();
@@ -165,6 +171,34 @@ public final class QRCodeScanningFragment extends Fragment {
         camera.release();
       }
     }
+  }
+
+  private void setupAddAttendeeManually() {
+    mQrCodeFragBinding.addAttendeeManually.setOnClickListener(
+        clicked -> {
+          // create the Alert Dialog to add manually an attendee token
+          AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+          builder.setTitle("Add an attendee");
+          builder.setMessage("Enter token:");
+          // Set up the input
+          final EditText attendeeTokenText = new EditText(getContext());
+
+          attendeeTokenText.setHint("Attendee Token");
+          builder.setView(attendeeTokenText);
+
+          // Set up the buttons
+          builder.setPositiveButton(
+              "ADD",
+              (dialog, which) -> {
+                String attendeeTokenString = attendeeTokenText.getText().toString();
+                if (!attendeeTokenString.isEmpty()) {
+                  PublicKey attendeeToken = new PublicKey(attendeeTokenString);
+                  ((LaoDetailViewModel) mQRCodeScanningViewModel).addAttendee(attendeeToken);
+                }
+              });
+          builder.setNegativeButton("CANCEL", (dialog, which) -> dialog.cancel());
+          builder.show();
+        });
   }
 
   private void setupCloseRollCallButton() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/QRCodeScanningFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/QRCodeScanningFragment.java
@@ -192,8 +192,13 @@ public final class QRCodeScanningFragment extends Fragment {
               (dialog, which) -> {
                 String attendeeTokenString = attendeeTokenText.getText().toString();
                 if (!attendeeTokenString.isEmpty()) {
-                  PublicKey attendeeToken = new PublicKey(attendeeTokenString);
-                  ((LaoDetailViewModel) mQRCodeScanningViewModel).addAttendee(attendeeToken);
+                  try {
+                    PublicKey attendeeToken = new PublicKey(attendeeTokenText.getText().toString());
+                    ((LaoDetailViewModel) mQRCodeScanningViewModel).addAttendee(attendeeToken);
+                  } catch (Exception e) {
+                    Log.e(TAG, "Invalid token : " + attendeeTokenString, e);
+                    setupWarningPopup("Invalid token");
+                  }
                 }
               });
           builder.setNegativeButton("CANCEL", (dialog, which) -> dialog.cancel());

--- a/fe2-android/app/src/main/res/layout/qrcode_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/qrcode_fragment.xml
@@ -86,6 +86,15 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintRight_toRightOf="parent" />
 
+    <Button
+      android:id="@+id/add_attendee_manually"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/add_attendee_manually"
+      android:visibility="gone"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toStartOf="@+id/add_attendee_confirm" />
+
     <LinearLayout
       android:id="@+id/add_attendee_number"
       android:layout_width="wrap_content"

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -105,6 +105,7 @@
   <string name="qrcode_scanning_connect_lao">Scan a QR code to connect to a LAO</string>
   <string name="event_description">Event Description</string>
   <string name="qrcode_scanning_add_attendee">Please scan each participant’s Roll-call QR code exactly once.</string>
+  <string name="add_attendee_manually">Add attendee</string>
   <string name="close_roll_call">Close Roll-Call</string>
   <string name="scan_all_attendees_question">Are you sure you have scanned all attendees ?</string>
   <string name="roll_call_title_required">Roll-Call Title required</string>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
   <string name="location_optional">Location</string>
   <string name="confirm">Confirm</string>
   <string name="cancel">Cancel</string>
+  <string name="ok">Ok</string>
   <string name="past_date_not_allowed">Event has to start/end today or in the future</string>
   <string name="end_date_after_start_date_not_allowed">End date has to be after or the same day as the start date
     </string>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -81,6 +81,12 @@
   <string name="add_attendee_already_exists">Attendee already recorded</string>
   <string name="add_attendee_unsuccessful">Error when adding attendee</string>
   <string name="add_attendees_number">Number of attendees : %1$d</string>
+  <string name="add_attendee_manually">Add attendee</string>
+  <string name="add_attendee_title">Add an attendee</string>
+  <string name="add_attendee_ask_input">Enter token:</string>
+  <string name="add_attendee_hint">Attendee Token</string>
+  <string name="invalid_token">Invalid token</string>
+  <string name="attendee_added">Attendee has been added.</string>
 
   <!-- Event Buttons -->
   <string name="open_rollcall">OPEN</string>
@@ -105,11 +111,12 @@
   <string name="qrcode_scanning_connect_lao">Scan a QR code to connect to a LAO</string>
   <string name="event_description">Event Description</string>
   <string name="qrcode_scanning_add_attendee">Please scan each participant’s Roll-call QR code exactly once.</string>
-  <string name="add_attendee_manually">Add attendee</string>
   <string name="close_roll_call">Close Roll-Call</string>
   <string name="scan_all_attendees_question">Are you sure you have scanned all attendees ?</string>
   <string name="roll_call_title_required">Roll-Call Title required</string>
   <string name="show_qrcode_to_organizer">Please show the QR code to the organizer</string>
+  <string name="invalid_qrcode">Invalid QR code. Please try again.</string>
+  <string name="qrcode_already_scanned">This QR code has already been scanned. Please try again.</string>
 
   <!-- Witness -->
   <string name="delete_witness_dialog_title">Delete ?</string>


### PR DESCRIPTION
Add a button for the organizer during a roll call for adding an attendee manually (image 1).
When clicked, it will open a popup asking the attendee token (image 2).
When confirming the token (image 3), if the key is invalid (for example if not base64 or decoded length != 32) or if it was already added, it will display a warning (image 5), else it will add the token to the attendees list (image 4).

### TODO fix the tests (work locally but not in the CI) or drop this PR if the QRCodeScanningFragment will be redo from scratch

![image](https://user-images.githubusercontent.com/19479532/148807543-94eefb73-26a2-4dc5-a4f4-fab1e2077ce5.png)
![image](https://user-images.githubusercontent.com/19479532/148807865-d50345a4-5249-4fda-aac1-7d77267a92b9.png)
![image](https://user-images.githubusercontent.com/19479532/148807731-98724f79-f2ab-451c-854e-343e253acae0.png)
![image](https://user-images.githubusercontent.com/19479532/148808988-6900b4ac-1f07-4d0f-a200-3766c48287fa.png)
![image](https://user-images.githubusercontent.com/19479532/148808014-f78f2ec0-e3cb-428f-8299-ae00f2ccf533.png)
