### PR TITLE
Add the server URL directly in the LAO QRCode

### DIFF
--- a/fe2-android/app/build.gradle
+++ b/fe2-android/app/build.gradle
@@ -192,6 +192,7 @@ copy {
 
     include 'answer/**'
     include 'examples/**'
+    include 'qrcode/**'
     include 'query/**'
     include 'jsonRPC.json'
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonUtils.java
@@ -33,7 +33,7 @@ public final class JsonUtils {
   public static final String ROOT_SCHEMA = "protocol/jsonRPC.json";
   public static final String GENERAL_MESSAGE_SCHEMA = "protocol/query/method/message/message.json";
   public static final String DATA_SCHEMA = "protocol/query/method/message/data/data.json";
-  public static final String CONNECT_TO_LAO_SCHEMA = "protocol/qrcode/connect_lao.json";
+  public static final String CONNECT_TO_LAO_SCHEMA = "protocol/qrcode/connect_to_lao.json";
 
   private static final Map<String, JsonSchema> schemas = new ConcurrentHashMap<>();
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonUtils.java
@@ -33,6 +33,7 @@ public final class JsonUtils {
   public static final String ROOT_SCHEMA = "protocol/jsonRPC.json";
   public static final String GENERAL_MESSAGE_SCHEMA = "protocol/query/method/message/message.json";
   public static final String DATA_SCHEMA = "protocol/query/method/message/data/data.json";
+  public static final String CONNECT_TO_LAO_SCHEMA = "protocol/qrcode/connect_lao.json";
 
   private static final Map<String, JsonSchema> schemas = new ConcurrentHashMap<>();
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/qrcode/ConnectToLao.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/qrcode/ConnectToLao.java
@@ -9,7 +9,7 @@ public class ConnectToLao {
   public final String server;
   public final String lao;
 
-  private ConnectToLao(String server, String lao) {
+  public ConnectToLao(String server, String lao) {
     this.server = server;
     this.lao = lao;
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/qrcode/ConnectToLao.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/qrcode/ConnectToLao.java
@@ -1,0 +1,21 @@
+package com.github.dedis.popstellar.model.qrcode;
+
+import com.github.dedis.popstellar.model.network.serializer.JsonUtils;
+import com.google.android.gms.vision.barcode.Barcode;
+import com.google.gson.Gson;
+
+public class ConnectToLao {
+
+  public final String server;
+  public final String lao;
+
+  private ConnectToLao(String server, String lao) {
+    this.server = server;
+    this.lao = lao;
+  }
+
+  public static ConnectToLao extractFrom(Gson mGson, Barcode barcode) {
+    JsonUtils.verifyJson(JsonUtils.CONNECT_TO_LAO_SCHEMA, barcode.rawValue);
+    return mGson.fromJson(barcode.rawValue, ConnectToLao.class);
+  }
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/qrcode/ConnectToLao.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/qrcode/ConnectToLao.java
@@ -1,9 +1,9 @@
 package com.github.dedis.popstellar.model.qrcode;
 
 import com.github.dedis.popstellar.model.network.serializer.JsonUtils;
-import com.google.android.gms.vision.barcode.Barcode;
 import com.google.gson.Gson;
 
+/** Represent the data held in a QRCode used to connect to an LAO */
 public class ConnectToLao {
 
   public final String server;
@@ -14,8 +14,16 @@ public class ConnectToLao {
     this.lao = lao;
   }
 
-  public static ConnectToLao extractFrom(Gson mGson, Barcode barcode) {
-    JsonUtils.verifyJson(JsonUtils.CONNECT_TO_LAO_SCHEMA, barcode.rawValue);
-    return mGson.fromJson(barcode.rawValue, ConnectToLao.class);
+  /**
+   * Extract ConnectToLao data from the given json string
+   *
+   * @param gson is used to parse the json string into the object
+   * @param json representation of the ConnectToLao data
+   * @return the extracted ConnectToLao data
+   * @throws com.google.gson.JsonParseException if the value cannot be parsed
+   */
+  public static ConnectToLao extractFrom(Gson gson, String json) {
+    JsonUtils.verifyJson(JsonUtils.CONNECT_TO_LAO_SCHEMA, json);
+    return gson.fromJson(json, ConnectToLao.class);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailFragment.java
@@ -19,13 +19,18 @@ import com.github.dedis.popstellar.databinding.LaoDetailFragmentBinding;
 import com.github.dedis.popstellar.model.objects.RollCall;
 import com.github.dedis.popstellar.model.objects.event.Event;
 import com.github.dedis.popstellar.model.objects.event.EventType;
+import com.github.dedis.popstellar.model.qrcode.ConnectToLao;
+import com.github.dedis.popstellar.repository.remote.LAORequestFactory;
 import com.github.dedis.popstellar.ui.detail.event.EventExpandableListViewAdapter;
 import com.github.dedis.popstellar.ui.detail.witness.WitnessListViewAdapter;
 import com.github.dedis.popstellar.ui.qrcode.ScanningAction;
+import com.google.gson.Gson;
 
 import net.glxn.qrgen.android.QRCode;
 
 import java.util.ArrayList;
+
+import javax.inject.Inject;
 
 import dagger.hilt.android.AndroidEntryPoint;
 
@@ -34,6 +39,9 @@ import dagger.hilt.android.AndroidEntryPoint;
 public class LaoDetailFragment extends Fragment {
 
   public static final String TAG = LaoDetailFragment.class.getSimpleName();
+
+  @Inject Gson gson;
+  @Inject LAORequestFactory requestFactory;
 
   private LaoDetailFragmentBinding mLaoDetailFragBinding;
   private LaoDetailViewModel mLaoDetailViewModel;
@@ -115,7 +123,8 @@ public class LaoDetailFragment extends Fragment {
         .observe(
             requireActivity(),
             lao -> {
-              Bitmap myBitmap = QRCode.from(lao.getChannel().substring(6)).bitmap();
+              ConnectToLao data = new ConnectToLao(requestFactory.getUrl(), lao.getId());
+              Bitmap myBitmap = QRCode.from(gson.toJson(data)).bitmap();
               mLaoDetailFragBinding.channelQrCode.setImageBitmap(myBitmap);
             });
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.app.Application;
 import android.content.pm.PackageManager;
 import android.util.Log;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
@@ -20,13 +21,16 @@ import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
 import com.github.dedis.popstellar.model.network.method.message.data.lao.CreateLao;
 import com.github.dedis.popstellar.model.objects.Lao;
 import com.github.dedis.popstellar.model.objects.Wallet;
+import com.github.dedis.popstellar.model.qrcode.ConnectToLao;
 import com.github.dedis.popstellar.repository.LAORepository;
+import com.github.dedis.popstellar.repository.remote.LAORequestFactory;
 import com.github.dedis.popstellar.ui.qrcode.CameraPermissionViewModel;
 import com.github.dedis.popstellar.ui.qrcode.QRCodeScanningViewModel;
 import com.github.dedis.popstellar.ui.qrcode.ScanningAction;
 import com.github.dedis.popstellar.utility.security.KeyManager;
 import com.google.android.gms.vision.barcode.Barcode;
 import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -84,6 +88,7 @@ public class HomeViewModel extends AndroidViewModel
   private final LAORepository mLAORepository;
   private final KeyManager mKeyManager;
   private final Wallet wallet;
+  private final LAORequestFactory mRequestFactory;
 
   private final CompositeDisposable disposables = new CompositeDisposable();
 
@@ -93,13 +98,15 @@ public class HomeViewModel extends AndroidViewModel
       Gson gson,
       Wallet wallet,
       LAORepository laoRepository,
-      KeyManager keyManager) {
+      KeyManager keyManager,
+      LAORequestFactory requestFactory) {
     super(application);
 
     mLAORepository = laoRepository;
     mGson = gson;
     mKeyManager = keyManager;
     this.wallet = wallet;
+    mRequestFactory = requestFactory;
 
     mLAOs =
         LiveDataReactiveStreams.fromPublisher(
@@ -124,7 +131,19 @@ public class HomeViewModel extends AndroidViewModel
   @Override
   public void onQRCodeDetected(Barcode barcode) {
     Log.d(TAG, "Detected barcode with value: " + barcode.rawValue);
-    String channel = "/root/" + barcode.rawValue;
+    ConnectToLao data;
+    try {
+      data = ConnectToLao.extractFrom(mGson, barcode);
+    } catch (JsonParseException e) {
+      Log.e(TAG, "Invalid QRCode data", e);
+      Toast.makeText(
+              getApplication().getApplicationContext(), "Invalid QRCode data", Toast.LENGTH_LONG)
+          .show();
+      return;
+    }
+
+    mRequestFactory.setUrl(data.server);
+    String channel = "/root/" + data.lao;
     disposables.add(
         mLAORepository
             .sendSubscribe(channel)

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
@@ -133,7 +133,7 @@ public class HomeViewModel extends AndroidViewModel
     Log.d(TAG, "Detected barcode with value: " + barcode.rawValue);
     ConnectToLao data;
     try {
-      data = ConnectToLao.extractFrom(mGson, barcode);
+      data = ConnectToLao.extractFrom(mGson, barcode.rawValue);
     } catch (JsonParseException e) {
       Log.e(TAG, "Invalid QRCode data", e);
       Toast.makeText(


### PR DESCRIPTION
Add the server URL directly in the LAO QRCode for Android

Generate the right QRCode and retrieve the data correctly following the Json-Schema.

The new code isn't tested, as the current implementation is almost impossible to test.
It would need camera mocking, which is very complex to do inside a CI.