### PR TITLE
Add current user public key in social media navigation

### DIFF
--- a/fe1-web/components/TextInputChirp.tsx
+++ b/fe1-web/components/TextInputChirp.tsx
@@ -6,8 +6,8 @@ import {
 import STRINGS from 'res/strings';
 import { gray, red } from 'styles/colors';
 import { Ionicons } from '@expo/vector-icons';
+import { PublicKey } from 'model/objects';
 import TextBlock from './TextBlock';
-import { PublicKey } from '../model/objects';
 import ProfileIcon from './ProfileIcon';
 
 const MAX_CHIRP_CHARS = 300;

--- a/fe1-web/ingestion/handlers/RollCall.ts
+++ b/fe1-web/ingestion/handlers/RollCall.ts
@@ -18,8 +18,8 @@ import {
   setLaoLastRollCall,
   updateEvent,
 } from 'store';
+import { subscribeToChannel } from 'network/CommunicationApi';
 import { getEventFromId, hasWitnessSignatureQuorum } from './Utils';
-import { subscribeToChannel } from '../../network/CommunicationApi';
 
 const getCurrentLao = makeCurrentLao();
 

--- a/fe1-web/parts/lao/socialMedia/SocialHome.tsx
+++ b/fe1-web/parts/lao/socialMedia/SocialHome.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import {
   FlatList,
   ListRenderItemInfo,
@@ -16,10 +16,9 @@ import STRINGS from 'res/strings';
 import { requestAddChirp } from 'network/MessageApi';
 import { makeChirpsList } from 'store/reducers/SocialReducer';
 import { useSelector } from 'react-redux';
-import { PublicKey, RollCall } from 'model/objects';
-import { generateToken } from 'model/objects/wallet/Token';
-import { makeCurrentLao, makeEventGetter } from 'store';
 import { Chirp, ChirpState } from 'model/objects/Chirp';
+import { PublicKey } from 'model/objects';
+import PropTypes from 'prop-types';
 
 /**
  * UI for the Social Media home screen component
@@ -45,33 +44,12 @@ const styles = StyleSheet.create({
   } as TextStyle,
 });
 
-const SocialHome = () => {
+const SocialHome = (props: IPropTypes) => {
+  const { currentUserPublicKey } = props;
   const [inputChirp, setInputChirp] = useState('');
-  const [userPublicKey, setUserPublicKey] = useState(new PublicKey(''));
-
-  const laoSelect = makeCurrentLao();
-  const lao = useSelector(laoSelect);
-
-  if (lao === undefined) {
-    throw new Error('LAO is currently undefined, impossible to access to Social Media');
-  }
-
-  // Get the pop token of the user using the last tokenized roll call
-  const rollCallId = lao.last_tokenized_roll_call_id;
-  const eventSelect = makeEventGetter(lao.id, rollCallId);
-  const rollCall: RollCall = useSelector(eventSelect) as RollCall;
-
-  // This will be run again each time the lao.last_tokenized_roll_call_id changes
-  useEffect(() => {
-    generateToken(lao.id, rollCallId).then((token) => {
-      if (token && rollCall.containsToken(token)) {
-        setUserPublicKey(token.publicKey);
-      }
-    });
-  }, [lao.last_tokenized_roll_call_id]);
 
   const publishChirp = () => {
-    requestAddChirp(userPublicKey, inputChirp)
+    requestAddChirp(currentUserPublicKey, inputChirp)
       .catch((err) => {
         console.error('Failed to post chirp, error:', err);
       });
@@ -96,8 +74,8 @@ const SocialHome = () => {
           onChangeText={setInputChirp}
           onPress={publishChirp}
           // The publish button is disabled when the user public key is not defined
-          publishIsDisabledCond={userPublicKey.valueOf() === ''}
-          currentUserPublicKey={userPublicKey}
+          publishIsDisabledCond={currentUserPublicKey.valueOf() === ''}
+          currentUserPublicKey={currentUserPublicKey}
         />
         <FlatList
           data={chirpList}
@@ -107,6 +85,16 @@ const SocialHome = () => {
       </View>
     </View>
   );
+};
+
+const propTypes = {
+  currentUserPublicKey: PropTypes.instanceOf(PublicKey).isRequired,
+};
+
+SocialHome.prototype = propTypes;
+
+type IPropTypes = {
+  currentUserPublicKey: PublicKey,
 };
 
 export default SocialHome;

--- a/fe1-web/parts/lao/socialMedia/SocialMediaNavigation.tsx
+++ b/fe1-web/parts/lao/socialMedia/SocialMediaNavigation.tsx
@@ -16,7 +16,7 @@ import SocialHome from './SocialHome';
 const Tab = createMaterialTopTabNavigator();
 
 const SocialMediaNavigation = () => {
-  const [userPublicKey, setUserPublicKey] = useState(new PublicKey(''));
+  const [currentUserPublicKey, setCurrentUserPublicKey] = useState(new PublicKey(''));
 
   const laoSelect = makeCurrentLao();
   const lao = useSelector(laoSelect);
@@ -34,7 +34,7 @@ const SocialMediaNavigation = () => {
   useEffect(() => {
     generateToken(lao.id, rollCallId).then((token) => {
       if (token && rollCall.containsToken(token)) {
-        setUserPublicKey(token.publicKey);
+        setCurrentUserPublicKey(token.publicKey);
       }
     });
   }, [lao.last_tokenized_roll_call_id]);
@@ -70,12 +70,11 @@ const SocialMediaNavigation = () => {
       })}
     >
       <Tab.Screen name={STRINGS.social_media_navigation_tab_home}>
-        {() => <SocialHome userPublicKey={userPublicKey} />}
+        {() => <SocialHome currentUserPublicKey={currentUserPublicKey} />}
       </Tab.Screen>
-      <Tab.Screen
-        name={STRINGS.social_media_navigation_tab_search}
-        component={SocialSearch}
-      />
+      <Tab.Screen name={STRINGS.social_media_navigation_tab_search}>
+        {() => <SocialSearch currentUserPublicKey={currentUserPublicKey} />}
+      </Tab.Screen>
       <Tab.Screen
         name={STRINGS.social_media_navigation_tab_follows}
         component={SocialFollows}

--- a/fe1-web/parts/lao/socialMedia/SocialMediaNavigation.tsx
+++ b/fe1-web/parts/lao/socialMedia/SocialMediaNavigation.tsx
@@ -3,49 +3,89 @@ import { Ionicons } from '@expo/vector-icons';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import STRINGS from 'res/strings';
 import { red, gray } from 'styles/colors';
-
-import SocialHome from './SocialHome';
-import SocialFollows from './SocialFollows';
-import SocialSearch from './SocialSearch';
+import { useEffect, useState } from 'react';
+import { PublicKey, RollCall } from 'model/objects';
+import { generateToken } from 'model/objects/wallet';
+import { makeCurrentLao, makeEventGetter } from 'store';
+import { useSelector } from 'react-redux';
 import SocialProfile from './SocialProfile';
+import SocialSearch from './SocialSearch';
+import SocialFollows from './SocialFollows';
+import SocialHome from './SocialHome';
 
 const Tab = createMaterialTopTabNavigator();
 
-const SocialMediaNavigation = () => (
-  <Tab.Navigator
-    screenOptions={({ route }) => ({
-      tabBarIcon: ({ color }) => {
-        let iconName;
+const SocialMediaNavigation = () => {
+  const [userPublicKey, setUserPublicKey] = useState(new PublicKey(''));
 
-        switch (route.name) {
-          case STRINGS.social_media_navigation_tab_home:
-            iconName = 'home';
-            break;
-          case STRINGS.social_media_navigation_tab_search:
-            iconName = 'search';
-            break;
-          case STRINGS.social_media_navigation_tab_follows:
-            iconName = 'people';
-            break;
-          case STRINGS.social_media_navigation_tab_profile:
-            iconName = 'person';
-            break;
-          default:
-            console.error('wrong route.');
-            break;
-        }
+  const laoSelect = makeCurrentLao();
+  const lao = useSelector(laoSelect);
 
-        return <Ionicons name={iconName} size={23} color={color} />;
-      },
-      tabBarActiveTintColor: red,
-      tabBarInactiveTintColor: gray,
-    })}
-  >
-    <Tab.Screen name={STRINGS.social_media_navigation_tab_home} component={SocialHome} />
-    <Tab.Screen name={STRINGS.social_media_navigation_tab_search} component={SocialSearch} />
-    <Tab.Screen name={STRINGS.social_media_navigation_tab_follows} component={SocialFollows} />
-    <Tab.Screen name={STRINGS.social_media_navigation_tab_profile} component={SocialProfile} />
-  </Tab.Navigator>
-);
+  if (lao === undefined) {
+    throw new Error('LAO is currently undefined, impossible to access to Social Media');
+  }
+
+  // Get the pop token of the user using the last tokenized roll call
+  const rollCallId = lao.last_tokenized_roll_call_id;
+  const eventSelect = makeEventGetter(lao.id, rollCallId);
+  const rollCall: RollCall = useSelector(eventSelect) as RollCall;
+
+  // This will be run again each time the lao.last_tokenized_roll_call_id changes
+  useEffect(() => {
+    generateToken(lao.id, rollCallId).then((token) => {
+      if (token && rollCall.containsToken(token)) {
+        setUserPublicKey(token.publicKey);
+      }
+    });
+  }, [lao.last_tokenized_roll_call_id]);
+
+  return (
+    <Tab.Navigator
+      screenOptions={({ route }) => ({
+        tabBarIcon: ({ color }) => {
+          let iconName;
+
+          switch (route.name) {
+            case STRINGS.social_media_navigation_tab_home:
+              iconName = 'home';
+              break;
+            case STRINGS.social_media_navigation_tab_search:
+              iconName = 'search';
+              break;
+            case STRINGS.social_media_navigation_tab_follows:
+              iconName = 'people';
+              break;
+            case STRINGS.social_media_navigation_tab_profile:
+              iconName = 'person';
+              break;
+            default:
+              console.error('wrong route.');
+              break;
+          }
+
+          return <Ionicons name={iconName} size={23} color={color} />;
+        },
+        tabBarActiveTintColor: red,
+        tabBarInactiveTintColor: gray,
+      })}
+    >
+      <Tab.Screen name={STRINGS.social_media_navigation_tab_home}>
+        {() => <SocialHome userPublicKey={userPublicKey} />}
+      </Tab.Screen>
+      <Tab.Screen
+        name={STRINGS.social_media_navigation_tab_search}
+        component={SocialSearch}
+      />
+      <Tab.Screen
+        name={STRINGS.social_media_navigation_tab_follows}
+        component={SocialFollows}
+      />
+      <Tab.Screen
+        name={STRINGS.social_media_navigation_tab_profile}
+        component={SocialProfile}
+      />
+    </Tab.Navigator>
+  );
+};
 
 export default SocialMediaNavigation;

--- a/fe1-web/parts/lao/socialMedia/SocialSearch.tsx
+++ b/fe1-web/parts/lao/socialMedia/SocialSearch.tsx
@@ -9,6 +9,7 @@ import { PublicKey } from 'model/objects';
 import TextBlock from 'components/TextBlock';
 import UserListItem from 'components/UserListItem';
 import { gray } from 'styles/colors';
+import PropTypes from 'prop-types';
 
 /**
  * Component that will be used to allow users to search for other users or topics.
@@ -32,7 +33,8 @@ const styles = StyleSheet.create({
   } as ViewStyle,
 });
 
-const SocialSearch = () => {
+const SocialSearch = (props: IPropTypes) => {
+  const { currentUserPublicKey } = props;
   const laoSelect = makeCurrentLao();
   const currentLao = useSelector(laoSelect);
 
@@ -44,9 +46,13 @@ const SocialSearch = () => {
   const attendeesSelect = makeLastRollCallAttendeesList(currentLao.id, rollCallId);
   const attendees = useSelector(attendeesSelect);
 
-  const renderItem = ({ item }: ListRenderItemInfo<PublicKey>) => (
-    <UserListItem laoId={currentLao.id} publicKey={item} />
-  );
+  const renderItem = ({ item }: ListRenderItemInfo<PublicKey>) => {
+    // Not show our own profile
+    if (item.valueOf() === currentUserPublicKey.valueOf()) {
+      return null;
+    }
+    return <UserListItem laoId={currentLao.id} publicKey={item} />;
+  };
 
   return (
     <View style={styles.viewCenter}>
@@ -62,6 +68,16 @@ const SocialSearch = () => {
       </View>
     </View>
   );
+};
+
+const propTypes = {
+  currentUserPublicKey: PropTypes.instanceOf(PublicKey).isRequired,
+};
+
+SocialSearch.prototype = propTypes;
+
+type IPropTypes = {
+  currentUserPublicKey: PublicKey,
 };
 
 export default SocialSearch;


### PR DESCRIPTION
Since we use it everywhere in the social media, I realized that it would be much simpler if the PoP token's public key was given as a props to the social screens. Then, I added it directly in SocialMediaNavigation and passed it to SocialHome and SocialSearch.
With this, I could resolve an issue where you would see yourself in the list of attendees in search. It is now no longer the case.
I also addressed Jiabao's comments in my PR #737.