### PR TITLE
Change color of blockies

### DIFF
--- a/fe1-web/components/ChirpCard.tsx
+++ b/fe1-web/components/ChirpCard.tsx
@@ -127,13 +127,13 @@ const ChirpCard = (props: IPropTypes) => {
           <>
             <View style={styles.reactionView}>
               <Pressable onPress={() => addReaction('👍')} testID="thumbs-up">
-                <Ionicons name="thumbs-up" size={16} color="black" />
+                <Ionicons name="thumbs-up-sharp" size={16} color="black" />
               </Pressable>
               <Text>{`  ${thumbsUp}`}</Text>
             </View>
             <View style={styles.reactionView}>
               <Pressable onPress={() => addReaction('👎')} testID="thumbs-down">
-                <Ionicons name="thumbs-down" size={16} color="black" />
+                <Ionicons name="thumbs-down-sharp" size={16} color="black" />
               </Pressable>
               <Text>{`  ${thumbsDown}`}</Text>
             </View>

--- a/fe1-web/components/ProfileIcon.tsx
+++ b/fe1-web/components/ProfileIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Blockies from 'react-blockies';
 import { PublicKey } from 'model/objects';
-import { popBlue, popGray } from 'styles/colors';
+import { popBlue } from '../styles/colors';
 
 const ProfileIcon = (props: IPropTypes) => {
   const { publicKey, size, scale } = props;
@@ -12,9 +12,8 @@ const ProfileIcon = (props: IPropTypes) => {
       seed={publicKey.valueOf()}
       size={size}
       scale={scale}
-      color={popBlue}
+      spotColor={popBlue}
       bgColor="#ffffff"
-      spotColor={popGray}
     />
   );
 };

--- a/fe1-web/components/ProfileIcon.tsx
+++ b/fe1-web/components/ProfileIcon.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Blockies from 'react-blockies';
+import { popBlue } from 'styles/colors';
 import { PublicKey } from 'model/objects';
-import { popBlue } from '../styles/colors';
 
 const ProfileIcon = (props: IPropTypes) => {
   const { publicKey, size, scale } = props;

--- a/fe1-web/components/__tests__/__snapshots__/ChirpCard.test.tsx.snap
+++ b/fe1-web/components/__tests__/__snapshots__/ChirpCard.test.tsx.snap
@@ -234,7 +234,7 @@ exports[`ChirpCard for deletion renders correctly for non-sender 1`] = `
               ]
             }
           >
-            
+            
           </Text>
         </View>
         <Text>
@@ -283,7 +283,7 @@ exports[`ChirpCard for deletion renders correctly for non-sender 1`] = `
               ]
             }
           >
-            
+            
           </Text>
         </View>
         <Text>
@@ -721,7 +721,7 @@ exports[`ChirpCard for reaction renders correctly with reaction 1`] = `
               ]
             }
           >
-            
+            
           </Text>
         </View>
         <Text>
@@ -770,7 +770,7 @@ exports[`ChirpCard for reaction renders correctly with reaction 1`] = `
               ]
             }
           >
-            
+            
           </Text>
         </View>
         <Text>
@@ -1015,7 +1015,7 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
               ]
             }
           >
-            
+            
           </Text>
         </View>
         <Text>
@@ -1064,7 +1064,7 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
               ]
             }
           >
-            
+            
           </Text>
         </View>
         <Text>

--- a/fe1-web/parts/lao/socialMedia/SocialProfile.tsx
+++ b/fe1-web/parts/lao/socialMedia/SocialProfile.tsx
@@ -49,7 +49,7 @@ const SocialProfile = (props: IPropTypes) => {
         />
         <View style={styles.textView}>
           <Text style={styles.profileText}>{currentUserPublicKey.valueOf()}</Text>
-          <Text>{`${userChirpList.length} chirps`}</Text>
+          <Text>{`${userChirpList.length} ${userChirpList.length === 1 ? 'chirp' : 'chirps'}`}</Text>
         </View>
       </View>
       <View style={styles.userFeed}>

--- a/fe1-web/parts/lao/socialMedia/SocialUserProfile.tsx
+++ b/fe1-web/parts/lao/socialMedia/SocialUserProfile.tsx
@@ -62,7 +62,7 @@ const SocialUserProfile = ({ route }: any) => {
         />
         <View style={styles.textView}>
           <Text style={styles.profileText}>{userPublicKey.valueOf()}</Text>
-          <Text>{`${userChirpList.length} chirps`}</Text>
+          <Text>{`${userChirpList.length} ${userChirpList.length === 1 ? 'chirp' : 'chirps'}`}</Text>
         </View>
       </View>
       <View style={styles.userFeed}>


### PR DESCRIPTION
- To distinguish users easier, I made the blockies use a random color.
- I adapted the text so that it says "1 chirp" on the profile page if the user has posted only one chirp.
- I also changed the design of the reaction buttons, so that they are sharper.

New blockies
<img width="643" alt="Capture d’écran 2022-01-19 à 15 10 01" src="https://user-images.githubusercontent.com/33868847/150152805-eabce848-57a6-410e-8c0a-e5a639383e8a.png">

New reactions icons
<img width="643" alt="Capture d’écran 2022-01-19 à 15 41 41" src="https://user-images.githubusercontent.com/33868847/150152980-9771a981-1837-4026-a32b-466071ff4022.png">