### PR TITLE
[REVERT IF NEEDED] re-enable connection extension to peers

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.kt
@@ -221,10 +221,7 @@ constructor(
     // The greetLao will also be sent by the other servers, so the message sender
     // should handle this, avoiding to connect twice to the same server
 
-    // TODO: Remove the comment when testing for backend is finished ! Maxime @Kaz | May 2024
-    // Also, I realised removing this line that no tests are actually testing this part of the
-    // code...
-    // context.messageSender.extendConnection(greetLao.peers)
+    context.messageSender.extendConnection(greetLao.peers)
   }
 
   companion object {


### PR DESCRIPTION
Do not merge this PR unless back-end testing is finished!

This PR reverts #1967 and re-enables connection extension to peers when connecting to the main server.