### PR TITLE
Remove navigation warnings

### DIFF
--- a/fe1-web/navigation/socialMedia/SocialSearchNavigation.tsx
+++ b/fe1-web/navigation/socialMedia/SocialSearchNavigation.tsx
@@ -21,7 +21,7 @@ const SocialSearchNavigation = (props: IPropTypes) => {
         headerShown: false,
       }}
     >
-      <Stack.Screen name={STRINGS.social_media_navigation_tab_search}>
+      <Stack.Screen name={STRINGS.social_media_navigation_tab_attendee_list}>
         {() => <SocialSearch currentUserPublicKey={currentUserPublicKey} />}
       </Stack.Screen>
       <Stack.Screen

--- a/fe1-web/parts/lao/socialMedia/SocialUserProfile.tsx
+++ b/fe1-web/parts/lao/socialMedia/SocialUserProfile.tsx
@@ -20,7 +20,7 @@ const styles = socialMediaProfile;
 
 const SocialUserProfile = ({ route }: any) => {
   const { currentUserPublicKey, userPublicKey } = route.params;
-  if (!userPublicKey) {
+  if (!userPublicKey || userPublicKey === '') {
     return (
       <View style={styles.viewCenter}>
         <View style={styles.topView}>
@@ -51,7 +51,7 @@ const SocialUserProfile = ({ route }: any) => {
       <View style={styles.topView}>
         <View style={{ marginBottom: 15 }}>
           <BackButton
-            navigationTabName={STRINGS.social_media_navigation_tab_search}
+            navigationTabName={STRINGS.social_media_navigation_tab_attendee_list}
             testID="backButtonUserProfile"
           />
         </View>

--- a/fe1-web/parts/lao/socialMedia/SocialUserProfile.tsx
+++ b/fe1-web/parts/lao/socialMedia/SocialUserProfile.tsx
@@ -20,7 +20,7 @@ const styles = socialMediaProfile;
 
 const SocialUserProfile = ({ route }: any) => {
   const { currentUserPublicKey, userPublicKey } = route.params;
-  if (!userPublicKey || userPublicKey === '') {
+  if (!userPublicKey) {
     return (
       <View style={styles.viewCenter}>
         <View style={styles.topView}>

--- a/fe1-web/res/strings.ts
+++ b/fe1-web/res/strings.ts
@@ -53,6 +53,7 @@ const STRINGS = {
   social_media_navigation_tab_follows: 'My Follows',
   social_media_navigation_tab_profile: 'My Profile',
   social_media_navigation_tab_user_profile: 'User profile',
+  social_media_navigation_tab_attendee_list: 'List of attendees',
 
   /* --- Home Strings --- */
   home_welcome: 'Welcome to Personhood.Online!',


### PR DESCRIPTION
When adding navigation inside search, I realized I had 2 screens with the same name, which made a warning appear in web console. So I changed the name of the attendee list and it is now fixed.