### PR TITLE
Throws a JsonParseException if a Base64 deserialization failed

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonBase64DataSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonBase64DataSerializer.java
@@ -24,7 +24,11 @@ public class JsonBase64DataSerializer<T extends Base64URLData>
   @Override
   public T deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
-    return constructor.apply(json.getAsString());
+    try {
+      return constructor.apply(json.getAsString());
+    } catch (Exception e) {
+      throw new JsonParseException(e);
+    }
   }
 
   @Override


### PR DESCRIPTION
When a JsonBase64DataSerializer failed to deserialize it was throwing an IllegalArgumentException, instead of a JsonParseException
=> catch exception and throw a JsonParseException