### PR TITLE
Add functionalities to KeyManager to simplify expressions and give access to PoP Tokens

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/Wallet.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/Wallet.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import com.github.dedis.popstellar.model.objects.security.PoPToken;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.ui.wallet.stellar.SLIP10;
+import com.github.dedis.popstellar.utility.error.keys.InvalidPoPTokenException;
 import com.github.dedis.popstellar.utility.error.keys.KeyGenerationException;
 import com.github.dedis.popstellar.utility.error.keys.SeedValidationException;
 import com.github.dedis.popstellar.utility.error.keys.UninitializedWalletException;
@@ -28,7 +29,6 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 
@@ -105,15 +105,16 @@ public class Wallet {
    * @param rollCallTokens a {@link Set} containing the public keys of all attendees present on
    *     roll-call’s results.
    * @return the PoP Token if the user participated in that roll-call or else empty.
-   * @throws KeyGenerationException if an error occurs
+   * @throws KeyGenerationException if an error occurs during key generation
    * @throws UninitializedWalletException if the wallet is not initialized with a seed
+   * @throws InvalidPoPTokenException if the token is not a valid attendee
    */
-  public Optional<PoPToken> recoverKey(
+  public PoPToken recoverKey(
       @NonNull String laoID, @NonNull String rollCallID, @NonNull Set<PublicKey> rollCallTokens)
-      throws KeyGenerationException, UninitializedWalletException {
+      throws KeyGenerationException, UninitializedWalletException, InvalidPoPTokenException {
     PoPToken token = generatePoPToken(laoID, rollCallID);
-    if (rollCallTokens.contains(token.getPublicKey())) return Optional.of(token);
-    else return Optional.empty();
+    if (rollCallTokens.contains(token.getPublicKey())) return token;
+    else throw new InvalidPoPTokenException(token);
   }
 
   /**

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/Wallet.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/Wallet.java
@@ -104,7 +104,7 @@ public class Wallet {
    * @param rollCallID a String.
    * @param rollCallTokens a {@link Set} containing the public keys of all attendees present on
    *     roll-call’s results.
-   * @return the PoP Token if the user participated in that roll-call or else empty.
+   * @return the PoP Token if the user participated in that roll-call.
    * @throws KeyGenerationException if an error occurs during key generation
    * @throws UninitializedWalletException if the wallet is not initialized with a seed
    * @throws InvalidPoPTokenException if the token is not a valid attendee

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
@@ -28,8 +28,6 @@ import com.github.dedis.popstellar.utility.security.KeyManager;
 import com.google.gson.Gson;
 import com.tinder.scarlet.WebSocket;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -191,29 +189,23 @@ public class LAORepository {
    * @param channel Represents the channel on which to send the stateLao message
    */
   public void sendStateLao(Lao lao, MessageGeneral msg, MessageID messageId, String channel) {
-    try {
-      if (mKeyManager.getMainPublicKey().equals(lao.getOrganizer())) {
-        UpdateLao updateLao = (UpdateLao) msg.getData();
-        StateLao stateLao =
-            new StateLao(
-                lao.getId(),
-                updateLao.getName(),
-                lao.getCreation(),
-                updateLao.getLastModified(),
-                lao.getOrganizer(),
-                messageId,
-                updateLao.getWitnesses(),
-                msg.getWitnessSignatures());
+    if (mKeyManager.getMainPublicKey().equals(lao.getOrganizer())) {
+      UpdateLao updateLao = (UpdateLao) msg.getData();
+      StateLao stateLao =
+          new StateLao(
+              lao.getId(),
+              updateLao.getName(),
+              lao.getCreation(),
+              updateLao.getLastModified(),
+              lao.getOrganizer(),
+              messageId,
+              updateLao.getWitnesses(),
+              msg.getWitnessSignatures());
 
-        MessageGeneral stateLaoMsg =
-            new MessageGeneral(mKeyManager.getMainKeyPair(), stateLao, mGson);
+      MessageGeneral stateLaoMsg =
+          new MessageGeneral(mKeyManager.getMainKeyPair(), stateLao, mGson);
 
-        sendPublish(channel, stateLaoMsg);
-      }
-    } catch (GeneralSecurityException e) {
-      Log.d(TAG, "failed to get keyset handle: " + e.getMessage());
-    } catch (IOException e) {
-      Log.d(TAG, "failed to get encoded public key: " + e.getMessage());
+      sendPublish(channel, stateLaoMsg);
     }
   }
 
@@ -300,13 +292,8 @@ public class LAORepository {
    * @param data the data to encapsulate in the message
    */
   public Single<Answer> sendMessageGeneral(String channel, Data data) {
-    try {
-      MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), data, mGson);
-      return sendPublish(channel, msg);
-    } catch (GeneralSecurityException | IOException e) {
-      Log.e(TAG, "failed to retrieve public key");
-      return Single.error(e);
-    }
+    MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), data, mGson);
+    return sendPublish(channel, msg);
   }
 
   /**
@@ -315,12 +302,7 @@ public class LAORepository {
    * @return the public key
    */
   public PublicKey getPublicKey() {
-    try {
-      return mKeyManager.getMainPublicKey();
-    } catch (Exception e) {
-      Log.e(TAG, "failed to retrieve public key", e);
-      return null;
-    }
+    return mKeyManager.getMainPublicKey();
   }
 
   /**

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
@@ -247,12 +247,7 @@ public class LaoDetailViewModel extends AndroidViewModel
    * @return the public key
    */
   public PublicKey getPublicKey() {
-    try {
-      return mKeyManager.getMainPublicKey();
-    } catch (GeneralSecurityException | IOException e) {
-      Log.d(TAG, PK_FAILURE_MESSAGE, e);
-      return null;
-    }
+    return mKeyManager.getMainPublicKey();
   }
 
   @Override
@@ -274,32 +269,28 @@ public class LaoDetailViewModel extends AndroidViewModel
     ElectionEnd electionEnd =
         new ElectionEnd(election.getId(), laoId, election.computerRegisteredVotes());
 
-    try {
-      MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), electionEnd, mGson);
+    MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), electionEnd, mGson);
 
-      Log.d(TAG, PUBLISH_MESSAGE);
-      Disposable disposable =
-          mLAORepository
-              .sendPublish(channel, msg)
-              .subscribeOn(Schedulers.io())
-              .observeOn(AndroidSchedulers.mainThread())
-              .timeout(5, TimeUnit.SECONDS)
-              .subscribe(
-                  answer -> {
-                    if (answer instanceof Result) {
-                      Log.d(TAG, "ended election successfully");
-                      endElectionEvent();
-                    } else {
-                      Log.d(TAG, "failed to end the election");
-                    }
-                  },
-                  throwable ->
-                      Log.d(TAG, "timed out waiting for result on election/end", throwable));
+    Log.d(TAG, PUBLISH_MESSAGE);
+    Disposable disposable =
+        mLAORepository
+            .sendPublish(channel, msg)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .timeout(5, TimeUnit.SECONDS)
+            .subscribe(
+                answer -> {
+                  if (answer instanceof Result) {
+                    Log.d(TAG, "ended election successfully");
+                    endElectionEvent();
+                  } else {
+                    Log.d(TAG, "failed to end the election");
+                  }
+                },
+                throwable ->
+                    Log.d(TAG, "timed out waiting for result on election/end", throwable));
 
-      disposables.add(disposable);
-    } catch (GeneralSecurityException | IOException e) {
-      Log.d(TAG, PK_FAILURE_MESSAGE, e);
-    }
+    disposables.add(disposable);
   }
 
   /**
@@ -333,38 +324,34 @@ public class LaoDetailViewModel extends AndroidViewModel
     // Is channel set ?
     String electionChannel = election.getChannel();
 
-    try {
-      MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), castVote, mGson);
+    MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), castVote, mGson);
 
-      Log.d(TAG, PUBLISH_MESSAGE);
-      Disposable disposable =
-          mLAORepository
-              .sendPublish(electionChannel, msg)
-              .subscribeOn(Schedulers.io())
-              .observeOn(AndroidSchedulers.mainThread())
-              .timeout(5, TimeUnit.SECONDS)
-              .subscribe(
-                  answer -> {
-                    if (answer instanceof Result) {
-                      Log.d(TAG, "sent a vote successfully");
-                      // Toast ? + send back to election screen or details screen ?
-                      Toast.makeText(
-                              getApplication(), "vote successfully sent !", Toast.LENGTH_LONG)
-                          .show();
-                    } else {
-                      Log.d(TAG, "failed to send the vote");
-                      Toast.makeText(
-                              getApplication(), "vote was sent too late !", Toast.LENGTH_LONG)
-                          .show();
-                    }
-                    openLaoDetail();
-                  },
-                  throwable -> Log.d(TAG, "timed out waiting for result on cast_vote", throwable));
+    Log.d(TAG, PUBLISH_MESSAGE);
+    Disposable disposable =
+        mLAORepository
+            .sendPublish(electionChannel, msg)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .timeout(5, TimeUnit.SECONDS)
+            .subscribe(
+                answer -> {
+                  if (answer instanceof Result) {
+                    Log.d(TAG, "sent a vote successfully");
+                    // Toast ? + send back to election screen or details screen ?
+                    Toast.makeText(
+                            getApplication(), "vote successfully sent !", Toast.LENGTH_LONG)
+                        .show();
+                  } else {
+                    Log.d(TAG, "failed to send the vote");
+                    Toast.makeText(
+                            getApplication(), "vote was sent too late !", Toast.LENGTH_LONG)
+                        .show();
+                  }
+                  openLaoDetail();
+                },
+                throwable -> Log.d(TAG, "timed out waiting for result on cast_vote", throwable));
 
-      disposables.add(disposable);
-    } catch (GeneralSecurityException | IOException e) {
-      Log.d(TAG, PK_FAILURE_MESSAGE, e);
-    }
+    disposables.add(disposable);
   }
 
   /**
@@ -406,40 +393,35 @@ public class LaoDetailViewModel extends AndroidViewModel
         new ElectionSetup(
             name, creation, start, end, votingMethod, writeIn, ballotOptions, question, laoId);
 
-    try {
-      // Retrieve identity of who is creating the election
-      MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), electionSetup, mGson);
+    // Retrieve identity of who is creating the election
+    MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), electionSetup, mGson);
 
-      Log.d(TAG, PUBLISH_MESSAGE);
-      Disposable disposable =
-          mLAORepository
-              .sendPublish(channel, msg)
-              .subscribeOn(Schedulers.io())
-              .observeOn(AndroidSchedulers.mainThread())
-              .timeout(5, TimeUnit.SECONDS)
-              .subscribe(
-                  answer -> {
-                    if (answer instanceof Result) {
-                      Log.d(TAG, "setup an election");
-                      mElectionCreatedEvent.postValue(new SingleEvent<>(true));
-                    } else if (answer instanceof Error) {
-                      Log.d(
-                          TAG,
-                          "failed to setup an election because of the following error : "
-                              + ((Error) answer).getError().getDescription());
-                    } else {
-                      Log.d(TAG, "failed to setup an election");
-                    }
-                  },
-                  throwable ->
-                      Log.d(TAG, "timed out waiting for result on election/create", throwable));
+    Log.d(TAG, PUBLISH_MESSAGE);
+    Disposable disposable =
+        mLAORepository
+            .sendPublish(channel, msg)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .timeout(5, TimeUnit.SECONDS)
+            .subscribe(
+                answer -> {
+                  if (answer instanceof Result) {
+                    Log.d(TAG, "setup an election");
+                    mElectionCreatedEvent.postValue(new SingleEvent<>(true));
+                  } else if (answer instanceof Error) {
+                    Log.d(
+                        TAG,
+                        "failed to setup an election because of the following error : "
+                            + ((Error) answer).getError().getDescription());
+                  } else {
+                    Log.d(TAG, "failed to setup an election");
+                  }
+                },
+                throwable ->
+                    Log.d(TAG, "timed out waiting for result on election/create", throwable));
 
-      disposables.add(disposable);
+    disposables.add(disposable);
 
-    } catch (GeneralSecurityException | IOException e) {
-      Log.d(TAG, PK_FAILURE_MESSAGE, e);
-      return null;
-    }
     return electionSetup.getId();
   }
 
@@ -475,34 +457,30 @@ public class LaoDetailViewModel extends AndroidViewModel
         new CreateRollCall(
             title, creation, proposedStart, proposedEnd, "Lausanne", description, laoId);
 
-    try {
-      Log.d(TAG, PUBLISH_MESSAGE);
-      MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), createRollCall, mGson);
-      Disposable disposable =
-          mLAORepository
-              .sendPublish(channel, msg)
-              .subscribeOn(Schedulers.io())
-              .observeOn(AndroidSchedulers.mainThread())
-              .timeout(5, TimeUnit.SECONDS)
-              .subscribe(
-                  answer -> {
-                    if (answer instanceof Result) {
-                      Log.d(TAG, "created a roll call with id: " + createRollCall.getId());
-                      if (open) {
-                        openRollCall(createRollCall.getId());
-                      } else {
-                        mCreatedRollCallEvent.postValue(new SingleEvent<>(true));
-                      }
+    Log.d(TAG, PUBLISH_MESSAGE);
+    MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), createRollCall, mGson);
+    Disposable disposable =
+        mLAORepository
+            .sendPublish(channel, msg)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .timeout(5, TimeUnit.SECONDS)
+            .subscribe(
+                answer -> {
+                  if (answer instanceof Result) {
+                    Log.d(TAG, "created a roll call with id: " + createRollCall.getId());
+                    if (open) {
+                      openRollCall(createRollCall.getId());
                     } else {
-                      Log.d(TAG, "failed to create a roll call");
+                      mCreatedRollCallEvent.postValue(new SingleEvent<>(true));
                     }
-                  },
-                  throwable ->
-                      Log.d(TAG, "timed out waiting for result on roll_call/create", throwable));
-      disposables.add(disposable);
-    } catch (GeneralSecurityException | IOException e) {
-      Log.d(TAG, PK_FAILURE_MESSAGE, e);
-    }
+                  } else {
+                    Log.d(TAG, "failed to create a roll call");
+                  }
+                },
+                throwable ->
+                    Log.d(TAG, "timed out waiting for result on roll_call/create", throwable));
+    disposables.add(disposable);
   }
 
   /**
@@ -532,30 +510,26 @@ public class LaoDetailViewModel extends AndroidViewModel
 
     ConsensusElect consensusElect = new ConsensusElect(creation, objId, type, property, value);
 
-    try {
-      Log.d(TAG, PUBLISH_MESSAGE);
-      MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), consensusElect, mGson);
+    Log.d(TAG, PUBLISH_MESSAGE);
+    MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), consensusElect, mGson);
 
-      Disposable disposable =
-          mLAORepository
-              .sendPublish(channel, msg)
-              .subscribeOn(Schedulers.io())
-              .observeOn(AndroidSchedulers.mainThread())
-              .timeout(5, TimeUnit.SECONDS)
-              .subscribe(
-                  answer -> {
-                    if (answer instanceof Result) {
-                      Log.d(TAG, "created a consensus with messageId: " + msg.getMessageId());
-                    } else {
-                      Log.d(TAG, "failed to create a consensus");
-                    }
-                  },
-                  throwable ->
-                      Log.d(TAG, "timed out waiting for result on consensus/elect", throwable));
-      disposables.add(disposable);
-    } catch (GeneralSecurityException | IOException e) {
-      Log.d(TAG, PK_FAILURE_MESSAGE, e);
-    }
+    Disposable disposable =
+        mLAORepository
+            .sendPublish(channel, msg)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .timeout(5, TimeUnit.SECONDS)
+            .subscribe(
+                answer -> {
+                  if (answer instanceof Result) {
+                    Log.d(TAG, "created a consensus with messageId: " + msg.getMessageId());
+                  } else {
+                    Log.d(TAG, "failed to create a consensus");
+                  }
+                },
+                throwable ->
+                    Log.d(TAG, "timed out waiting for result on consensus/elect", throwable));
+    disposables.add(disposable);
   }
 
   /**
@@ -583,38 +557,34 @@ public class LaoDetailViewModel extends AndroidViewModel
     ConsensusElectAccept consensusElectAccept =
         new ConsensusElectAccept(consensus.getId(), consensus.getMessageId(), accept);
 
-    try {
-      MessageGeneral msg =
-          new MessageGeneral(mKeyManager.getMainKeyPair(), consensusElectAccept, mGson);
+    MessageGeneral msg =
+        new MessageGeneral(mKeyManager.getMainKeyPair(), consensusElectAccept, mGson);
 
-      Log.d(TAG, PUBLISH_MESSAGE);
-      Disposable disposable =
-          mLAORepository
-              .sendPublish(consensus.getChannel(), msg)
-              .subscribeOn(Schedulers.io())
-              .observeOn(AndroidSchedulers.mainThread())
-              .timeout(5, TimeUnit.SECONDS)
-              .subscribe(
-                  answer -> {
-                    if (answer instanceof Result) {
-                      Log.d(TAG, "sent an elect_accept successfully");
-                    } else {
-                      Log.d(
-                          TAG,
-                          "failed to send the elect_accept for consensus with messageId : "
-                              + consensus.getMessageId());
-                    }
-                  },
-                  throwable ->
-                      Log.d(
-                          TAG,
-                          "timed out waiting for result on consensus/elect_accept",
-                          throwable));
+    Log.d(TAG, PUBLISH_MESSAGE);
+    Disposable disposable =
+        mLAORepository
+            .sendPublish(consensus.getChannel(), msg)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .timeout(5, TimeUnit.SECONDS)
+            .subscribe(
+                answer -> {
+                  if (answer instanceof Result) {
+                    Log.d(TAG, "sent an elect_accept successfully");
+                  } else {
+                    Log.d(
+                        TAG,
+                        "failed to send the elect_accept for consensus with messageId : "
+                            + consensus.getMessageId());
+                  }
+                },
+                throwable ->
+                    Log.d(
+                        TAG,
+                        "timed out waiting for result on consensus/elect_accept",
+                        throwable));
 
-      disposables.add(disposable);
-    } catch (GeneralSecurityException | IOException e) {
-      Log.d(TAG, PK_FAILURE_MESSAGE, e);
-    }
+    disposables.add(disposable);
   }
 
   /**
@@ -644,31 +614,27 @@ public class LaoDetailViewModel extends AndroidViewModel
     OpenRollCall openRollCall = new OpenRollCall(laoId, id, openedAt, rollCall.getState());
     attendees = new HashSet<>(rollCall.getAttendees());
 
-    try {
-      MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), openRollCall, mGson);
-      Disposable disposable =
-          mLAORepository
-              .sendPublish(channel, msg)
-              .subscribeOn(Schedulers.io())
-              .observeOn(AndroidSchedulers.mainThread())
-              .timeout(5, TimeUnit.SECONDS)
-              .subscribe(
-                  answer -> {
-                    if (answer instanceof Result) {
-                      Log.d(TAG, "opened the roll call");
-                      mCurrentRollCallId = openRollCall.getUpdateId();
-                      scanningAction = ScanningAction.ADD_ROLL_CALL_ATTENDEE;
-                      openScanning();
-                    } else {
-                      Log.d(TAG, "failed to open the roll call");
-                    }
-                  },
-                  throwable ->
-                      Log.d(TAG, "timed out waiting for result on roll_call/open", throwable));
-      disposables.add(disposable);
-    } catch (GeneralSecurityException | IOException e) {
-      Log.d(TAG, PK_FAILURE_MESSAGE, e);
-    }
+    MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), openRollCall, mGson);
+    Disposable disposable =
+        mLAORepository
+            .sendPublish(channel, msg)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .timeout(5, TimeUnit.SECONDS)
+            .subscribe(
+                answer -> {
+                  if (answer instanceof Result) {
+                    Log.d(TAG, "opened the roll call");
+                    mCurrentRollCallId = openRollCall.getUpdateId();
+                    scanningAction = ScanningAction.ADD_ROLL_CALL_ATTENDEE;
+                    openScanning();
+                  } else {
+                    Log.d(TAG, "failed to open the roll call");
+                  }
+                },
+                throwable ->
+                    Log.d(TAG, "timed out waiting for result on roll_call/open", throwable));
+    disposables.add(disposable);
   }
 
   /**
@@ -688,31 +654,27 @@ public class LaoDetailViewModel extends AndroidViewModel
     String laoId = channel.substring(6); // removing /root/ prefix
     CloseRollCall closeRollCall =
         new CloseRollCall(laoId, mCurrentRollCallId, end, new ArrayList<>(attendees));
-    try {
-      MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), closeRollCall, mGson);
-      Disposable disposable =
-          mLAORepository
-              .sendPublish(channel, msg)
-              .subscribeOn(Schedulers.io())
-              .observeOn(AndroidSchedulers.mainThread())
-              .timeout(5, TimeUnit.SECONDS)
-              .subscribe(
-                  answer -> {
-                    if (answer instanceof Result) {
-                      Log.d(TAG, "closed the roll call");
-                      mCurrentRollCallId = "";
-                      attendees.clear();
-                      mCloseRollCallEvent.setValue(new SingleEvent<>(nextFragment));
-                    } else {
-                      Log.d(TAG, "failed to close the roll call");
-                    }
-                  },
-                  throwable ->
-                      Log.d(TAG, "timed out waiting for result on roll_call/open", throwable));
-      disposables.add(disposable);
-    } catch (GeneralSecurityException | IOException e) {
-      Log.d(TAG, PK_FAILURE_MESSAGE, e);
-    }
+    MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), closeRollCall, mGson);
+    Disposable disposable =
+        mLAORepository
+            .sendPublish(channel, msg)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .timeout(5, TimeUnit.SECONDS)
+            .subscribe(
+                answer -> {
+                  if (answer instanceof Result) {
+                    Log.d(TAG, "closed the roll call");
+                    mCurrentRollCallId = "";
+                    attendees.clear();
+                    mCloseRollCallEvent.setValue(new SingleEvent<>(nextFragment));
+                  } else {
+                    Log.d(TAG, "failed to close the roll call");
+                  }
+                },
+                throwable ->
+                    Log.d(TAG, "timed out waiting for result on roll_call/open", throwable));
+    disposables.add(disposable);
   }
 
   public void signMessage(WitnessMessage witnessMessage) {
@@ -755,7 +717,7 @@ public class LaoDetailViewModel extends AndroidViewModel
                   throwable ->
                       Log.d(TAG, "timed out waiting for result on sign message", throwable)));
 
-    } catch (GeneralSecurityException | IOException e) {
+    } catch (GeneralSecurityException e) {
       Log.d(TAG, PK_FAILURE_MESSAGE, e);
     }
   }
@@ -884,34 +846,17 @@ public class LaoDetailViewModel extends AndroidViewModel
   }
 
   public LiveData<Boolean> isWitness() {
-    try {
-      boolean isWitness =
-          getCurrentLaoValue().getWitnesses().contains(mKeyManager.getMainPublicKey());
-      Log.d(TAG, "isWitness: " + isWitness);
-      mIsWitness.setValue(isWitness);
-      return mIsWitness;
-
-    } catch (GeneralSecurityException e) {
-      Log.d(TAG, KEYSET_HANDLE_FAILURE_MESSAGE, e);
-    } catch (IOException e) {
-      Log.d(TAG, GET_PK_FAILURE, e);
-    }
-    mIsWitness.setValue(false);
+    boolean isWitness =
+        getCurrentLaoValue().getWitnesses().contains(mKeyManager.getMainPublicKey());
+    Log.d(TAG, "isWitness: " + isWitness);
+    mIsWitness.setValue(isWitness);
     return mIsWitness;
   }
 
   public LiveData<Boolean> isSignedByCurrentWitness(Set<PublicKey> witnesses) {
-    try {
-      boolean isSignedByCurrentWitness = witnesses.contains(mKeyManager.getMainPublicKey());
-      Log.d(TAG, "isSignedByCurrentWitness: " + isSignedByCurrentWitness);
-      mIsSignedByCurrentWitness.setValue(isSignedByCurrentWitness);
-      return mIsSignedByCurrentWitness;
-    } catch (GeneralSecurityException e) {
-      Log.d(TAG, KEYSET_HANDLE_FAILURE_MESSAGE, e);
-    } catch (IOException e) {
-      Log.d(TAG, GET_PK_FAILURE, e);
-    }
-    mIsSignedByCurrentWitness.setValue(false);
+    boolean isSignedByCurrentWitness = witnesses.contains(mKeyManager.getMainPublicKey());
+    Log.d(TAG, "isSignedByCurrentWitness: " + isSignedByCurrentWitness);
+    mIsSignedByCurrentWitness.setValue(isSignedByCurrentWitness);
     return mIsSignedByCurrentWitness;
   }
 
@@ -1046,14 +991,7 @@ public class LaoDetailViewModel extends AndroidViewModel
 
   public void openIdentity() {
     if (mCurrentRollCallId.equals("")) {
-      PublicKey publicKey = null;
-      try {
-        publicKey = mKeyManager.getMainPublicKey();
-      } catch (GeneralSecurityException | IOException e) {
-        Log.d(TAG, PK_FAILURE_MESSAGE, e);
-      }
-
-      mOpenIdentityEvent.setValue(new SingleEvent<>(publicKey));
+      mOpenIdentityEvent.setValue(new SingleEvent<>(mKeyManager.getMainPublicKey()));
     } else {
       mAskCloseRollCallEvent.setValue(new SingleEvent<>(R.id.fragment_identity));
     }
@@ -1160,38 +1098,34 @@ public class LaoDetailViewModel extends AndroidViewModel
 
     Lao lao = getCurrentLaoValue();
     String channel = lao.getChannel();
-    try {
-      KeyPair mainKey = mKeyManager.getMainKeyPair();
-      long now = Instant.now().getEpochSecond();
-      UpdateLao updateLao =
-          new UpdateLao(
-              mainKey.getPublicKey(),
-              lao.getCreation(),
-              mLaoName.getValue(),
-              now,
-              lao.getWitnesses());
-      MessageGeneral msg = new MessageGeneral(mainKey, updateLao, mGson);
-      Disposable disposable =
-          mLAORepository
-              .sendPublish(channel, msg)
-              .subscribeOn(Schedulers.io())
-              .observeOn(AndroidSchedulers.mainThread())
-              .timeout(5, TimeUnit.SECONDS)
-              .subscribe(
-                  answer -> {
-                    if (answer instanceof Result) {
-                      Log.d(TAG, "updated lao name");
-                      dipatchLaoUpdate("lao name", updateLao, lao, channel, msg);
-                    } else {
-                      Log.d(TAG, "failed to update lao name");
-                    }
-                  },
-                  throwable ->
-                      Log.d(TAG, "timed out waiting for result on update lao name", throwable));
-      disposables.add(disposable);
-    } catch (GeneralSecurityException | IOException e) {
-      Log.d(TAG, PK_FAILURE_MESSAGE, e);
-    }
+    KeyPair mainKey = mKeyManager.getMainKeyPair();
+    long now = Instant.now().getEpochSecond();
+    UpdateLao updateLao =
+        new UpdateLao(
+            mainKey.getPublicKey(),
+            lao.getCreation(),
+            mLaoName.getValue(),
+            now,
+            lao.getWitnesses());
+    MessageGeneral msg = new MessageGeneral(mainKey, updateLao, mGson);
+    Disposable disposable =
+        mLAORepository
+            .sendPublish(channel, msg)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .timeout(5, TimeUnit.SECONDS)
+            .subscribe(
+                answer -> {
+                  if (answer instanceof Result) {
+                    Log.d(TAG, "updated lao name");
+                    dipatchLaoUpdate("lao name", updateLao, lao, channel, msg);
+                  } else {
+                    Log.d(TAG, "failed to update lao name");
+                  }
+                },
+                throwable ->
+                    Log.d(TAG, "timed out waiting for result on update lao name", throwable));
+    disposables.add(disposable);
   }
 
   /**
@@ -1208,35 +1142,31 @@ public class LaoDetailViewModel extends AndroidViewModel
       return;
     }
     String channel = lao.getChannel();
-    try {
-      KeyPair mainKey = mKeyManager.getMainKeyPair();
-      long now = Instant.now().getEpochSecond();
-      UpdateLao updateLao =
-          new UpdateLao(mainKey.getPublicKey(), lao.getCreation(), lao.getName(), now, witnesses);
-      MessageGeneral msg = new MessageGeneral(mainKey, updateLao, mGson);
-      Disposable disposable =
-          mLAORepository
-              .sendPublish(channel, msg)
-              .subscribeOn(Schedulers.io())
-              .observeOn(AndroidSchedulers.mainThread())
-              .timeout(5, TimeUnit.SECONDS)
-              .subscribe(
-                  answer -> {
-                    if (answer instanceof Result) {
-                      Log.d(TAG, "updated lao witnesses");
-                      dipatchLaoUpdate(
-                          "lao state with new witnesses", updateLao, lao, channel, msg);
-                    } else {
-                      Log.d(TAG, "failed to update lao witnesses");
-                    }
-                  },
-                  throwable ->
-                      Log.d(
-                          TAG, "timed out waiting for result on update lao witnesses", throwable));
-      disposables.add(disposable);
-    } catch (GeneralSecurityException | IOException e) {
-      Log.d(TAG, PK_FAILURE_MESSAGE, e);
-    }
+    KeyPair mainKey = mKeyManager.getMainKeyPair();
+    long now = Instant.now().getEpochSecond();
+    UpdateLao updateLao =
+        new UpdateLao(mainKey.getPublicKey(), lao.getCreation(), lao.getName(), now, witnesses);
+    MessageGeneral msg = new MessageGeneral(mainKey, updateLao, mGson);
+    Disposable disposable =
+        mLAORepository
+            .sendPublish(channel, msg)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .timeout(5, TimeUnit.SECONDS)
+            .subscribe(
+                answer -> {
+                  if (answer instanceof Result) {
+                    Log.d(TAG, "updated lao witnesses");
+                    dipatchLaoUpdate(
+                        "lao state with new witnesses", updateLao, lao, channel, msg);
+                  } else {
+                    Log.d(TAG, "failed to update lao witnesses");
+                  }
+                },
+                throwable ->
+                    Log.d(
+                        TAG, "timed out waiting for result on update lao witnesses", throwable));
+    disposables.add(disposable);
   }
 
   /** Helper method for updateLaoWitnesses and updateLaoName to send a stateLao message */
@@ -1252,27 +1182,24 @@ public class LaoDetailViewModel extends AndroidViewModel
             msg.getMessageId(),
             updateLao.getWitnesses(),
             new ArrayList<>());
-    try {
-      MessageGeneral stateMsg = new MessageGeneral(mKeyManager.getMainKeyPair(), stateLao, mGson);
-      disposables.add(
-          mLAORepository
-              .sendPublish(channel, stateMsg)
-              .subscribeOn(Schedulers.io())
-              .observeOn(AndroidSchedulers.mainThread())
-              .timeout(5, TimeUnit.SECONDS)
-              .subscribe(
-                  answer2 -> {
-                    if (answer2 instanceof Result) {
-                      Log.d(TAG, "updated " + desc);
-                    } else {
-                      Log.d(TAG, "failed to update " + desc);
-                    }
-                  },
-                  throwable ->
-                      Log.d(TAG, "timed out waiting for result on update " + desc, throwable)));
-    } catch (IOException | GeneralSecurityException e) {
-      Log.d(TAG, PK_FAILURE_MESSAGE, e);
-    }
+
+    MessageGeneral stateMsg = new MessageGeneral(mKeyManager.getMainKeyPair(), stateLao, mGson);
+    disposables.add(
+        mLAORepository
+            .sendPublish(channel, stateMsg)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .timeout(5, TimeUnit.SECONDS)
+            .subscribe(
+                answer2 -> {
+                  if (answer2 instanceof Result) {
+                    Log.d(TAG, "updated " + desc);
+                  } else {
+                    Log.d(TAG, "failed to update " + desc);
+                  }
+                },
+                throwable ->
+                    Log.d(TAG, "timed out waiting for result on update " + desc, throwable)));
   }
 
   public void cancelEdit() {
@@ -1290,17 +1217,9 @@ public class LaoDetailViewModel extends AndroidViewModel
                 lao -> {
                   Log.d(TAG, "got an update for lao: " + lao.getName());
                   mCurrentLao.postValue(lao);
-                  try {
-                    boolean isOrganizer = lao.getOrganizer().equals(mKeyManager.getMainPublicKey());
-                    Log.d(TAG, "isOrganizer: " + isOrganizer);
-                    mIsOrganizer.setValue(isOrganizer);
-                    return;
-                  } catch (GeneralSecurityException e) {
-                    Log.d(TAG, KEYSET_HANDLE_FAILURE_MESSAGE, e);
-                  } catch (IOException e) {
-                    Log.d(TAG, GET_PK_FAILURE, e);
-                  }
-                  mIsOrganizer.setValue(false);
+                  boolean isOrganizer = lao.getOrganizer().equals(mKeyManager.getMainPublicKey());
+                  Log.d(TAG, "isOrganizer: " + isOrganizer);
+                  mIsOrganizer.setValue(isOrganizer);
                 }));
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
@@ -86,8 +86,6 @@ public class LaoDetailViewModel extends AndroidViewModel
   private static final String LAO_FAILURE_MESSAGE = "failed to retrieve current lao";
   private static final String PK_FAILURE_MESSAGE = "failed to retrieve public key";
   private static final String PUBLISH_MESSAGE = "sending publish message";
-  private static final String KEYSET_HANDLE_FAILURE_MESSAGE = "failed to get public keyset handle";
-  private static final String GET_PK_FAILURE = "failed to get public key";
   /*
    * LiveData objects for capturing events like button clicks
    */

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
@@ -29,9 +29,7 @@ import com.github.dedis.popstellar.utility.security.KeyManager;
 import com.google.android.gms.vision.barcode.Barcode;
 import com.google.gson.Gson;
 
-import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
@@ -31,6 +31,7 @@ import com.google.gson.Gson;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -166,36 +167,29 @@ public class HomeViewModel extends AndroidViewModel
   public void launchLao() {
     String laoName = mLaoName.getValue();
 
-    try {
-      Log.d(TAG, "creating lao with name " + laoName);
-      CreateLao createLao = new CreateLao(laoName, mKeyManager.getMainPublicKey());
-      MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), createLao, mGson);
+    Log.d(TAG, "creating lao with name " + laoName);
+    CreateLao createLao = new CreateLao(laoName, mKeyManager.getMainPublicKey());
+    MessageGeneral msg = new MessageGeneral(mKeyManager.getMainKeyPair(), createLao, mGson);
 
-      disposables.add(
-          mLAORepository
-              .sendPublish("/root", msg)
-              .observeOn(AndroidSchedulers.mainThread())
-              .timeout(5, TimeUnit.SECONDS)
-              .subscribe(
-                  answer -> {
-                    if (answer instanceof Result) {
-                      Log.d(TAG, "got success result for create lao");
-                      openHome();
-                    } else {
-                      Log.d(
-                          TAG,
-                          "got failure result for create lao: "
-                              + ((Error) answer).getError().getDescription());
-                    }
-                  },
-                  throwable ->
-                      Log.d(TAG, "timed out waiting for a response for create lao", throwable)));
-
-    } catch (GeneralSecurityException e) {
-      Log.d(TAG, "failed to get public key", e);
-    } catch (IOException e) {
-      Log.d(TAG, "failed to encode public key", e);
-    }
+    disposables.add(
+        mLAORepository
+            .sendPublish("/root", msg)
+            .observeOn(AndroidSchedulers.mainThread())
+            .timeout(5, TimeUnit.SECONDS)
+            .subscribe(
+                answer -> {
+                  if (answer instanceof Result) {
+                    Log.d(TAG, "got success result for create lao");
+                    openHome();
+                  } else {
+                    Log.d(
+                        TAG,
+                        "got failure result for create lao: "
+                            + ((Error) answer).getError().getDescription());
+                  }
+                },
+                throwable ->
+                    Log.d(TAG, "timed out waiting for a response for create lao", throwable)));
   }
 
   public void importSeed(String seed) throws GeneralSecurityException, SeedValidationException {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/socialmedia/SocialMediaViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/socialmedia/SocialMediaViewModel.java
@@ -41,7 +41,6 @@ import io.reactivex.schedulers.Schedulers;
 public class SocialMediaViewModel extends AndroidViewModel {
   public static final String TAG = SocialMediaViewModel.class.getSimpleName();
   private static final String LAO_FAILURE_MESSAGE = "failed to retrieve lao";
-  private static final String PK_FAILURE_MESSAGE = "failed to retrieve public key";
   private static final String PUBLISH_MESSAGE = "sending publish message";
   private static final String ROOT = "/root/";
   public static final Integer MAX_CHAR_NUMBERS = 300;

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/socialmedia/SocialMediaViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/socialmedia/SocialMediaViewModel.java
@@ -23,8 +23,6 @@ import com.github.dedis.popstellar.repository.LAORepository;
 import com.github.dedis.popstellar.utility.security.KeyManager;
 import com.google.gson.Gson;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -204,34 +202,26 @@ public class SocialMediaViewModel extends AndroidViewModel {
   public void subscribeToChannel(String laoId) {
     Log.d(TAG, "subscribing to channel: " + ROOT + laoId + "/social/<sender>");
 
-    try {
-      String channel = ROOT + laoId + "/social/" + mKeyManager.getMainPublicKey().getEncoded();
+    String channel = ROOT + laoId + "/social/" + mKeyManager.getMainPublicKey().getEncoded();
 
-      Disposable disposable =
-          mLaoRepository
-              .sendSubscribe(channel)
-              .subscribeOn(Schedulers.io())
-              .observeOn(AndroidSchedulers.mainThread())
-              .timeout(5, TimeUnit.SECONDS)
-              .subscribe(
-                  answer -> {
-                    if (answer instanceof Result) {
-                      Log.d(TAG, "subscribed to the channel");
-                    } else {
-                      Log.d(TAG, "failed to subscribe to the channel");
-                    }
-                  },
-                  throwable ->
-                      Log.d(TAG, "timed out waiting for result on subscribe/channel", throwable));
+    Disposable disposable =
+        mLaoRepository
+            .sendSubscribe(channel)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .timeout(5, TimeUnit.SECONDS)
+            .subscribe(
+                answer -> {
+                  if (answer instanceof Result) {
+                    Log.d(TAG, "subscribed to the channel");
+                  } else {
+                    Log.d(TAG, "failed to subscribe to the channel");
+                  }
+                },
+                throwable ->
+                    Log.d(TAG, "timed out waiting for result on subscribe/channel", throwable));
 
-      disposables.add(disposable);
-
-    } catch (GeneralSecurityException | IOException e) {
-      Log.d(TAG, PK_FAILURE_MESSAGE, e);
-      Toast.makeText(
-              getApplication().getApplicationContext(), PK_FAILURE_MESSAGE, Toast.LENGTH_SHORT)
-          .show();
-    }
+    disposables.add(disposable);
   }
 
   /**
@@ -252,38 +242,31 @@ public class SocialMediaViewModel extends AndroidViewModel {
     }
     AddChirp addChirp = new AddChirp(text, parentId, timestamp);
 
-    try {
-      KeyPair mainKey = mKeyManager.getMainKeyPair();
-      String channel = laoChannel + "/social/" + mainKey.getPublicKey().getEncoded();
-      Log.d(TAG, PUBLISH_MESSAGE);
-      MessageGeneral msg = new MessageGeneral(mainKey, addChirp, mGson);
+    KeyPair mainKey = mKeyManager.getMainKeyPair();
+    String channel = laoChannel + "/social/" + mainKey.getPublicKey().getEncoded();
+    Log.d(TAG, PUBLISH_MESSAGE);
+    MessageGeneral msg = new MessageGeneral(mainKey, addChirp, mGson);
 
-      Disposable disposable =
-          mLaoRepository
-              .sendPublish(channel, msg)
-              .subscribeOn(Schedulers.io())
-              .observeOn(AndroidSchedulers.mainThread())
-              .timeout(5, TimeUnit.SECONDS)
-              .subscribe(
-                  answer -> {
-                    if (answer instanceof Result) {
-                      Log.d(TAG, "sent chirp with messageId: " + msg.getMessageId());
-                    } else {
-                      Log.d(TAG, "failed to send chirp");
-                      Toast.makeText(
-                              getApplication().getApplicationContext(),
-                              R.string.toast_error_sending_chirp,
-                              Toast.LENGTH_LONG)
-                          .show();
-                    }
-                  },
-                  throwable -> Log.d(TAG, "timed out waiting for result on chirp/add", throwable));
-      disposables.add(disposable);
-    } catch (GeneralSecurityException | IOException e) {
-      Log.d(TAG, PK_FAILURE_MESSAGE, e);
-      Toast.makeText(
-              getApplication().getApplicationContext(), PK_FAILURE_MESSAGE, Toast.LENGTH_SHORT)
-          .show();
-    }
+    Disposable disposable =
+        mLaoRepository
+            .sendPublish(channel, msg)
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .timeout(5, TimeUnit.SECONDS)
+            .subscribe(
+                answer -> {
+                  if (answer instanceof Result) {
+                    Log.d(TAG, "sent chirp with messageId: " + msg.getMessageId());
+                  } else {
+                    Log.d(TAG, "failed to send chirp");
+                    Toast.makeText(
+                            getApplication().getApplicationContext(),
+                            R.string.toast_error_sending_chirp,
+                            Toast.LENGTH_LONG)
+                        .show();
+                  }
+                },
+                throwable -> Log.d(TAG, "timed out waiting for result on chirp/add", throwable));
+    disposables.add(disposable);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/error/keys/NoRollCallException.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/error/keys/NoRollCallException.java
@@ -1,0 +1,14 @@
+package com.github.dedis.popstellar.utility.error.keys;
+
+import com.github.dedis.popstellar.model.objects.Lao;
+
+/**
+ * Exception thrown when a rollcall is expected to be found in an LAO
+ * and none exist
+ */
+public class NoRollCallException extends KeyException {
+
+    public NoRollCallException(Lao lao) {
+        super("No RollCall exist in the LAO : " + lao.getId());
+    }
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/security/KeyManager.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/security/KeyManager.java
@@ -34,6 +34,7 @@ public class KeyManager {
 
   private final AndroidKeysetManager keysetManager;
   private final Wallet wallet;
+  private KeyPair keyPair;
 
   @Inject
   public KeyManager(AndroidKeysetManager keysetManager, Wallet wallet) {
@@ -41,22 +42,24 @@ public class KeyManager {
     this.wallet = wallet;
 
     try {
+      regenerateMainKey();
       Log.d(TAG, "Public Key = " + getMainPublicKey().getEncoded());
     } catch (IOException | GeneralSecurityException e) {
       Log.e(TAG, "Failed to retrieve public key", e);
-      throw new IllegalStateException("Failed to retrieve public key", e);
+      throw new IllegalStateException("Failed to retrieve device key", e);
     }
   }
 
-  public PublicKey getMainPublicKey() throws IOException, GeneralSecurityException {
-    return getPublicKey(keysetManager.getKeysetHandle());
+  public void regenerateMainKey() throws GeneralSecurityException, IOException {
+    keyPair = getKeyPair(keysetManager.getKeysetHandle());
   }
 
-  public KeyPair getMainKeyPair() throws IOException, GeneralSecurityException {
-    PrivateKey privateKey = new ProtectedPrivateKey(keysetManager.getKeysetHandle());
-    PublicKey publicKey = getMainPublicKey();
+  public PublicKey getMainPublicKey() {
+    return keyPair.getPublicKey();
+  }
 
-    return new KeyPair(privateKey, publicKey);
+  public KeyPair getMainKeyPair() {
+    return keyPair;
   }
 
   public PoPToken getPoPToken(String laoID, String rollCallID) throws KeyException {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/security/KeyManager.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/security/KeyManager.java
@@ -36,7 +36,7 @@ import java.util.Comparator;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-/** Service manging keys and providing easy access to the main device key and PoP Tokens */
+/** Service managing keys and providing easy access to the main device key and PoP Tokens */
 @Singleton
 public class KeyManager {
 
@@ -86,7 +86,7 @@ public class KeyManager {
    * Try to retrieve the user's PoPToken for the given Lao.
    *
    * @param lao we want to retrieve the PoP Token from
-   * @return the PoP Token if it was retrieve, empty if no RollCall exist in the LAO
+   * @return the PoP Token if it was retrieved, empty if no RollCall exist in the LAO
    * @throws KeyGenerationException if an error occurs during key generation
    * @throws UninitializedWalletException if the wallet is not initialized with a seed
    * @throws InvalidPoPTokenException if the token is not a valid attendee
@@ -102,7 +102,7 @@ public class KeyManager {
   }
 
   /**
-   * Try to retrieve the user's PoPToken for the given Lao. It will fail is the user did not attend
+   * Try to retrieve the user's PoPToken for the given Lao and RollCall. It will fail is the user did not attend
    * the roll call of if the token cannot be generated
    *
    * @param lao we want to retrieve the PoP Token from

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/security/KeyManager.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/security/KeyManager.java
@@ -52,7 +52,7 @@ public class KeyManager {
     this.wallet = wallet;
 
     try {
-      regenerateMainKey();
+      cacheMainKey();
       Log.d(TAG, "Public Key = " + getMainPublicKey().getEncoded());
     } catch (IOException | GeneralSecurityException e) {
       Log.e(TAG, "Failed to retrieve device's key", e);
@@ -61,14 +61,14 @@ public class KeyManager {
   }
 
   /**
-   * This will regenerate the cached device KeyPair.
+   * This will cache the device KeyPair by extracting it from Tink.
    *
    * <p>Use this only if you know what you are doing
    *
    * @throws IOException when the key cannot be retrieved due to IO errors
    * @throws GeneralSecurityException when the retrieved key is not valid
    */
-  public void regenerateMainKey() throws GeneralSecurityException, IOException {
+  private void cacheMainKey() throws GeneralSecurityException, IOException {
     keyPair = getKeyPair(keysetManager.getKeysetHandle());
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/security/KeyManager.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/security/KeyManager.java
@@ -86,7 +86,7 @@ public class KeyManager {
    * Try to retrieve the user's PoPToken for the given Lao.
    *
    * @param lao we want to retrieve the PoP Token from
-   * @return the PoP Token if it was retrieved, empty if no RollCall exist in the LAO
+   * @return the PoP Token if it was retrieved
    * @throws KeyGenerationException if an error occurs during key generation
    * @throws UninitializedWalletException if the wallet is not initialized with a seed
    * @throws InvalidPoPTokenException if the token is not a valid attendee
@@ -102,12 +102,12 @@ public class KeyManager {
   }
 
   /**
-   * Try to retrieve the user's PoPToken for the given Lao and RollCall. It will fail is the user did not attend
-   * the roll call of if the token cannot be generated
+   * Try to retrieve the user's PoPToken for the given Lao and RollCall. It will fail if the user did not attend
+   * the roll call or if the token cannot be generated
    *
    * @param lao we want to retrieve the PoP Token from
    * @param rollCall we want to retrieve the PoP Token from
-   * @return the generated token is present in the rollcall
+   * @return the generated token if present in the rollcall
    * @throws KeyGenerationException if an error occurs during key generation
    * @throws UninitializedWalletException if the wallet is not initialized with a seed
    * @throws InvalidPoPTokenException if the token is not a valid attendee


### PR DESCRIPTION
Generate the device key object only once, as it should never change during the whole application lifecycle
With this change, there is no need to try for errors each time a key is retrieved.

Also add the functionalities to retrieve a valid PoP Token from an LAO.

Use that new functionality to finally fix the issue with the CastVote sender that was the device key and not the public part of the PoP Token.