### PR TITLE
Fix crash cause of undefined public key

### DIFF
--- a/fe1-web/parts/lao/socialMedia/SocialProfile.tsx
+++ b/fe1-web/parts/lao/socialMedia/SocialProfile.tsx
@@ -20,7 +20,12 @@ const styles = StyleSheet.create({
 const SocialProfile = (props: IPropTypes) => {
   const { currentUserPublicKey } = props;
   if (currentUserPublicKey.valueOf() !== '') {
-    return <SocialUserProfile userPublicKey={currentUserPublicKey} />;
+    return (
+      <SocialUserProfile
+        currentUserPublicKey={currentUserPublicKey}
+        userPublicKey={currentUserPublicKey}
+      />
+    );
   }
   return (
     <View style={styles.textUnavailableView}>

--- a/fe1-web/parts/lao/socialMedia/SocialUserProfile.tsx
+++ b/fe1-web/parts/lao/socialMedia/SocialUserProfile.tsx
@@ -48,13 +48,14 @@ const styles = StyleSheet.create({
 });
 
 const SocialUserProfile = (props: IPropTypes) => {
-  const { userPublicKey } = props;
+  const { currentUserPublicKey, userPublicKey } = props;
   const userChirps = makeChirpsListOfUser(userPublicKey);
   const userChirpList = useSelector(userChirps);
 
   const renderChirpState = ({ item }: ListRenderItemInfo<ChirpState>) => (
     <ChirpCard
       chirp={Chirp.fromState(item)}
+      userPublicKey={currentUserPublicKey}
     />
   );
 
@@ -83,12 +84,14 @@ const SocialUserProfile = (props: IPropTypes) => {
 };
 
 const propTypes = {
+  currentUserPublicKey: PropTypes.instanceOf(PublicKey).isRequired,
   userPublicKey: PropTypes.instanceOf(PublicKey).isRequired,
 };
 
 SocialUserProfile.prototype = propTypes;
 
 type IPropTypes = {
+  currentUserPublicKey: PublicKey,
   userPublicKey: PublicKey,
 };
 


### PR DESCRIPTION
The public key of the current user was not passed to chirp cards in `SocialUserProfile`. It happened because Jiabao and I merged our work and I didn't realize she added a prop to `ChirpCard`.